### PR TITLE
Expand functionality for PairPotential derivative method

### DIFF
--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -328,8 +328,8 @@ class Spline(PairPotential):
 
         Parameters
         ----------
-        param : :py:class:`Variable`
-            The knot with respect to which to calculate the derivative.
+        param : str
+            The name of the knot with respect to which to calculate the derivative.
         r : array_like
             The value or values of r at which to evaluate the energy.
         params : dict

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -224,11 +224,8 @@ class Spline(PairPotential):
             raise ValueError('u must have the same length as the number of knots')
 
         # convert to r,knot form given the mode
-        rs = np.zeros_like(r, dtype=np.float64)
-        ks = np.zeros_like(r, dtype=np.float64)
-        for i,(ri,ki) in enumerate(zip(r,u)):
-            rs[i] = ri.value if isinstance(ri, core.Variable) else ri
-            ks[i] = ki.value if isinstance(ki, core.Variable) else ki
+        rs = np.asarray(r, dtype=np.float64)
+        ks = np.asarray(u, dtype=np.float64)
         if self.mode == 'diff':
             # difference is next knot minus my knot, with last knot fixed at its current value
             ks[:-1] -= ks[1:]

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -224,8 +224,11 @@ class Spline(PairPotential):
             raise ValueError('u must have the same length as the number of knots')
 
         # convert to r,knot form given the mode
-        rs = np.asarray(r, dtype=np.float64)
-        ks = np.asarray(u, dtype=np.float64)
+        rs = np.zeros_like(r, dtype=np.float64)
+        ks = np.zeros_like(r, dtype=np.float64)
+        for i,(ri,ki) in enumerate(zip(r,u)):
+            rs[i] = ri.value if isinstance(ri, core.Variable) else ri
+            ks[i] = ki.value if isinstance(ki, core.Variable) else ki
         if self.mode == 'diff':
             # difference is next knot minus my knot, with last knot fixed at its current value
             ks[:-1] -= ks[1:]
@@ -325,8 +328,8 @@ class Spline(PairPotential):
 
         Parameters
         ----------
-        pair : tuple
-            The type pair (i,j) for which to initialize the spline potential.
+        param : :py:class:`Variable`
+            The knot with respect to which to calculate the derivative.
         r : array_like
             The value or values of r at which to evaluate the energy.
         params : dict

--- a/relentless/potential/potential.py
+++ b/relentless/potential/potential.py
@@ -427,7 +427,6 @@ class PairPotential(abc.ABC):
             flags[r > params['rmax']] = False
 
         # evaluate with respect to parameter
-        d_params = [i for i in self.coeff.params if not(i=='rmin' or i=='rmax' or i=='shift')]
         for p in self.coeff.params:
             p_obj = self.coeff[pair][p]
             if p=='rmin' or p=='rmax' or p=='shift':

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -230,14 +230,16 @@ class test_Spline(unittest.TestCase):
         s = relentless.potential.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([1.125,0.625,0])
-        d = s.derivative(pair=('1','1'), param='knot-1', r=[1.5,2.5,3.5])
+        param = [i for i in s.knots(('1','1'))][1][1]
+        d = s.derivative(pair=('1','1'), param=param, r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
         #test value mode
         s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([0.75,0.75,0])
-        d = s.derivative(pair=('1','1'), param='knot-1', r=[1.5,2.5,3.5])
+        param = [i for i in s.knots(('1','1'))][1][1]
+        d = s.derivative(pair=('1','1'), param=param, r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
 class test_Yukawa(unittest.TestCase):

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -230,7 +230,7 @@ class test_Spline(unittest.TestCase):
         s = relentless.potential.Spline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([1.125,0.625,0])
-        param = [i for i in s.knots(('1','1'))][1][1]
+        param = list(s.knots(('1','1')))[1][1]
         d = s.derivative(pair=('1','1'), param=param, r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
@@ -238,7 +238,7 @@ class test_Spline(unittest.TestCase):
         s = relentless.potential.Spline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([0.75,0.75,0])
-        param = [i for i in s.knots(('1','1'))][1][1]
+        param = list(s.knots(('1','1')))[1][1]
         d = s.derivative(pair=('1','1'), param=param, r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -582,16 +582,16 @@ class test_PairPotential(unittest.TestCase):
         p.coeff['1','1']['m'] = x
 
         #test with no cutoffs
-        #d = p.derivative(pair=('1','1'), var=x, r=0.5)
-        #self.assertAlmostEqual(d, 0.5)
-        #d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
-        #np.testing.assert_allclose(d, [0.25,0.75])
+        d = p.derivative(pair=('1','1'), var=x, r=0.5)
+        self.assertAlmostEqual(d, 0.5)
+        d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
+        np.testing.assert_allclose(d, [0.25,0.75])
 
         #test with rmin set
         rmin = relentless.DesignVariable(value=0.5)
         p.coeff['1','1']['rmin'] = rmin
-        #d = p.derivative(pair=('1','1'), var=x, r=0.6)
-        #self.assertAlmostEqual(d, 0.6)
+        d = p.derivative(pair=('1','1'), var=x, r=0.6)
+        self.assertAlmostEqual(d, 0.6)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
         np.testing.assert_allclose(d, [2.0,0.75])
 

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -593,7 +593,7 @@ class test_PairPotential(unittest.TestCase):
         d = p.derivative(pair=('1','1'), var=x, r=0.6)
         self.assertAlmostEqual(d, 0.6)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
-        np.testing.assert_allclose(d, [2.0,0.75])
+        np.testing.assert_allclose(d, [0.5,0.75])
 
         #test with rmax set
         rmax = relentless.DesignVariable(value=1.5)
@@ -601,14 +601,14 @@ class test_PairPotential(unittest.TestCase):
         d = p.derivative(pair=('1','1'), var=x, r=1.0)
         self.assertAlmostEqual(d, 1.0)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,1.75])
-        np.testing.assert_allclose(d, [0.25,2.0])
+        np.testing.assert_allclose(d, [0.25,1.5])
 
         #test with rmin and rmax set
         p.coeff['1','1']['rmin'] = rmin
         d = p.derivative(pair=('1','1'), var=x, r=0.75)
         self.assertAlmostEqual(d, 0.75)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.5,1.5,1.75])
-        np.testing.assert_allclose(d, [2.0,0.5,1.5,2.0])
+        np.testing.assert_allclose(d, [0.5,0.5,1.5,1.5])
 
         #test w.r.t. rmin and rmax
         d = p.derivative(pair=('1','1'), var=rmin, r=[0.25,1.0,2.0])
@@ -619,9 +619,9 @@ class test_PairPotential(unittest.TestCase):
         #test parameter derivative with shift set
         p.coeff['1','1'].update(shift=True)
         d = p.derivative(pair=('1','1'), var=x, r=0.5)
-        self.assertAlmostEqual(d, -1.5)
+        self.assertAlmostEqual(d, -1.0)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,1.0,1.5,1.75])
-        np.testing.assert_allclose(d, [0.0,-1.0,-0.5,0.0])
+        np.testing.assert_allclose(d, [-1.0,-0.5,0.0,0.0])
 
         #test w.r.t. rmin and rmax, shift set
         d = p.derivative(pair=('1','1'), var=rmin, r=[0.25,1.0,2.0])

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -483,7 +483,7 @@ class test_PairPotential(unittest.TestCase):
         r = [0.2]
         r_copy, u, s = p._zeros(r)
         u_copy = np.zeros(1)
-        np.testing.assert_allclose(r_copy, r)
+        np.testing.assert_allclose(r, r_copy)
         np.testing.assert_allclose(u, u_copy)
         self.assertEqual(s, False)
 
@@ -639,7 +639,7 @@ class test_PairPotential(unittest.TestCase):
 
         #test with respect to dependent variable parameter
         d = q.derivative(pair=('1','1'), var=z, r=2.0)
-        #self.assertAlmostEqual(d, 2.0)
+        self.assertAlmostEqual(d, 2.0)
 
         #test with respect to independent variable on which parameter is dependent
         d = q.derivative(pair=('1','1'), var=x, r=1.5)

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -631,15 +631,6 @@ class test_PairPotential(unittest.TestCase):
         with self.assertRaises(TypeError):
             d = q.derivative(pair=('1','1'), var=a, r=2.0)
 
-    #def _derivative(self, param, r, **params):
-    #    r,d,s = self._zeros(r)
-    #    if param == 'x':
-    #        d = 2*r
-    #    elif param == 'y':
-    #        d = 3*r
-    #    if s:
-    #        d = d.item()
-    #    return d
         #test with respect to independent variable which is related to a SameAs variable
         r = TwoVarPot(types=('1',), params=('x','y'))
 


### PR DESCRIPTION
- Modify PairPotential derivative to accept object argument, apply chain rule for DependentVariables
- Change compatibility for taking derivative w.r.t. rmin or rmax, include shift effects
- Add PairParameters dependent_variables method
- Add respective unit test cases