### PR TITLE
Documentation, features, and unit tests for PairParameters

### DIFF
--- a/relentless/core.py
+++ b/relentless/core.py
@@ -348,8 +348,8 @@ class FixedKeyDict:
             raise TypeError('All keys must be strings')
         self._keys = tuple(keys)
         self._data = {}
-        for i in self.keys:
-            self._data[i] = default
+        self._default = default
+        self.clear()
 
     def _check_key(self, key):
         """Check that a type is in the dictionary.
@@ -385,6 +385,11 @@ class FixedKeyDict:
 
     def __str__(self):
         return str(self._data)
+
+    def clear(self):
+        """Clear entries in dict, resetting to default."""
+        for i in self.keys:
+            self._data[i] = self._default
 
     def update(self, *data, **values):
         """Partially reassigns key values.

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -165,8 +165,9 @@ class Spline(PairPotential):
     num_knots : int
         The number of knots with which to interpolate.
     mode : str
-        Describes the type of design parameter used in the optimization. Setting the mode to 'value' uses the knot amplitudes,
-        while 'diff' uses the differences between neighboring knot amplitudes. (Defaults to 'diff').
+        Describes the type of design parameter used in the optimization.
+        Setting the mode to 'value' uses the knot amplitudes, while 'diff' uses
+        the differences between neighboring knot amplitudes. (Defaults to 'diff').
 
     Raises
     ------

--- a/relentless/potential/potential.py
+++ b/relentless/potential/potential.py
@@ -1,4 +1,4 @@
-__all__ = ['PairPotential','Tabulator']
+__all__ = ['PairParameters','PairPotential','Tabulator']
 
 import abc
 import json

--- a/relentless/potential/potential.py
+++ b/relentless/potential/potential.py
@@ -81,7 +81,7 @@ class PairParameters(PairMatrix):
     Assigning to a type sets the specified per-type parameters::
 
         m['A'].update(energy=1.0, mass=2.0)
-        >>> print(m.evaluate('A'))
+        >>> print(m['A'])
         {'energy':1.0, 'mass':2.0}
 
     Assigning to shared sets the specified shared parameters::
@@ -90,11 +90,14 @@ class PairParameters(PairMatrix):
         >>> print(m.shared)
         {'energy':0.5, 'mass':None}
 
-    Setting shared parameters does not override the per-pair parameters if the pair
-    is accessed directly, but does override the per-pair parameters if `evaluate()` is used::
+    Shared parameters will be used in `evaluate()` if the per-pair parameter is not set::
 
+        >>> m['B','B'] = {'mass': 0.1}
+        >>> m.shared = {'energy': 0.5}
         >>> print(m['B','B'])
-        {'energy':0.1, 'mass':0.1}
+        {'energy': None, 'mass': 0.1}
+        >>> print(m.shared)
+        {'energy': 0.5, 'mass': None}
         >>> print(m.evaluate(('B','B'))
         {'energy':0.5, 'mass':0.1}
 

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -337,17 +337,15 @@ class test_Depletion(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data"""
-        dp = pair.Depletion(types=('1','2'))
-        coeff = potential.CoefficientMatrix(types=('1','2'),
-                                            params=('P','sigma_i','sigma_j','sigma_d','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
+        dp = relentless.potential.pair.Depletion(types=('1','2'))
+        coeff = relentless.potential.potential.PairParameters(types=('1','2'),
+                                                              params=('P','sigma_i','sigma_j','sigma_d','rmin','rmax','shift'))
         self.assertCountEqual(dp.coeff.types, coeff.types)
         self.assertCountEqual(dp.coeff.params, coeff.params)
-        self.assertDictEqual(dp.coeff.default.todict(), coeff.default.todict())
 
     def test_energy(self):
         """Test _energy method"""
-        dp = pair.Depletion(types=('1',))
+        dp = relentless.potential.pair.Depletion(types=('1',))
 
         #test scalar r
         r_input = 3
@@ -371,7 +369,7 @@ class test_Depletion(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        dp = pair.Depletion(types=('1',))
+        dp = relentless.potential.pair.Depletion(types=('1',))
 
         #test scalar r
         r_input = 3
@@ -395,7 +393,7 @@ class test_Depletion(unittest.TestCase):
 
     def test_derivative(self):
         """Test _derivative method"""
-        dp = pair.Depletion(types=('1',))
+        dp = relentless.potential.pair.Depletion(types=('1',))
 
         #w.r.t. P
         #test scalar r

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -3,25 +3,26 @@ import unittest
 
 import numpy as np
 
-from relentless import core
-from relentless.potential import pair
-from relentless.potential import potential
+import relentless
 
 class test_LennardJones(unittest.TestCase):
-    """Unit tests for pair.LennardJones"""
+    """Unit tests for relentless.potential.pair.LennardJones"""
 
     def test_init(self):
         """Test creation from data"""
-        lj = pair.LennardJones(types=('1','2'))
-        coeff = potential.CoefficientMatrix(types=('1','2'), params=('epsilon','sigma','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
+        lj = relentless.potential.pair.LennardJones(types=('1',))
+        coeff = relentless.potential.potential.PairParameters(types=('1',),
+                                                              params=('epsilon','sigma','rmin','rmax','shift'))
+        for pair in coeff.pairs:
+            coeff[pair]['rmin'] = False
+            coeff[pair]['rmax'] = False
+            coeff[pair]['shift'] = False
         self.assertCountEqual(lj.coeff.types, coeff.types)
         self.assertCountEqual(lj.coeff.params, coeff.params)
-        self.assertDictEqual(lj.coeff.default.todict(), coeff.default.todict())
 
     def test_energy(self):
         """Test _energy method"""
-        lj = pair.LennardJones(types=('1',))
+        lj = relentless.potential.pair.LennardJones(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -41,7 +42,7 @@ class test_LennardJones(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        lj = pair.LennardJones(types=('1',))
+        lj = relentless.potential.pair.LennardJones(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -61,7 +62,7 @@ class test_LennardJones(unittest.TestCase):
 
     def test_derivative(self):
         """Test _derivative method"""
-        lj = pair.LennardJones(types=('1',))
+        lj = relentless.potential.pair.LennardJones(types=('1',))
 
         #w.r.t. epsilon
         #test scalar r
@@ -98,40 +99,35 @@ class test_LennardJones(unittest.TestCase):
             u = lj._derivative(param='simga', r=r_input, epsilon=1.0, sigma=1.0)
 
 class test_Spline(unittest.TestCase):
-    """Unit tests for pair.Spline"""
+    """Unit tests for relentless.potential.pair.Spline"""
 
     def test_init(self):
         """Test creation from data"""
         #test diff mode
-        s = pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
         self.assertEqual(s.num_knots, 3)
         self.assertEqual(s.mode, 'diff')
-        coeff = potential.CoefficientMatrix(types=('1',),
-                                            params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
+        coeff = relentless.potential.potential.PairParameters(types=('1',),
+                                                              params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
-        self.assertDictEqual(s.coeff.default.todict(), coeff.default.todict())
 
         #test value mode
-        s = pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
         self.assertEqual(s.num_knots, 3)
         self.assertEqual(s.mode, 'value')
-        coeff = potential.CoefficientMatrix(types=('1',),
-                                            params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
+        coeff = relentless.potential.potential.PairParameters(types=('1',),
+                                                              params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
-        self.assertDictEqual(s.coeff.default.todict(), coeff.default.todict())
-
 
         #test invalid number of knots
         with self.assertRaises(ValueError):
-            s = pair.Spline(types=('1',), num_knots=1)
+            s = relentless.potential.pair.Spline(types=('1',), num_knots=1)
 
         #test invalid mode
         with self.assertRaises(ValueError):
-            s = pair.Spline(types=('1',), num_knots=3, mode='val')
+            s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='val')
 
     def test_from_array(self):
         """Test from_array method and knots generator"""
@@ -140,7 +136,7 @@ class test_Spline(unittest.TestCase):
         u_arr_diff = [5,3,1]
 
         #test diff mode
-        s = pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
         for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
@@ -153,7 +149,7 @@ class test_Spline(unittest.TestCase):
                 self.assertEqual(k.const, False)
 
         #test value mode
-        s = pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
         for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
@@ -181,21 +177,21 @@ class test_Spline(unittest.TestCase):
         u_arr = [9,4,1]
 
         #test diff mode
-        s = pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         u_actual = np.array([6.25,2.25,1])
         u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(u, u_actual)
 
         #test value mode
-        s = pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         u_actual = np.array([6.25,2.25,1])
         u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(u, u_actual)
 
         #test Spline with 2 knots
-        s = pair.Spline(types=('1',), num_knots=2, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=2, mode='value')
         s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
         u = s.energy(pair=('1','1'), r=1.5)
         self.assertAlmostEqual(u, 3)
@@ -206,21 +202,21 @@ class test_Spline(unittest.TestCase):
         u_arr = [9,4,1]
 
         #test diff mode
-        s = pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         f_actual = np.array([5,3,0])
         f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(f, f_actual)
 
         #test value mode
-        s = pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         f_actual = np.array([5,3,0])
         f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(f, f_actual)
 
         #test Spline with 2 knots
-        s = pair.Spline(types=('1',), num_knots=2, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=2, mode='value')
         s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
         f = s.force(pair=('1','1'), r=1.5)
         self.assertAlmostEqual(f, 2)
@@ -231,34 +227,36 @@ class test_Spline(unittest.TestCase):
         u_arr = [9,4,1]
 
         #test diff mode
-        s = pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([1.125,0.625,0])
         d = s.derivative(pair=('1','1'), param='knot-1', r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
         #test value mode
-        s = pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([0.75,0.75,0])
         d = s.derivative(pair=('1','1'), param='knot-1', r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
 class test_Yukawa(unittest.TestCase):
-    """Unit tests for pair.Yukawa"""
+    """Unit tests for relentless.potential.pair.Yukawa"""
 
     def test_init(self):
         """Test creation from data"""
-        y = pair.Yukawa(types=('1','2'))
-        coeff = potential.CoefficientMatrix(types=('1','2'), params=('epsilon','kappa','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
+        y = relentless.potential.pair.Yukawa(types=('1',))
+        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('epsilon','kappa','rmin','rmax','shift'))
+        for pair in coeff.pairs:
+            coeff[pair]['rmin'] = False
+            coeff[pair]['rmax'] = False
+            coeff[pair]['shift'] = False
         self.assertCountEqual(y.coeff.types, coeff.types)
         self.assertCountEqual(y.coeff.params, coeff.params)
-        self.assertDictEqual(y.coeff.default.todict(), coeff.default.todict())
 
     def test_energy(self):
         """Test _energy method"""
-        y = pair.Yukawa(types=('1',))
+        y = relentless.potential.pair.Yukawa(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -278,7 +276,7 @@ class test_Yukawa(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        y = pair.Yukawa(types=('1',))
+        y = relentless.potential.pair.Yukawa(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -298,7 +296,7 @@ class test_Yukawa(unittest.TestCase):
 
     def test_derivative(self):
         """Test _derivative method"""
-        y = pair.Yukawa(types=('1',))
+        y = relentless.potential.pair.Yukawa(types=('1',))
 
         #w.r.t. epsilon
         #test scalar r

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -6,13 +6,13 @@ import numpy as np
 import relentless
 
 class test_LennardJones(unittest.TestCase):
-    """Unit tests for relentless.potential.pair.LennardJones"""
+    """Unit tests for relentless.potential.LennardJones"""
 
     def test_init(self):
         """Test creation from data"""
-        lj = relentless.potential.pair.LennardJones(types=('1',))
-        coeff = relentless.potential.potential.PairParameters(types=('1',),
-                                                              params=('epsilon','sigma','rmin','rmax','shift'))
+        lj = relentless.potential.LennardJones(types=('1',))
+        coeff = relentless.potential.PairParameters(types=('1',),
+                                                    params=('epsilon','sigma','rmin','rmax','shift'))
         for pair in coeff.pairs:
             coeff[pair]['rmin'] = False
             coeff[pair]['rmax'] = False
@@ -22,7 +22,7 @@ class test_LennardJones(unittest.TestCase):
 
     def test_energy(self):
         """Test _energy method"""
-        lj = relentless.potential.pair.LennardJones(types=('1',))
+        lj = relentless.potential.LennardJones(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -42,7 +42,7 @@ class test_LennardJones(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        lj = relentless.potential.pair.LennardJones(types=('1',))
+        lj = relentless.potential.LennardJones(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -62,7 +62,7 @@ class test_LennardJones(unittest.TestCase):
 
     def test_derivative(self):
         """Test _derivative method"""
-        lj = relentless.potential.pair.LennardJones(types=('1',))
+        lj = relentless.potential.LennardJones(types=('1',))
 
         #w.r.t. epsilon
         #test scalar r
@@ -99,35 +99,35 @@ class test_LennardJones(unittest.TestCase):
             u = lj._derivative(param='simga', r=r_input, epsilon=1.0, sigma=1.0)
 
 class test_Spline(unittest.TestCase):
-    """Unit tests for relentless.potential.pair.Spline"""
+    """Unit tests for relentless.potential.Spline"""
 
     def test_init(self):
         """Test creation from data"""
         #test diff mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.Spline(types=('1',), num_knots=3)
         self.assertEqual(s.num_knots, 3)
         self.assertEqual(s.mode, 'diff')
-        coeff = relentless.potential.potential.PairParameters(types=('1',),
-                                                              params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',),
+                                                    params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
 
         #test value mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         self.assertEqual(s.num_knots, 3)
         self.assertEqual(s.mode, 'value')
-        coeff = relentless.potential.potential.PairParameters(types=('1',),
-                                                              params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',),
+                                                    params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
 
         #test invalid number of knots
         with self.assertRaises(ValueError):
-            s = relentless.potential.pair.Spline(types=('1',), num_knots=1)
+            s = relentless.potential.Spline(types=('1',), num_knots=1)
 
         #test invalid mode
         with self.assertRaises(ValueError):
-            s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='val')
+            s = relentless.potential.Spline(types=('1',), num_knots=3, mode='val')
 
     def test_from_array(self):
         """Test from_array method and knots generator"""
@@ -136,7 +136,7 @@ class test_Spline(unittest.TestCase):
         u_arr_diff = [5,3,1]
 
         #test diff mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
         for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
@@ -149,7 +149,7 @@ class test_Spline(unittest.TestCase):
                 self.assertEqual(k.const, False)
 
         #test value mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
         for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
@@ -177,21 +177,21 @@ class test_Spline(unittest.TestCase):
         u_arr = [9,4,1]
 
         #test diff mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         u_actual = np.array([6.25,2.25,1])
         u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(u, u_actual)
 
         #test value mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         u_actual = np.array([6.25,2.25,1])
         u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(u, u_actual)
 
         #test Spline with 2 knots
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=2, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=2, mode='value')
         s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
         u = s.energy(pair=('1','1'), r=1.5)
         self.assertAlmostEqual(u, 3)
@@ -202,21 +202,21 @@ class test_Spline(unittest.TestCase):
         u_arr = [9,4,1]
 
         #test diff mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         f_actual = np.array([5,3,0])
         f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(f, f_actual)
 
         #test value mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         f_actual = np.array([5,3,0])
         f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
         np.testing.assert_allclose(f, f_actual)
 
         #test Spline with 2 knots
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=2, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=2, mode='value')
         s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
         f = s.force(pair=('1','1'), r=1.5)
         self.assertAlmostEqual(f, 2)
@@ -227,26 +227,26 @@ class test_Spline(unittest.TestCase):
         u_arr = [9,4,1]
 
         #test diff mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3)
+        s = relentless.potential.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([1.125,0.625,0])
         d = s.derivative(pair=('1','1'), param='knot-1', r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
         #test value mode
-        s = relentless.potential.pair.Spline(types=('1',), num_knots=3, mode='value')
+        s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([0.75,0.75,0])
         d = s.derivative(pair=('1','1'), param='knot-1', r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
 class test_Yukawa(unittest.TestCase):
-    """Unit tests for relentless.potential.pair.Yukawa"""
+    """Unit tests for relentless.potential.Yukawa"""
 
     def test_init(self):
         """Test creation from data"""
-        y = relentless.potential.pair.Yukawa(types=('1',))
-        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('epsilon','kappa','rmin','rmax','shift'))
+        y = relentless.potential.Yukawa(types=('1',))
+        coeff = relentless.potential.PairParameters(types=('1',), params=('epsilon','kappa','rmin','rmax','shift'))
         for pair in coeff.pairs:
             coeff[pair]['rmin'] = False
             coeff[pair]['rmax'] = False
@@ -256,7 +256,7 @@ class test_Yukawa(unittest.TestCase):
 
     def test_energy(self):
         """Test _energy method"""
-        y = relentless.potential.pair.Yukawa(types=('1',))
+        y = relentless.potential.Yukawa(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -276,7 +276,7 @@ class test_Yukawa(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        y = relentless.potential.pair.Yukawa(types=('1',))
+        y = relentless.potential.Yukawa(types=('1',))
 
         #test scalar r
         r_input = 0.5
@@ -296,7 +296,7 @@ class test_Yukawa(unittest.TestCase):
 
     def test_derivative(self):
         """Test _derivative method"""
-        y = relentless.potential.pair.Yukawa(types=('1',))
+        y = relentless.potential.Yukawa(types=('1',))
 
         #w.r.t. epsilon
         #test scalar r
@@ -333,19 +333,19 @@ class test_Yukawa(unittest.TestCase):
             u = y._derivative(param='kapppa', r=r_input, epsilon=1.0, kappa=1.0)
 
 class test_Depletion(unittest.TestCase):
-    """Unit tests for pair.Depletion"""
+    """Unit tests for relentless.potential.Depletion"""
 
     def test_init(self):
         """Test creation from data"""
-        dp = relentless.potential.pair.Depletion(types=('1','2'))
-        coeff = relentless.potential.potential.PairParameters(types=('1','2'),
-                                                              params=('P','sigma_i','sigma_j','sigma_d','rmin','rmax','shift'))
+        dp = relentless.potential.Depletion(types=('1','2'))
+        coeff = relentless.potential.PairParameters(types=('1','2'),
+                                                    params=('P','sigma_i','sigma_j','sigma_d','rmin','rmax','shift'))
         self.assertCountEqual(dp.coeff.types, coeff.types)
         self.assertCountEqual(dp.coeff.params, coeff.params)
 
     def test_energy(self):
         """Test _energy method"""
-        dp = relentless.potential.pair.Depletion(types=('1',))
+        dp = relentless.potential.Depletion(types=('1',))
 
         #test scalar r
         r_input = 3
@@ -369,7 +369,7 @@ class test_Depletion(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        dp = relentless.potential.pair.Depletion(types=('1',))
+        dp = relentless.potential.Depletion(types=('1',))
 
         #test scalar r
         r_input = 3
@@ -393,7 +393,7 @@ class test_Depletion(unittest.TestCase):
 
     def test_derivative(self):
         """Test _derivative method"""
-        dp = relentless.potential.pair.Depletion(types=('1',))
+        dp = relentless.potential.Depletion(types=('1',))
 
         #w.r.t. P
         #test scalar r

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -8,7 +8,7 @@ import numpy as np
 import relentless
 
 class test_PairParameters(unittest.TestCase):
-    """Unit tests for relentless.potential.potential.PairParameters"""
+    """Unit tests for relentless.potential.PairParameters"""
 
     def test_init(self):
         """Test creation from data"""
@@ -17,34 +17,34 @@ class test_PairParameters(unittest.TestCase):
         params = ('energy', 'mass')
 
         #test construction with tuple input
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with list input
-        m = relentless.potential.potential.PairParameters(types=['A','B'], params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=['A','B'], params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with mixed tuple/list input
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=['energy','mass'])
+        m = relentless.potential.PairParameters(types=('A','B'), params=['energy','mass'])
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with int type parameters
         with self.assertRaises(TypeError):
-            m = relentless.potential.potential.PairParameters(types=('A','B'), params=(1,2))
+            m = relentless.potential.PairParameters(types=('A','B'), params=(1,2))
 
         #test construction with mixed type parameters
         with self.assertRaises(TypeError):
-            m = relentless.potential.potential.PairParameters(types=('A','B'), params=('1',2))
+            m = relentless.potential.PairParameters(types=('A','B'), params=('1',2))
 
     def test_param_types(self):
         """Test various get and set methods on pair parameter types"""
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy', 'mass'))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy', 'mass'))
 
         self.assertEqual(m.shared['energy'], None)
         self.assertEqual(m.shared['mass'], None)
@@ -112,7 +112,7 @@ class test_PairParameters(unittest.TestCase):
 
     def test_accessor_methods(self):
         """Test various get and set methods on pairs"""
-        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A',), params=('energy','mass'))
 
         #test set and get for each pair type and param
         self.assertEqual(m['A','A']['energy'], None)
@@ -170,7 +170,7 @@ class test_PairParameters(unittest.TestCase):
     def test_accessor_pairs(self):
         """Test get and set methods for various pairs"""
         #test set and get for initialized default
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         self.assertEqual(m['A','B']['energy'], None)
         self.assertEqual(m['A','B']['mass'], None)
         self.assertEqual(m['A','A']['energy'], None)
@@ -223,7 +223,7 @@ class test_PairParameters(unittest.TestCase):
     def test_evaluate(self):
         """Test evaluation of pair parameters"""
         #test evaluation with empty parameter values
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         with self.assertRaises(ValueError):
             x = m.evaluate(('A','B'))
 
@@ -232,7 +232,7 @@ class test_PairParameters(unittest.TestCase):
             x = m.evaluate(('A','C'))
 
         #test evaluation with initialized shared parameter values
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         m.shared['energy'] = 0.0
         m.shared['mass'] = 0.5
         self.assertEqual(m.evaluate(('A','B')), {'energy':0.0, 'mass':0.5})
@@ -241,7 +241,7 @@ class test_PairParameters(unittest.TestCase):
         self.assertEqual(m.evaluate(('B','A')), m.evaluate(('A','B')))
 
         #test evaluation with initialized shared and individual parameter values
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         m.shared['energy'] = 0.0
         m.shared['mass'] = 0.5
         m['B','B']['energy'] = 1.5
@@ -251,15 +251,15 @@ class test_PairParameters(unittest.TestCase):
         self.assertEqual(m.evaluate(('B','A')), m.evaluate(('A','B')))
 
         #test evaluation with initialized parameter values as Variable types
-        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
-        m['A','A']['energy'] = relentless.core.Variable(value=-1.0,low=0.1)
-        m['A','A']['mass'] = relentless.core.Variable(value=1.0,high=0.3)
+        m = relentless.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m['A','A']['energy'] = relentless.Variable(value=-1.0,low=0.1)
+        m['A','A']['mass'] = relentless.Variable(value=1.0,high=0.3)
         self.assertEqual(m.evaluate(('A','A')), {'energy':0.1, 'mass':0.3})
 
         #test evaluation with initialized parameter values as unrecognized types
-        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
-        m.shared['energy'] = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
-        m.shared['mass'] = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m.shared['energy'] = relentless.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        m.shared['mass'] = relentless.Interpolator(x=(-1,0,1), y=(-2,0,2))
         with self.assertRaises(TypeError):
             x = m.evaluate(('A','B'))
 
@@ -268,7 +268,7 @@ class test_PairParameters(unittest.TestCase):
         temp = tempfile.NamedTemporaryFile()
 
         #test dumping/re-loading data with scalar parameter values
-        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m = relentless.potential.PairParameters(types=('A',), params=('energy','mass'))
         m['A','A']['energy'] = 1.5
         m['A','A']['mass'] = 2.5
         m.save(temp.name)
@@ -278,9 +278,9 @@ class test_PairParameters(unittest.TestCase):
         self.assertEqual(m['A','A']['mass'], x["('A', 'A')"]['mass'])
 
         #test dumping/re-loading data with Variable parameter values
-        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
-        m['A','A']['energy'] = relentless.core.Variable(value=0.5)
-        m['A','A']['mass'] = relentless.core.Variable(value=2.0)
+        m = relentless.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m['A','A']['energy'] = relentless.Variable(value=0.5)
+        m['A','A']['mass'] = relentless.Variable(value=2.0)
         m.save(temp.name)
         with open(temp.name, 'r') as f:
             x = json.load(f)
@@ -289,8 +289,8 @@ class test_PairParameters(unittest.TestCase):
 
         temp.close()
 
-class LinPot(relentless.potential.potential.PairPotential):
-    """Linear potential function used to test relentless.potential.potential.PairPotential"""
+class LinPot(relentless.potential.PairPotential):
+    """Linear potential function used to test relentless.potential.PairPotential"""
 
     def __init__(self, types, params):
         super().__init__(types, params)
@@ -318,7 +318,7 @@ class LinPot(relentless.potential.potential.PairPotential):
         return d
 
 class test_PairPotential(unittest.TestCase):
-    """Unit tests for relentless.potential.potential.PairPotential"""
+    """Unit tests for relentless.potential.PairPotential"""
 
     def test_init(self):
         """Test creation from data"""
@@ -326,7 +326,7 @@ class test_PairPotential(unittest.TestCase):
         p = LinPot(types=('1',), params=('m',))
         p.coeff['1','1']['m'] = 3.5
 
-        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
         coeff['1','1']['m'] = 3.5
         coeff['1','1']['rmin'] = False
         coeff['1','1']['rmax'] = False
@@ -341,7 +341,7 @@ class test_PairPotential(unittest.TestCase):
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['rmin'] = 0.0
 
-        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
         coeff['1','1']['m'] = 3.5
         coeff['1','1']['rmin'] = 0.0
         coeff['1','1']['rmax'] = False
@@ -356,7 +356,7 @@ class test_PairPotential(unittest.TestCase):
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['rmax'] = 1.0
 
-        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
         coeff['1','1']['m'] = 3.5
         coeff['1','1']['rmin'] = False
         coeff['1','1']['rmax'] = 1.0
@@ -371,7 +371,7 @@ class test_PairPotential(unittest.TestCase):
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['shift'] = True
 
-        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
         coeff['1','1']['m'] = 3.5
         coeff['1','1']['rmin'] = False
         coeff['1','1']['rmax'] = False
@@ -388,7 +388,7 @@ class test_PairPotential(unittest.TestCase):
         p.coeff['1','1']['rmax'] = 1.0
         p.coeff['1','1']['shift'] = True
 
-        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff = relentless.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
         coeff['1','1']['m'] = 3.5
         coeff['1','1']['rmin'] = 0.0
         coeff['1','1']['rmax'] = 1.0
@@ -590,8 +590,8 @@ class test_PairPotential(unittest.TestCase):
 
         temp.close()
 
-class QuadPot(relentless.potential.potential.PairPotential):
-    """Quadratic potential function used to test relentless.potential.potential.Tabulator"""
+class QuadPot(relentless.potential.PairPotential):
+    """Quadratic potential function used to test relentless.potential.Tabulator"""
 
     def __init__(self, types, params):
         super().__init__(types, params)
@@ -619,21 +619,21 @@ class QuadPot(relentless.potential.potential.PairPotential):
         return d
 
 class test_Tabulator(unittest.TestCase):
-    """Unit tests for relentless.potential.potential.Tabulator"""
+    """Unit tests for relentless.potential.Tabulator"""
 
     def test_init(self):
         """Test creation of object with data"""
         r_input = np.array([0.5,0.75,1,1.25,1.5])
 
         #test creation with required param
-        t = relentless.potential.potential.Tabulator(r=r_input)
+        t = relentless.potential.Tabulator(r=r_input)
         np.testing.assert_allclose(t.r, r_input)
         self.assertEqual(t.fmax, None)
         self.assertEqual(t.fcut, None)
         self.assertEqual(t.shift, True)
 
         #test creation with required param, fmax, fcut, shift
-        t = relentless.potential.potential.Tabulator(r=r_input, fmax=1.5, fcut=1.0, shift=False)
+        t = relentless.potential.Tabulator(r=r_input, fmax=1.5, fcut=1.0, shift=False)
         np.testing.assert_allclose(t.r, r_input)
         self.assertAlmostEqual(t.fmax, 1.5)
         self.assertAlmostEqual(t.fcut, 1.0)
@@ -644,13 +644,13 @@ class test_Tabulator(unittest.TestCase):
 
         #test creation with invalid r,fmax,fcut setup
         with self.assertRaises(TypeError):
-            t = relentless.potential.potential.Tabulator(r=r_input_2d)
+            t = relentless.potential.Tabulator(r=r_input_2d)
         with self.assertRaises(ValueError):
-            t = relentless.potential.potential.Tabulator(r=r_input_bad)
+            t = relentless.potential.Tabulator(r=r_input_bad)
         with self.assertRaises(ValueError):
-            t = relentless.potential.potential.Tabulator(r=r_input, fmax=-1.0)
+            t = relentless.potential.Tabulator(r=r_input, fmax=-1.0)
         with self.assertRaises(ValueError):
-            t = relentless.potential.potential.Tabulator(r=r_input, fcut=-1.0)
+            t = relentless.potential.Tabulator(r=r_input, fcut=-1.0)
 
     def test_potential(self):
         """Test energy and force methods"""
@@ -660,7 +660,7 @@ class test_Tabulator(unittest.TestCase):
         for pair in p2.coeff.pairs:
             p2.coeff[pair]['m'] = 1.0
         p_all = [p1, p2]
-        t = relentless.potential.potential.Tabulator(r=np.array([1,2,3,4,5]))
+        t = relentless.potential.Tabulator(r=np.array([1,2,3,4,5]))
 
         #test energy method
         u = t.energy(pair=('1','1'), potentials=p_all)
@@ -684,7 +684,7 @@ class test_Tabulator(unittest.TestCase):
         for pair in p2.coeff.pairs:
             p2.coeff[pair]['m'] = 1.0
         p_all = [p1, p2]
-        t = relentless.potential.potential.Tabulator(r=np.array([0.5,1,1.5,2,2.5]))
+        t = relentless.potential.Tabulator(r=np.array([0.5,1,1.5,2,2.5]))
 
         #test without fmax or fcut
         u = t.energy(pair=('1','1'), potentials=p_all)

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -1,14 +1,14 @@
 """Unit tests for potential module."""
+import json
 import tempfile
 import unittest
 
 import numpy as np
 
-from relentless import core
-from relentless.potential import potential
+import relentless
 
-class test_CoefficientMatrix(unittest.TestCase):
-    """Unit tests for potential.CoefficientMatrix"""
+class test_PairParameters(unittest.TestCase):
+    """Unit tests for relentless.potential.potential.PairParameters"""
 
     def test_init(self):
         """Test creation from data"""
@@ -17,43 +17,102 @@ class test_CoefficientMatrix(unittest.TestCase):
         params = ('energy', 'mass')
 
         #test construction with tuple input
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with list input
-        m = potential.CoefficientMatrix(types=['A','B'], params=('energy','mass'))
+        m = relentless.potential.potential.PairParameters(types=['A','B'], params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with mixed tuple/list input
-        m = potential.CoefficientMatrix(types=('A','B'), params=['energy','mass'])
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=['energy','mass'])
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
-        self.assertCountEqual(m.pairs, pairs)
-
-        #test construction with default values initialized
-        default = {'energy':0.0, 'mass':0.0}
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':0.0, 'mass':0.0})
-        self.assertEqual(m.types, types)
-        self.assertEqual(m.params, params)
-        self.assertEqual(m.default.todict(), default)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with int type parameters
         with self.assertRaises(TypeError):
-            m = potential.CoefficientMatrix(types=('A','B'), params=(1,2))
+            m = relentless.potential.potential.PairParameters(types=('A','B'), params=(1,2))
 
         #test construction with mixed type parameters
         with self.assertRaises(TypeError):
-            m = potential.CoefficientMatrix(types=('A','B'), params=('1',2))
+            m = relentless.potential.potential.PairParameters(types=('A','B'), params=('1',2))
+
+    def test_param_types(self):
+        """Test various get and set methods on pair parameter types"""
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy', 'mass'))
+
+        self.assertEqual(m.shared['energy'], None)
+        self.assertEqual(m.shared['mass'], None)
+        self.assertEqual(m['A','A']['energy'], None)
+        self.assertEqual(m['A','A']['mass'], None)
+        self.assertEqual(m['A','B']['energy'], None)
+        self.assertEqual(m['A','B']['mass'], None)
+        self.assertEqual(m['B','B']['energy'], None)
+        self.assertEqual(m['B','B']['mass'], None)
+        self.assertEqual(m['A']['energy'], None)
+        self.assertEqual(m['A']['mass'], None)
+        self.assertEqual(m['B']['energy'], None)
+        self.assertEqual(m['B']['mass'], None)
+
+        #test setting shared params
+        m.shared.update(energy=1.0, mass=2.0)
+
+        self.assertEqual(m.shared['energy'], 1.0)
+        self.assertEqual(m.shared['mass'], 2.0)
+        self.assertEqual(m['A','A']['energy'], None)
+        self.assertEqual(m['A','A']['mass'], None)
+        self.assertEqual(m['A','B']['energy'], None)
+        self.assertEqual(m['A','B']['mass'], None)
+        self.assertEqual(m['B','B']['energy'], None)
+        self.assertEqual(m['B','B']['mass'], None)
+        self.assertEqual(m['A']['energy'], None)
+        self.assertEqual(m['A']['mass'], None)
+        self.assertEqual(m['B']['energy'], None)
+        self.assertEqual(m['B']['mass'], None)
+
+        #test setting per-pair params
+        m['A','A'].update(energy=1.5, mass=2.5)
+        m['A','B'].update(energy=2.0, mass=3.0)
+        m['B','B'].update(energy=0.5, mass=0.7)
+
+        self.assertEqual(m.shared['energy'], 1.0)
+        self.assertEqual(m.shared['mass'], 2.0)
+        self.assertEqual(m['A','A']['energy'], 1.5)
+        self.assertEqual(m['A','A']['mass'], 2.5)
+        self.assertEqual(m['A','B']['energy'], 2.0)
+        self.assertEqual(m['A','B']['mass'], 3.0)
+        self.assertEqual(m['B','B']['energy'], 0.5)
+        self.assertEqual(m['B','B']['mass'], 0.7)
+        self.assertEqual(m['A']['energy'], None)
+        self.assertEqual(m['A']['mass'], None)
+        self.assertEqual(m['B']['energy'], None)
+        self.assertEqual(m['B']['mass'], None)
+
+        #test setting per-type params
+        m['A'].update(energy=0.1, mass=0.2)
+        m['B'].update(energy=0.2, mass=0.1)
+
+        self.assertEqual(m.shared['energy'], 1.0)
+        self.assertEqual(m.shared['mass'], 2.0)
+        self.assertEqual(m['A','A']['energy'], 1.5)
+        self.assertEqual(m['A','A']['mass'], 2.5)
+        self.assertEqual(m['A','B']['energy'], 2.0)
+        self.assertEqual(m['A','B']['mass'], 3.0)
+        self.assertEqual(m['B','B']['energy'], 0.5)
+        self.assertEqual(m['B','B']['mass'], 0.7)
+        self.assertEqual(m['A']['energy'], 0.1)
+        self.assertEqual(m['A']['mass'], 0.2)
+        self.assertEqual(m['B']['energy'], 0.2)
+        self.assertEqual(m['B']['mass'], 0.1)
 
     def test_accessor_methods(self):
         """Test various get and set methods on pairs"""
-        m = potential.CoefficientMatrix(types=('A',), params=('energy','mass'))
+        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
 
         #test set and get for each pair type and param
         self.assertEqual(m['A','A']['energy'], None)
@@ -111,31 +170,30 @@ class test_CoefficientMatrix(unittest.TestCase):
     def test_accessor_pairs(self):
         """Test get and set methods for various pairs"""
         #test set and get for initialized default
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':0.0, 'mass':0.0})
-        self.assertEqual(m['A','B']['energy'], 0.0)
-        self.assertEqual(m['A','B']['mass'], 0.0)
-        self.assertEqual(m['A','A']['energy'], 0.0)
-        self.assertEqual(m['A','A']['mass'], 0.0)
-        self.assertEqual(m['B','B']['energy'], 0.0)
-        self.assertEqual(m['B','B']['mass'], 0.0)
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        self.assertEqual(m['A','B']['energy'], None)
+        self.assertEqual(m['A','B']['mass'], None)
+        self.assertEqual(m['A','A']['energy'], None)
+        self.assertEqual(m['A','A']['mass'], None)
+        self.assertEqual(m['B','B']['energy'], None)
+        self.assertEqual(m['B','B']['mass'], None)
 
         #test reset and get manually
         m['A','B'] = {'energy':1.0, 'mass':2.0}
         self.assertEqual(m['A','B']['energy'], 1.0)
         self.assertEqual(m['A','B']['mass'], 2.0)
-        self.assertEqual(m['A','A']['energy'], 0.0)
-        self.assertEqual(m['A','A']['mass'], 0.0)
-        self.assertEqual(m['B','B']['energy'], 0.0)
-        self.assertEqual(m['B','B']['mass'], 0.0)
+        self.assertEqual(m['A','A']['energy'], None)
+        self.assertEqual(m['A','A']['mass'], None)
+        self.assertEqual(m['B','B']['energy'], None)
+        self.assertEqual(m['B','B']['mass'], None)
 
         m['A','A'].update({'energy':1.5, 'mass':2.5})
         self.assertEqual(m['A','B']['energy'], 1.0)
         self.assertEqual(m['A','B']['mass'], 2.0)
         self.assertEqual(m['A','A']['energy'], 1.5)
         self.assertEqual(m['A','A']['mass'], 2.5)
-        self.assertEqual(m['B','B']['energy'], 0.0)
-        self.assertEqual(m['B','B']['mass'], 0.0)
+        self.assertEqual(m['B','B']['energy'], None)
+        self.assertEqual(m['B','B']['mass'], None)
 
         m['B','B'] = {'energy':3.0, 'mass':4.0}
         self.assertEqual(m['A','B']['energy'], 1.0)
@@ -158,14 +216,14 @@ class test_CoefficientMatrix(unittest.TestCase):
         self.assertEqual(m['A','B']['energy'], 1.0)
         self.assertEqual(m['A','B']['mass'], 2.0)
         self.assertEqual(m['A','A']['energy'], 2.0)
-        self.assertEqual(m['A','A']['mass'], 0.0)
+        self.assertEqual(m['A','A']['mass'], None)
         self.assertEqual(m['B','B']['energy'], 3.5)
         self.assertEqual(m['B','B']['mass'], 4.5)
 
     def test_evaluate(self):
         """Test evaluation of pair parameters"""
         #test evaluation with empty parameter values
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         with self.assertRaises(ValueError):
             x = m.evaluate(('A','B'))
 
@@ -173,148 +231,69 @@ class test_CoefficientMatrix(unittest.TestCase):
         with self.assertRaises(KeyError):
             x = m.evaluate(('A','C'))
 
-        #test evaluation with initialized parameter values as scalars
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':0.0, 'mass':0.0})
-        self.assertEqual(m.evaluate(('A','B')), {'energy':0.0, 'mass':0.0})
-        self.assertEqual(m.evaluate(('A','A')), {'energy':0.0, 'mass':0.0})
-        self.assertEqual(m.evaluate(('B','B')), {'energy':0.0, 'mass':0.0})
+        #test evaluation with initialized shared parameter values
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m.shared['energy'] = 0.0
+        m.shared['mass'] = 0.5
+        self.assertEqual(m.evaluate(('A','B')), {'energy':0.0, 'mass':0.5})
+        self.assertEqual(m.evaluate(('A','A')), {'energy':0.0, 'mass':0.5})
+        self.assertEqual(m.evaluate(('B','B')), {'energy':0.0, 'mass':0.5})
+        self.assertEqual(m.evaluate(('B','A')), m.evaluate(('A','B')))
+
+        #test evaluation with initialized shared and individual parameter values
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m.shared['energy'] = 0.0
+        m.shared['mass'] = 0.5
+        m['B','B']['energy'] = 1.5
+        self.assertEqual(m.evaluate(('A','B')), {'energy':0.0, 'mass':0.5})
+        self.assertEqual(m.evaluate(('A','A')), {'energy':0.0, 'mass':0.5})
+        self.assertEqual(m.evaluate(('B','B')), {'energy':1.5, 'mass':0.5})
         self.assertEqual(m.evaluate(('B','A')), m.evaluate(('A','B')))
 
         #test evaluation with initialized parameter values as Variable types
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':core.Variable(value=-1.0,low=0.1),
-                                                 'mass':core.Variable(value=1.0,high=0.1)})
-        self.assertEqual(m.evaluate(('A','B')), {'energy':0.1, 'mass':0.1})
-        self.assertEqual(m.evaluate(('A','A')), {'energy':0.1, 'mass':0.1})
-        self.assertEqual(m.evaluate(('B','B')), {'energy':0.1, 'mass':0.1})
-        self.assertEqual(m.evaluate(('B','A')), m.evaluate(('A','B')))
+        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m['A','A']['energy'] = relentless.core.Variable(value=-1.0,low=0.1)
+        m['A','A']['mass'] = relentless.core.Variable(value=1.0,high=0.3)
+        self.assertEqual(m.evaluate(('A','A')), {'energy':0.1, 'mass':0.3})
 
         #test evaluation with initialized parameter values as unrecognized types
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':core.Interpolator(x=(-1,0,1), y=(-2,0,2)),
-                                                 'mass':core.Interpolator(x=(-1,0,1), y=(-2,0,2))})
+        m = relentless.potential.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m.shared['energy'] = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        m.shared['mass'] = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
         with self.assertRaises(TypeError):
             x = m.evaluate(('A','B'))
 
-    def test_saveload(self):
-        """Test saving to and loading from file"""
+    def test_save(self):
+        """Test saving to file"""
         temp = tempfile.NamedTemporaryFile()
 
         #test dumping/re-loading data with scalar parameter values
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':0.5, 'mass':2.0})
-        x = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m['A','A']['energy'] = 1.5
+        m['A','A']['mass'] = 2.5
         m.save(temp.name)
-        x.load(temp.name)
-
-        self.assertEqual(m['A','B']['energy'], x['A','B']['energy'])
-        self.assertEqual(m['A','B']['mass'], x['A','B']['mass'])
-        self.assertEqual(m['A','A']['energy'], x['A','A']['energy'])
-        self.assertEqual(m['A','A']['mass'], x['A','A']['mass'])
-        self.assertEqual(m['B','B']['energy'], x['B','B']['energy'])
-        self.assertEqual(m['B','B']['mass'], x['B','B']['mass'])
+        with open(temp.name, 'r') as f:
+            x = json.load(f)
+        self.assertEqual(m['A','A']['energy'], x["('A', 'A')"]['energy'])
+        self.assertEqual(m['A','A']['mass'], x["('A', 'A')"]['mass'])
 
         #test dumping/re-loading data with Variable parameter values
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                        default={'energy':core.Variable(value=0.5, high=0.2),
-                                                 'mass':core.Variable(value=2.0, low=3.0)})
-        x = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'))
+        m = relentless.potential.potential.PairParameters(types=('A',), params=('energy','mass'))
+        m['A','A']['energy'] = relentless.core.Variable(value=0.5)
+        m['A','A']['mass'] = relentless.core.Variable(value=2.0)
         m.save(temp.name)
-        x.load(temp.name)
-
-        self.assertEqual(m['A','B']['energy'].value, x['A','B']['energy'].value)
-        self.assertEqual(m['A','B']['mass'].value, x['A','B']['mass'].value)
-        self.assertEqual(m['A','A']['energy'].value, x['A','A']['energy'].value)
-        self.assertEqual(m['A','A']['mass'].value, x['A','A']['mass'].value)
-        self.assertEqual(m['B','B']['energy'].value, x['B','B']['energy'].value)
-        self.assertEqual(m['B','B']['mass'].value, x['B','B']['mass'].value)
-
-        self.assertEqual(m['A','B']['energy'].low, x['A','B']['energy'].low)
-        self.assertEqual(m['A','B']['mass'].low, x['A','B']['mass'].low)
-        self.assertEqual(m['A','A']['energy'].low, x['A','A']['energy'].low)
-        self.assertEqual(m['A','A']['mass'].low, x['A','A']['mass'].low)
-        self.assertEqual(m['B','B']['energy'].low, x['B','B']['energy'].low)
-        self.assertEqual(m['B','B']['mass'].low, x['B','B']['mass'].low)
-
-        self.assertEqual(m['A','B']['energy'].high, x['A','B']['energy'].high)
-        self.assertEqual(m['A','B']['mass'].high, x['A','B']['mass'].high)
-        self.assertEqual(m['A','A']['energy'].high, x['A','A']['energy'].high)
-        self.assertEqual(m['A','A']['mass'].high, x['A','A']['mass'].high)
-        self.assertEqual(m['B','B']['energy'].high, x['B','B']['energy'].high)
-        self.assertEqual(m['B','B']['mass'].high, x['B','B']['mass'].high)
-
-        #test dumping/re-loading data with types that don't match
-        m = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'))
-        x = potential.CoefficientMatrix(types=('A','B','C'), params=('energy','mass'),
-                                          default={'energy':0.5, 'mass':0.2})
-        x.save(temp.name)
-        with self.assertRaises(KeyError):
-            m.load(temp.name)
-
-        #test dumping/re-loading data with params that don't match
-        x = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass','charge'),
-                                          default={'energy':core.Variable(value=1.0),
-                                                   'mass':core.Variable(value=2.0),
-                                                   'charge':core.Variable(value=0.0)})
-        x.save(temp.name)
-        with self.assertRaises(KeyError):
-            m.load(temp.name)
+        with open(temp.name, 'r') as f:
+            x = json.load(f)
+        self.assertEqual(m['A','A']['energy'].value, x["('A', 'A')"]['energy'])
+        self.assertEqual(m['A','A']['mass'].value, x["('A', 'A')"]['mass'])
 
         temp.close()
 
-    def test_fromfile(self):
-        """Test creating new coefficient matrix from file."""
-        temp = tempfile.NamedTemporaryFile()
+class LinPot(relentless.potential.potential.PairPotential):
+    """Linear potential function used to test relentless.potential.potential.PairPotential"""
 
-        #test loading data with scalar values using class method `from_file`
-        x = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                          default={'energy':1.0, 'mass':2.0})
-        x.save(temp.name)
-        m = potential.CoefficientMatrix.from_file(temp.name)
-
-        self.assertEqual(m['A','B']['energy'], x['A','B']['energy'])
-        self.assertEqual(m['A','B']['mass'], x['A','B']['mass'])
-        self.assertEqual(m['A','A']['energy'], x['A','A']['energy'])
-        self.assertEqual(m['A','A']['mass'], x['A','A']['mass'])
-        self.assertEqual(m['B','B']['energy'], x['B','B']['energy'])
-        self.assertEqual(m['B','B']['mass'], x['B','B']['mass'])
-
-        #test loading data with Variable values using class method `from_file`
-        x = potential.CoefficientMatrix(types=('A','B'), params=('energy','mass'),
-                                          default={'energy':core.Variable(value=1.0,low=1.5),
-                                                   'mass':core.Variable(value=0.5,high=0.2)})
-        x.save(temp.name)
-        m = potential.CoefficientMatrix.from_file(temp.name)
-
-        self.assertEqual(m['A','B']['energy'].value, x['A','B']['energy'].value)
-        self.assertEqual(m['A','B']['mass'].value, x['A','B']['mass'].value)
-        self.assertEqual(m['A','A']['energy'].value, x['A','A']['energy'].value)
-        self.assertEqual(m['A','A']['mass'].value, x['A','A']['mass'].value)
-        self.assertEqual(m['B','B']['energy'].value, x['B','B']['energy'].value)
-        self.assertEqual(m['B','B']['mass'].value, x['B','B']['mass'].value)
-
-        self.assertEqual(m['A','B']['energy'].low, x['A','B']['energy'].low)
-        self.assertEqual(m['A','B']['mass'].low, x['A','B']['mass'].low)
-        self.assertEqual(m['A','A']['energy'].low, x['A','A']['energy'].low)
-        self.assertEqual(m['A','A']['mass'].low, x['A','A']['mass'].low)
-        self.assertEqual(m['B','B']['energy'].low, x['B','B']['energy'].low)
-        self.assertEqual(m['B','B']['mass'].low, x['B','B']['mass'].low)
-
-        self.assertEqual(m['A','B']['energy'].high, x['A','B']['energy'].high)
-        self.assertEqual(m['A','B']['mass'].high, x['A','B']['mass'].high)
-        self.assertEqual(m['A','A']['energy'].high, x['A','A']['energy'].high)
-        self.assertEqual(m['A','A']['mass'].high, x['A','A']['mass'].high)
-        self.assertEqual(m['B','B']['energy'].high, x['B','B']['energy'].high)
-        self.assertEqual(m['B','B']['mass'].high, x['B','B']['mass'].high)
-
-        temp.close()
-
-class LinPot(potential.PairPotential):
-    """Linear potential function used to test potential.PairPotential"""
-
-    def __init__(self, types, params, default={}):
-        super().__init__(types, params, default)
+    def __init__(self, types, params):
+        super().__init__(types, params)
 
     def _energy(self, r, m, **params):
         r,u,s = self._zeros(r)
@@ -339,66 +318,85 @@ class LinPot(potential.PairPotential):
         return d
 
 class test_PairPotential(unittest.TestCase):
-    """Unit tests for potential.PairPotential"""
+    """Unit tests for relentless.potential.potential.PairPotential"""
 
     def test_init(self):
         """Test creation from data"""
         #test creation with only m
-        p = LinPot(types=('1',), params=('m',), default={'m':3.5})
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'m':3.5,'rmin':False,'rmax':False,'shift':False})
+        p = LinPot(types=('1',), params=('m',))
+        p.coeff['1','1']['m'] = 3.5
+
+        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff['1','1']['m'] = 3.5
+        coeff['1','1']['rmin'] = False
+        coeff['1','1']['rmax'] = False
+        coeff['1','1']['shift'] = False
+
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
+        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with m and rmin
-        p = LinPot(types=('1',), params=('m','rmin'), default={'m':3.5,'rmin':0.0})
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'m':3.5,'rmin':0.0,'rmax':False,'shift':False})
+        p = LinPot(types=('1',), params=('m','rmin'))
+        p.coeff['1','1']['m'] = 3.5
+        p.coeff['1','1']['rmin'] = 0.0
+
+        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff['1','1']['m'] = 3.5
+        coeff['1','1']['rmin'] = 0.0
+        coeff['1','1']['rmax'] = False
+        coeff['1','1']['shift'] = False
+
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
+        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with m and rmax
-        p = LinPot(types=('1',), params=('m','rmax'), default={'m':3.5,'rmax':1.0})
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'m':3.5,'rmin':False,'rmax':1.0,'shift':False})
+        p = LinPot(types=('1',), params=('m','rmax'))
+        p.coeff['1','1']['m'] = 3.5
+        p.coeff['1','1']['rmax'] = 1.0
+
+        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff['1','1']['m'] = 3.5
+        coeff['1','1']['rmin'] = False
+        coeff['1','1']['rmax'] = 1.0
+        coeff['1','1']['shift'] = False
+
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
+        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with m and shift
-        p = LinPot(types=('1',), params=('m','shift'), default={'m':3.5,'shift':True})
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'m':3.5,'rmin':False,'rmax':False,'shift':True})
+        p = LinPot(types=('1',), params=('m','shift'))
+        p.coeff['1','1']['m'] = 3.5
+        p.coeff['1','1']['shift'] = True
+
+        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff['1','1']['m'] = 3.5
+        coeff['1','1']['rmin'] = False
+        coeff['1','1']['rmax'] = False
+        coeff['1','1']['shift'] = True
+
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
+        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
-        #test creation with all params, default values
-        p = LinPot(types=('1',), params=('m','rmin','rmax','shift'),
-                   default={'m':3.5,'rmin':0.0,'rmax':1.0,'shift':True})
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'m':3.5,'rmin':0.0,'rmax':1.0,'shift':True})
-        self.assertCountEqual(p.coeff.types, coeff.types)
-        self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
-
-        #test creation with no standard params, no default values
-        p = LinPot(types=('1',), params=('m',))
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
-        self.assertCountEqual(p.coeff.types, coeff.types)
-        self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
-
-        #test creation with all params, no default values
+        #test creation with all params
         p = LinPot(types=('1',), params=('m','rmin','rmax','shift'))
-        coeff = potential.CoefficientMatrix(types=('1',), params=('m','rmin','rmax','shift'),
-                                            default={'rmin':False,'rmax':False,'shift':False})
+        p.coeff['1','1']['m'] = 3.5
+        p.coeff['1','1']['rmin'] = 0.0
+        p.coeff['1','1']['rmax'] = 1.0
+        p.coeff['1','1']['shift'] = True
+
+        coeff = relentless.potential.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
+        coeff['1','1']['m'] = 3.5
+        coeff['1','1']['rmin'] = 0.0
+        coeff['1','1']['rmax'] = 1.0
+        coeff['1','1']['shift'] = True
+
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.default.todict(), coeff.default.todict())
+        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
     def test_zeros(self):
         """Test _zeros method"""
@@ -440,8 +438,10 @@ class test_PairPotential(unittest.TestCase):
 
     def test_energy(self):
         """Test energy method"""
+        p = LinPot(types=('1',), params=('m',))
+        p.coeff['1','1']['m'] = 2.0
+
         #test with no cutoffs
-        p = LinPot(types=('1',), params=('m',), default={'m':2})
         u = p.energy(pair=('1','1'), r=0.5)
         self.assertAlmostEqual(u, 1.0)
         u = p.energy(pair=('1','1'), r=[0.25,0.75])
@@ -482,8 +482,10 @@ class test_PairPotential(unittest.TestCase):
 
     def test_force(self):
         """Test force method"""
+        p = LinPot(types=('1',), params=('m',))
+        p.coeff['1','1']['m'] = 2.0
+
         #test with no cutoffs
-        p = LinPot(types=('1',), params=('m',), default={'m':2})
         f = p.force(pair=('1','1'), r=0.5)
         self.assertAlmostEqual(f, -2.0)
         f = p.force(pair=('1','1'), r=[0.25,0.75])
@@ -519,8 +521,10 @@ class test_PairPotential(unittest.TestCase):
 
     def test_derivative(self):
         """Test derivative method"""
+        p = LinPot(types=('1',), params=('m',))
+        p.coeff['1','1']['m'] = 2.0
+
         #test with no cutoffs
-        p = LinPot(types=('1',), params=('m',), default={'m':2})
         d = p.derivative(pair=('1','1'), param='m', r=0.5)
         self.assertAlmostEqual(d, 0.5)
         d = p.derivative(pair=('1','1'), param='m', r=[0.25,0.75])
@@ -566,26 +570,31 @@ class test_PairPotential(unittest.TestCase):
         self.assertDictEqual(p.coeff['1','2'].todict(), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
         self.assertDictEqual(p.coeff['2','2'].todict(), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
 
-    def test_saveload(self):
-        """Test saving to and loading from file"""
+    def test_save(self):
+        """Test saving to file"""
         temp = tempfile.NamedTemporaryFile()
-        p = LinPot(types=('1',), params=('m','rmin','rmax'), default={'m':2,'rmin':0.0,'rmax':1.0})
-        x = LinPot(types=('1',), params=('m','rmin','rmax','shift'))
-        p.save(temp.name)
-        x.load(temp.name)
+        p = LinPot(types=('1',), params=('m','rmin','rmax'))
+        p.coeff['1','1']['m'] = 2.0
+        p.coeff['1','1']['rmin'] = 0.0
+        p.coeff['1','1']['rmax'] = 1.0
+        p.coeff['1','1']['shift'] = True
 
-        self.assertEqual(p.coeff['1','1']['m'], x.coeff['1','1']['m'])
-        self.assertEqual(p.coeff['1','1']['rmin'], x.coeff['1','1']['rmin'])
-        self.assertEqual(p.coeff['1','1']['rmax'], x.coeff['1','1']['rmax'])
-        self.assertEqual(p.coeff['1','1']['shift'], x.coeff['1','1']['shift'])
+        p.save(temp.name)
+        with open(temp.name, 'r') as f:
+            x = json.load(f)
+
+        self.assertEqual(p.coeff['1','1']['m'], x["('1', '1')"]['m'])
+        self.assertEqual(p.coeff['1','1']['rmin'], x["('1', '1')"]['rmin'])
+        self.assertEqual(p.coeff['1','1']['rmax'], x["('1', '1')"]['rmax'])
+        self.assertEqual(p.coeff['1','1']['shift'], x["('1', '1')"]['shift'])
 
         temp.close()
 
-class QuadPot(potential.PairPotential):
-    """Quadratic potential function used to test potential.Tabulator"""
+class QuadPot(relentless.potential.potential.PairPotential):
+    """Quadratic potential function used to test relentless.potential.potential.Tabulator"""
 
-    def __init__(self, types, params, default={}):
-        super().__init__(types, params, default)
+    def __init__(self, types, params):
+        super().__init__(types, params)
 
     def _energy(self, r, m, **params):
         r,u,s = self._zeros(r)
@@ -610,21 +619,21 @@ class QuadPot(potential.PairPotential):
         return d
 
 class test_Tabulator(unittest.TestCase):
-    """Unit tests for potential.Tabulator"""
+    """Unit tests for relentless.potential.potential.Tabulator"""
 
     def test_init(self):
         """Test creation of object with data"""
         r_input = np.array([0.5,0.75,1,1.25,1.5])
 
         #test creation with required param
-        t = potential.Tabulator(r=r_input)
+        t = relentless.potential.potential.Tabulator(r=r_input)
         np.testing.assert_allclose(t.r, r_input)
         self.assertEqual(t.fmax, None)
         self.assertEqual(t.fcut, None)
         self.assertEqual(t.shift, True)
 
         #test creation with required param, fmax, fcut, shift
-        t = potential.Tabulator(r=r_input, fmax=1.5, fcut=1.0, shift=False)
+        t = relentless.potential.potential.Tabulator(r=r_input, fmax=1.5, fcut=1.0, shift=False)
         np.testing.assert_allclose(t.r, r_input)
         self.assertAlmostEqual(t.fmax, 1.5)
         self.assertAlmostEqual(t.fcut, 1.0)
@@ -635,20 +644,23 @@ class test_Tabulator(unittest.TestCase):
 
         #test creation with invalid r,fmax,fcut setup
         with self.assertRaises(TypeError):
-            t = potential.Tabulator(r=r_input_2d)
+            t = relentless.potential.potential.Tabulator(r=r_input_2d)
         with self.assertRaises(ValueError):
-            t = potential.Tabulator(r=r_input_bad)
+            t = relentless.potential.potential.Tabulator(r=r_input_bad)
         with self.assertRaises(ValueError):
-            t = potential.Tabulator(r=r_input, fmax=-1.0)
+            t = relentless.potential.potential.Tabulator(r=r_input, fmax=-1.0)
         with self.assertRaises(ValueError):
-            t = potential.Tabulator(r=r_input, fcut=-1.0)
+            t = relentless.potential.potential.Tabulator(r=r_input, fcut=-1.0)
 
     def test_potential(self):
         """Test energy and force methods"""
-        p1 = QuadPot(types=('1',), params=('m',), default={'m':2})
-        p2 = QuadPot(types=('1','2'), params=('m',), default={'m':1})
+        p1 = QuadPot(types=('1',), params=('m',))
+        p1.coeff['1','1']['m'] = 2.0
+        p2 = QuadPot(types=('1','2'), params=('m',))
+        for pair in p2.coeff.pairs:
+            p2.coeff[pair]['m'] = 1.0
         p_all = [p1, p2]
-        t = potential.Tabulator(r=np.array([1,2,3,4,5]))
+        t = relentless.potential.potential.Tabulator(r=np.array([1,2,3,4,5]))
 
         #test energy method
         u = t.energy(pair=('1','1'), potentials=p_all)
@@ -666,10 +678,13 @@ class test_Tabulator(unittest.TestCase):
 
     def test_regularize(self):
         """Test regularize_force method cases"""
-        p1 = QuadPot(types=('1',), params=('m',), default={'m':2})
-        p2 = QuadPot(types=('1','2'), params=('m',), default={'m':1})
+        p1 = QuadPot(types=('1',), params=('m',))
+        p1.coeff['1','1']['m'] = 2.0
+        p2 = QuadPot(types=('1','2'), params=('m',))
+        for pair in p2.coeff.pairs:
+            p2.coeff[pair]['m'] = 1.0
         p_all = [p1, p2]
-        t = potential.Tabulator(r=np.array([0.5,1,1.5,2,2.5]))
+        t = relentless.potential.potential.Tabulator(r=np.array([0.5,1,1.5,2,2.5]))
 
         #test without fmax or fcut
         u = t.energy(pair=('1','1'), potentials=p_all)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -306,7 +306,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test clear with set default
         d = relentless.core.FixedKeyDict(keys=('A','B'), default=1.0)
-        self.assertEqual([d[k] for k in d.keys], [None, None])
+        self.assertEqual([d[k] for k in d.keys], [1.0, 1.0])
         d.update(A=2, B=3)
         self.assertEqual([d[k] for k in d.keys], [2.0, 3.0])
         d.clear()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ import numpy as np
 import relentless
 
 class test_Interpolator(unittest.TestCase):
-    """Unit tests for core.Interpolator."""
+    """Unit tests for relentless.core.Interpolator."""
 
     def test_init(self):
         """Test creation from data."""
@@ -84,7 +84,7 @@ class test_Interpolator(unittest.TestCase):
         np.testing.assert_allclose(f([-2,0.5,2]), [-2.0,1.0,2.0])
 
 class test_PairMatrix(unittest.TestCase):
-    """Unit tests for core.PairMatrix."""
+    """Unit tests for relentless.core.PairMatrix."""
 
     def test_init(self):
         """Test construction with different list types."""
@@ -205,7 +205,7 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['B','B'], {'energy':3.0, 'mass':2.0})
 
 class test_FixedKeyDict(unittest.TestCase):
-    """Unit tests for core.FixedKeyDict."""
+    """Unit tests for relentless.core.FixedKeyDict."""
 
     def test_init(self):
         """Test construction with different list keys."""
@@ -302,6 +302,27 @@ class test_FixedKeyDict(unittest.TestCase):
         with self.assertRaises(KeyError):
             d.update(C=2.5)
 
+    def test_clear(self):
+        """Test clear method to reset keys to default."""
+
+        #test clear with no default set
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d.update(A=2, B=3)
+        self.assertEqual(d['A'], 2.0)
+        self.assertEqual(d['B'], 3.0)
+        d.clear()
+        self.assertEqual(d['A'], None)
+        self.assertEqual(d['B'], None)
+
+        #test clear with set default
+        d = relentless.core.FixedKeyDict(keys=('A','B'), default=1.0)
+        d.update(A=2, B=3)
+        self.assertEqual(d['A'], 2.0)
+        self.assertEqual(d['B'], 3.0)
+        d.clear()
+        self.assertEqual(d['A'], 1.0)
+        self.assertEqual(d['B'], 1.0)
+
     def test_iteration(self):
         """Test iteration on the dictionary."""
         d = relentless.core.FixedKeyDict(keys=('A','B'))
@@ -346,7 +367,7 @@ class test_FixedKeyDict(unittest.TestCase):
         self.assertEqual(d.todict(), dict_var)
 
 class test_Variable(unittest.TestCase):
-    """Unit tests for core.Variable."""
+    """Unit tests for relentless.core.Variable."""
 
     def test_init(self):
         """Test construction with different bounds."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,47 +6,47 @@ import numpy as np
 import relentless
 
 class test_Interpolator(unittest.TestCase):
-    """Unit tests for relentless.core.Interpolator."""
+    """Unit tests for relentless.Interpolator."""
 
     def test_init(self):
         """Test creation from data."""
         #test construction with tuple input
-        f = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        f = relentless.Interpolator(x=(-1,0,1), y=(-2,0,2))
         self.assertEqual(f.domain, (-1,1))
 
         #test construction with list input
-        f = relentless.core.Interpolator(x=[-1,0,1], y=[-2,0,2])
+        f = relentless.Interpolator(x=[-1,0,1], y=[-2,0,2])
         self.assertEqual(f.domain, (-1,1))
 
         #test construction with numpy array input
-        f = relentless.core.Interpolator(x=np.array([-1,0,1]),
+        f = relentless.Interpolator(x=np.array([-1,0,1]),
                                          y=np.array([-2,0,2]))
         self.assertEqual(f.domain, (-1,1))
 
         #test construction with mixed input
-        f = relentless.core.Interpolator(x=[-1,0,1], y=(-2,0,2))
+        f = relentless.Interpolator(x=[-1,0,1], y=(-2,0,2))
         self.assertEqual(f.domain, (-1,1))
 
         #test construction with scalar input
         with self.assertRaises(ValueError):
-            f = relentless.core.Interpolator(x=1, y=2)
+            f = relentless.Interpolator(x=1, y=2)
 
         #test construction with 2d-array input
         with self.assertRaises(ValueError):
-            f = relentless.core.Interpolator(x=np.array([[-1,0,1], [-2,2,4]]),
+            f = relentless.Interpolator(x=np.array([[-1,0,1], [-2,2,4]]),
                                              y=np.array([[-1,0,1], [-2,2,4]]))
 
         #test construction with x and y having different lengths
         with self.assertRaises(ValueError):
-            f = relentless.core.Interpolator(x=[-1,0], y=[-2,0,2])
+            f = relentless.Interpolator(x=[-1,0], y=[-2,0,2])
 
         #test construction with non-strictly-increasing domain
         with self.assertRaises(ValueError):
-            f = relentless.core.Interpolator(x=(0,1,-1), y=(0,2,-2))
+            f = relentless.Interpolator(x=(0,1,-1), y=(0,2,-2))
 
     def test_call(self):
         """Test calls, both scalar and array."""
-        f = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        f = relentless.Interpolator(x=(-1,0,1), y=(-2,0,2))
 
         #test scalar call
         self.assertAlmostEqual(f(-0.5), -1.0)
@@ -57,7 +57,7 @@ class test_Interpolator(unittest.TestCase):
 
     def test_derivative(self):
         """Test derivative function, both scalar and array."""
-        f = relentless.core.Interpolator(x=(-2,-1,0,1,2), y=(4,1,0,1,4))
+        f = relentless.Interpolator(x=(-2,-1,0,1,2), y=(4,1,0,1,4))
 
         #test scalar call
         d = f.derivative(x=1.5, n=1)
@@ -69,7 +69,7 @@ class test_Interpolator(unittest.TestCase):
 
     def test_extrap(self):
         """Test extrapolation calls."""
-        f = relentless.core.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        f = relentless.Interpolator(x=(-1,0,1), y=(-2,0,2))
 
         #test extrap below lo
         self.assertAlmostEqual(f(-2), -2.0)
@@ -84,7 +84,7 @@ class test_Interpolator(unittest.TestCase):
         np.testing.assert_allclose(f([-2,0.5,2]), [-2.0,1.0,2.0])
 
 class test_PairMatrix(unittest.TestCase):
-    """Unit tests for relentless.core.PairMatrix."""
+    """Unit tests for relentless.PairMatrix."""
 
     def test_init(self):
         """Test construction with different list types."""
@@ -92,12 +92,12 @@ class test_PairMatrix(unittest.TestCase):
         pairs  = (('A','B'), ('B','B'), ('A','A'))
 
         #test construction with tuple input
-        m = relentless.core.PairMatrix(types=('A','B'))
+        m = relentless.PairMatrix(types=('A','B'))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with list input
-        m = relentless.core.PairMatrix(types=['A','B'])
+        m = relentless.PairMatrix(types=['A','B'])
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
@@ -105,21 +105,21 @@ class test_PairMatrix(unittest.TestCase):
         pairs = (('A','A'),)
 
         #test construction with single type tuple
-        m = relentless.core.PairMatrix(types=('A',))
+        m = relentless.PairMatrix(types=('A',))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with int type input
         with self.assertRaises(TypeError):
-            m = relentless.core.PairMatrix(types=(1,2))
+            m = relentless.PairMatrix(types=(1,2))
 
         #test construction with mixed type input
         with self.assertRaises(TypeError):
-            m = relentless.core.PairMatrix(types=('1',2))
+            m = relentless.PairMatrix(types=('1',2))
 
     def test_accessors(self):
         """Test get and set methods on pairs."""
-        m = relentless.core.PairMatrix(types=('A','B'))
+        m = relentless.PairMatrix(types=('A','B'))
 
         #test set and get for each pair type
         m['A','A']['energy'] = 1.0
@@ -180,7 +180,7 @@ class test_PairMatrix(unittest.TestCase):
 
     def test_iteration(self):
         """Test iteration on the matrix."""
-        m = relentless.core.PairMatrix(types=('A','B'))
+        m = relentless.PairMatrix(types=('A','B'))
 
         #test iteration for initialization
         for pair in m:
@@ -205,7 +205,7 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['B','B'], {'energy':3.0, 'mass':2.0})
 
 class test_FixedKeyDict(unittest.TestCase):
-    """Unit tests for relentless.core.FixedKeyDict."""
+    """Unit tests for relentless.FixedKeyDict."""
 
     def test_init(self):
         """Test construction with different list keys."""
@@ -213,55 +213,49 @@ class test_FixedKeyDict(unittest.TestCase):
         default = {'A':1.0, 'B':1.0}
 
         #test construction with tuple input
-        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d = relentless.FixedKeyDict(keys=('A','B'))
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test construction with list input
-        d = relentless.core.FixedKeyDict(keys=['A','B'])
+        d = relentless.FixedKeyDict(keys=['A','B'])
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test construction with defined default input
-        d = relentless.core.FixedKeyDict(keys=('A','B'), default=1.0)
+        d = relentless.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [1.0, 1.0])
 
         #test construction with single-key tuple input
         keys = ('A',)
-        d = relentless.core.FixedKeyDict(keys=('A',))
+        d = relentless.FixedKeyDict(keys=('A',))
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [None])
 
         #test construction with int key input
         with self.assertRaises(TypeError):
-            d = relentless.core.FixedKeyDict(keys=(1,2))
+            d = relentless.FixedKeyDict(keys=(1,2))
 
         #test construction with mixed key input
         with self.assertRaises(TypeError):
-            d = relentless.core.FixedKeyDict(keys=('1',2))
+            d = relentless.FixedKeyDict(keys=('1',2))
 
     def test_accessors(self):
         """Test get and set methods on keys."""
-        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d = relentless.FixedKeyDict(keys=('A','B'))
 
         #test setting and getting values
         d['A'] = 1.0
-        self.assertEqual(d['A'], 1.0)
-        self.assertEqual(d['B'], None)
-
+        self.assertEqual([d[k] for k in d.keys], [1.0, None])
         d['B'] = 1.0
-        self.assertEqual(d['A'], 1.0)
-        self.assertEqual(d['B'], 1.0)
+        self.assertEqual([d[k] for k in d.keys], [1.0, 1.0])
 
         #test re-setting and getting values
         d['A'] = 2.0
-        self.assertEqual(d['A'], 2.0)
-        self.assertEqual(d['B'], 1.0)
-
+        self.assertEqual([d[k] for k in d.keys], [2.0, 1.0])
         d['B'] = 1.5
-        self.assertEqual(d['A'], 2.0)
-        self.assertEqual(d['B'], 1.5)
+        self.assertEqual([d[k] for k in d.keys], [2.0, 1.5])
 
         #test getting invalid key
         with self.assertRaises(KeyError):
@@ -269,25 +263,23 @@ class test_FixedKeyDict(unittest.TestCase):
 
     def test_update(self):
         """Test update method to get and set keys."""
-        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d = relentless.FixedKeyDict(keys=('A','B'))
+
+        self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test updating both keys
         d.update({'A':1.0, 'B':2.0})  #using dict
-        self.assertEqual(d['A'], 1.0)
-        self.assertEqual(d['B'], 2.0)
+        self.assertEqual([d[k] for k in d.keys], [1.0, 2.0])
 
         d.update(A=1.5, B=2.5)  #using kwargs
-        self.assertEqual(d['A'], 1.5)
-        self.assertEqual(d['B'], 2.5)
+        self.assertEqual([d[k] for k in d.keys], [1.5, 2.5])
 
         #test updating only one key at a time
         d.update({'A':1.1})   #using dict
-        self.assertEqual(d['A'], 1.1)
-        self.assertEqual(d['B'], 2.5)
+        self.assertEqual([d[k] for k in d.keys], [1.1, 2.5])
 
         d.update(B=2.2)   #using kwargs
-        self.assertEqual(d['A'], 1.1)
-        self.assertEqual(d['B'], 2.2)
+        self.assertEqual([d[k] for k in d.keys], [1.1, 2.2])
 
         #test using *args length > 1
         with self.assertRaises(TypeError):
@@ -295,8 +287,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test using both *args and **kwargs
         d.update({'A':3.0, 'B':2.0}, B=2.2)
-        self.assertEqual(d['A'], 3.0)
-        self.assertEqual(d['B'], 2.2)
+        self.assertEqual([d[k] for k in d.keys], [3.0, 2.2])
 
         #test using invalid kwarg
         with self.assertRaises(KeyError):
@@ -306,51 +297,44 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test clear method to reset keys to default."""
 
         #test clear with no default set
-        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d = relentless.FixedKeyDict(keys=('A','B'))
+        self.assertEqual([d[k] for k in d.keys], [None, None])
         d.update(A=2, B=3)
-        self.assertEqual(d['A'], 2.0)
-        self.assertEqual(d['B'], 3.0)
+        self.assertEqual([d[k] for k in d.keys], [2.0, 3.0])
         d.clear()
-        self.assertEqual(d['A'], None)
-        self.assertEqual(d['B'], None)
+        self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test clear with set default
-        d = relentless.core.FixedKeyDict(keys=('A','B'), default=1.0)
+        d = relentless.FixedKeyDict(keys=('A','B'), default=1.0)
+        self.assertEqual([d[k] for k in d.keys], [None, None])
         d.update(A=2, B=3)
-        self.assertEqual(d['A'], 2.0)
-        self.assertEqual(d['B'], 3.0)
+        self.assertEqual([d[k] for k in d.keys], [2.0, 3.0])
         d.clear()
-        self.assertEqual(d['A'], 1.0)
-        self.assertEqual(d['B'], 1.0)
+        self.assertEqual([d[k] for k in d.keys], [1.0, 1.0])
 
     def test_iteration(self):
         """Test iteration on the dictionary."""
-        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d = relentless.FixedKeyDict(keys=('A','B'))
 
         #test iteration for setting values
         for k in d:
             d[k] = 1.0
-        self.assertEqual(d['A'], 1.0)
-        self.assertEqual(d['B'], 1.0)
+        self.assertEqual([d[k] for k in d.keys], [1.0, 1.0])
 
         #test manual re-setting of values
         d['A'] = 2.0
-        self.assertEqual(d['A'], 2.0)
-        self.assertEqual(d['B'], 1.0)
-
+        self.assertEqual([d[k] for k in d.keys], [2.0, 1.0])
         d['B'] = 1.5
-        self.assertEqual(d['A'], 2.0)
-        self.assertEqual(d['B'], 1.5)
+        self.assertEqual([d[k] for k in d.keys], [2.0, 1.5])
 
         #test iteration for re-setting values
         for k in d:
             d[k] = 3.0
-        self.assertEqual(d['A'], 3.0)
-        self.assertEqual(d['B'], 3.0)
+        self.assertEqual([d[k] for k in d.keys], [3.0, 3.0])
 
     def test_copy(self):
         """Test copying custom dict to standard dict."""
-        d = relentless.core.FixedKeyDict(keys=('A','B'))
+        d = relentless.FixedKeyDict(keys=('A','B'))
 
         #test copying for empty dict
         dict_var = {'A':None, 'B':None}
@@ -367,12 +351,12 @@ class test_FixedKeyDict(unittest.TestCase):
         self.assertEqual(d.todict(), dict_var)
 
 class test_Variable(unittest.TestCase):
-    """Unit tests for relentless.core.Variable."""
+    """Unit tests for relentless.Variable."""
 
     def test_init(self):
         """Test construction with different bounds."""
         #test with no bounds and non-default value of `const`
-        v = relentless.core.Variable(value=1.0, const=True)
+        v = relentless.Variable(value=1.0, const=True)
         self.assertAlmostEqual(v.value, 1.0)
         self.assertEqual(v.const, True)
         self.assertEqual(v.low, None)
@@ -382,7 +366,7 @@ class test_Variable(unittest.TestCase):
         self.assertEqual(v.athigh(), False)
 
         #test in between low and high bounds
-        v = relentless.core.Variable(value=1.2, low=0.0, high=2.0)
+        v = relentless.Variable(value=1.2, low=0.0, high=2.0)
         self.assertAlmostEqual(v.value, 1.2)
         self.assertAlmostEqual(v.low, 0.0)
         self.assertAlmostEqual(v.high, 2.0)
@@ -391,7 +375,7 @@ class test_Variable(unittest.TestCase):
         self.assertEqual(v.athigh(), False)
 
         #test below low bound
-        v = relentless.core.Variable(value=-1, low=0.5)
+        v = relentless.Variable(value=-1, low=0.5)
         self.assertAlmostEqual(v.value, 0.5)
         self.assertAlmostEqual(v.low, 0.5)
         self.assertEqual(v.high, None)
@@ -400,7 +384,7 @@ class test_Variable(unittest.TestCase):
         self.assertEqual(v.athigh(), False)
 
         #test above high bound
-        v = relentless.core.Variable(value=2.2, high=2.0)
+        v = relentless.Variable(value=2.2, high=2.0)
         self.assertAlmostEqual(v.value, 2.0)
         self.assertEqual(v.high, 2.0)
         self.assertEqual(v.low, None)
@@ -421,7 +405,7 @@ class test_Variable(unittest.TestCase):
     def test_clamp(self):
         """Test methods for clamping values with bounds."""
         #construction with only low bound
-        v = relentless.core.Variable(value=0.0, low=2.0)
+        v = relentless.Variable(value=0.0, low=2.0)
         #test below low
         val,state = v.clamp(1.0)
         self.assertAlmostEqual(val, 2.0)
@@ -436,7 +420,7 @@ class test_Variable(unittest.TestCase):
         self.assertEqual(state, v.State.FREE)
 
         #construction with low and high bounds
-        v = relentless.core.Variable(value=0.0, low=0.0, high=2.0)
+        v = relentless.Variable(value=0.0, low=0.0, high=2.0)
         #test below low
         val,state = v.clamp(-1.0)
         self.assertAlmostEqual(val, 0.0)
@@ -451,7 +435,7 @@ class test_Variable(unittest.TestCase):
         self.assertEqual(state, v.State.HIGH)
 
         #construction with no bounds
-        v = relentless.core.Variable(value=0.0)
+        v = relentless.Variable(value=0.0)
         #test free variable
         val,state = v.clamp(1.0)
         self.assertAlmostEqual(val, 1.0)
@@ -460,7 +444,7 @@ class test_Variable(unittest.TestCase):
     def test_value(self):
         """Test methods for setting values and checking bounds."""
         #test construction with value between bounds
-        v = relentless.core.Variable(value=0.0, low=-1.0, high=1.0)
+        v = relentless.Variable(value=0.0, low=-1.0, high=1.0)
         self.assertAlmostEqual(v.value, 0.0)
         self.assertEqual(v.state, v.State.FREE)
 
@@ -481,7 +465,7 @@ class test_Variable(unittest.TestCase):
     def test_bounds(self):
         """Test methods for setting bounds and checking value clamping."""
         #test construction with value between bounds
-        v = relentless.core.Variable(value=0.0, low=-1.0, high=1.0)
+        v = relentless.Variable(value=0.0, low=-1.0, high=1.0)
         self.assertAlmostEqual(v.value, 0.0)
         self.assertEqual(v.state, v.State.FREE)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,7 +84,7 @@ class test_Interpolator(unittest.TestCase):
         np.testing.assert_allclose(f([-2,0.5,2]), [-2.0,1.0,2.0])
 
 class test_PairMatrix(unittest.TestCase):
-    """Unit tests for relentless.PairMatrix."""
+    """Unit tests for relentless.core.PairMatrix."""
 
     def test_init(self):
         """Test construction with different list types."""
@@ -92,12 +92,12 @@ class test_PairMatrix(unittest.TestCase):
         pairs  = (('A','B'), ('B','B'), ('A','A'))
 
         #test construction with tuple input
-        m = relentless.PairMatrix(types=('A','B'))
+        m = relentless.core.PairMatrix(types=('A','B'))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
         #test construction with list input
-        m = relentless.PairMatrix(types=['A','B'])
+        m = relentless.core.PairMatrix(types=['A','B'])
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
@@ -105,7 +105,7 @@ class test_PairMatrix(unittest.TestCase):
         pairs = (('A','A'),)
 
         #test construction with single type tuple
-        m = relentless.PairMatrix(types=('A',))
+        m = relentless.core.PairMatrix(types=('A',))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
@@ -119,7 +119,7 @@ class test_PairMatrix(unittest.TestCase):
 
     def test_accessors(self):
         """Test get and set methods on pairs."""
-        m = relentless.PairMatrix(types=('A','B'))
+        m = relentless.core.PairMatrix(types=('A','B'))
 
         #test set and get for each pair type
         m['A','A']['energy'] = 1.0
@@ -180,7 +180,7 @@ class test_PairMatrix(unittest.TestCase):
 
     def test_iteration(self):
         """Test iteration on the matrix."""
-        m = relentless.PairMatrix(types=('A','B'))
+        m = relentless.core.PairMatrix(types=('A','B'))
 
         #test iteration for initialization
         for pair in m:
@@ -205,7 +205,7 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['B','B'], {'energy':3.0, 'mass':2.0})
 
 class test_FixedKeyDict(unittest.TestCase):
-    """Unit tests for relentless.FixedKeyDict."""
+    """Unit tests for relentless.core.FixedKeyDict."""
 
     def test_init(self):
         """Test construction with different list keys."""
@@ -213,37 +213,37 @@ class test_FixedKeyDict(unittest.TestCase):
         default = {'A':1.0, 'B':1.0}
 
         #test construction with tuple input
-        d = relentless.FixedKeyDict(keys=('A','B'))
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test construction with list input
-        d = relentless.FixedKeyDict(keys=['A','B'])
+        d = relentless.core.FixedKeyDict(keys=['A','B'])
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test construction with defined default input
-        d = relentless.FixedKeyDict(keys=('A','B'), default=1.0)
+        d = relentless.core.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [1.0, 1.0])
 
         #test construction with single-key tuple input
         keys = ('A',)
-        d = relentless.FixedKeyDict(keys=('A',))
+        d = relentless.core.FixedKeyDict(keys=('A',))
         self.assertEqual(d.keys, keys)
         self.assertEqual([d[k] for k in d.keys], [None])
 
         #test construction with int key input
         with self.assertRaises(TypeError):
-            d = relentless.FixedKeyDict(keys=(1,2))
+            d = relentless.core.FixedKeyDict(keys=(1,2))
 
         #test construction with mixed key input
         with self.assertRaises(TypeError):
-            d = relentless.FixedKeyDict(keys=('1',2))
+            d = relentless.core.FixedKeyDict(keys=('1',2))
 
     def test_accessors(self):
         """Test get and set methods on keys."""
-        d = relentless.FixedKeyDict(keys=('A','B'))
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
 
         #test setting and getting values
         d['A'] = 1.0
@@ -263,7 +263,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
     def test_update(self):
         """Test update method to get and set keys."""
-        d = relentless.FixedKeyDict(keys=('A','B'))
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
 
         self.assertEqual([d[k] for k in d.keys], [None, None])
 
@@ -297,7 +297,7 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test clear method to reset keys to default."""
 
         #test clear with no default set
-        d = relentless.FixedKeyDict(keys=('A','B'))
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
         self.assertEqual([d[k] for k in d.keys], [None, None])
         d.update(A=2, B=3)
         self.assertEqual([d[k] for k in d.keys], [2.0, 3.0])
@@ -314,7 +314,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
     def test_iteration(self):
         """Test iteration on the dictionary."""
-        d = relentless.FixedKeyDict(keys=('A','B'))
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
 
         #test iteration for setting values
         for k in d:
@@ -334,7 +334,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
     def test_copy(self):
         """Test copying custom dict to standard dict."""
-        d = relentless.FixedKeyDict(keys=('A','B'))
+        d = relentless.core.FixedKeyDict(keys=('A','B'))
 
         #test copying for empty dict
         dict_var = {'A':None, 'B':None}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,11 +111,11 @@ class test_PairMatrix(unittest.TestCase):
 
         #test construction with int type input
         with self.assertRaises(TypeError):
-            m = relentless.PairMatrix(types=(1,2))
+            m = relentless.core.PairMatrix(types=(1,2))
 
         #test construction with mixed type input
         with self.assertRaises(TypeError):
-            m = relentless.PairMatrix(types=('1',2))
+            m = relentless.core.PairMatrix(types=('1',2))
 
     def test_accessors(self):
         """Test get and set methods on pairs."""
@@ -305,7 +305,7 @@ class test_FixedKeyDict(unittest.TestCase):
         self.assertEqual([d[k] for k in d.keys], [None, None])
 
         #test clear with set default
-        d = relentless.FixedKeyDict(keys=('A','B'), default=1.0)
+        d = relentless.core.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertEqual([d[k] for k in d.keys], [None, None])
         d.update(A=2, B=3)
         self.assertEqual([d[k] for k in d.keys], [2.0, 3.0])


### PR DESCRIPTION
- Rename CoefficientMatrix to PairParameters
- Add FixedKeyDict clear method
- Add shared/per-pair/per-type parameters
- Remove load/from-file methods
- Fix all unit tests