### PR TITLE
Construct Depletion Cutoff as DependentVariable dependent on scalars

### DIFF
--- a/relentless/core/variable.py
+++ b/relentless/core/variable.py
@@ -377,6 +377,8 @@ class DependentVariable(Variable):
         #Casts a scalar into an independent variable.
         if np.isscalar(v):
             v = IndependentVariable(value=v)
+        if not isinstance(v, Variable):
+            raise TypeError('Dependent variables can only depend on scalars or other variables.')
         return v
 
     @classmethod

--- a/relentless/core/variable.py
+++ b/relentless/core/variable.py
@@ -261,15 +261,13 @@ class DependentVariable(Variable):
             raise AttributeError('No attributes specified for DependentVariable.')
 
         for k,v in attrs.items():
-            if np.isscalar(v):
-                v = IndependentVariable(value=v)
-            super().__setattr__(k,self._assert_variable(v))
+            super().__setattr__(k,self._make_variable(v))
         self._params = tuple(attrs.keys())
 
     def __setattr__(self, name, value):
         #Sets the value of the variable on which the specified DependentVariable depends.
         if name != '_params' and name in self.params:
-            value = self._assert_variable(value)
+            value = self._make_variable(value)
         super().__setattr__(name,value)
 
     @property
@@ -375,10 +373,10 @@ class DependentVariable(Variable):
         pass
 
     @classmethod
-    def _assert_variable(cls, v):
-        #Checks if the dependent variable depends on another variable.
-        if not isinstance(v, Variable):
-            raise TypeError('Dependent variables can only depend on other variables.')
+    def _make_variable(cls, v):
+        #Casts a scalar into an independent variable.
+        if np.isscalar(v):
+            v = IndependentVariable(value=v)
         return v
 
     @classmethod

--- a/relentless/core/variable.py
+++ b/relentless/core/variable.py
@@ -237,6 +237,9 @@ class DependentVariable(Variable):
     value property, it must also supply a derivative method with respect to
     any of its dependent variables.
 
+    The dependent variable attribute can also be set as a scalar value, but during
+    construction the value is casted to a :py:class:`IndepedentVariable`.
+
     The number of dependencies of the variable are locked at construction, but
     their values can be modified.
 
@@ -258,6 +261,8 @@ class DependentVariable(Variable):
             raise AttributeError('No attributes specified for DependentVariable.')
 
         for k,v in attrs.items():
+            if np.isscalar(v):
+                v = IndependentVariable(value=v)
             super().__setattr__(k,self._assert_variable(v))
         self._params = tuple(attrs.keys())
 

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -695,9 +695,6 @@ class Depletion(PairPotential):
     def __init__(self, types, shift=False):
         super().__init__(types=types, params=('P','sigma_i','sigma_j','sigma_d'))
 
-    def get_bounds(self, sigma_i, sigma_j, sigma_d):
-        lo = core.Dependen
-
     def _energy(self, r, P, sigma_i, sigma_j, sigma_d, **params):
         """Evaluates the depletion potential energy.
 

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -590,70 +590,21 @@ class Depletion(PairPotential):
 
     """
 
-    class LowBound(core.DependentVariable):
-        r"""Dependent variable for the low bound of the depletion pair potential.
+    class Cutoff(core.DependentVariable):
+        r"""Dependent variable for the "high bound" or cutoff of the depletion pair potential.
 
         .. math::
 
-            low = \frac{1}{2}(\sigma_i+\sigma_j)
+            cutoff = \frac{1}{2}(\sigma_i+\sigma_j)+\sigma_d
 
         Parameters
         ----------
         sigma_i : int/float or :py:class:`Variable`
-            The `sigma_i` parameter of the low bound.
+            The `sigma_i` parameter of the cutoff.
         sigma_j : int/float or :py:class:`Variable`
-            The `sigma_j` parameter of the low bound.
-
-        """
-        def __init__(self, sigma_i, sigma_j):
-            super().__init__(sigma_i=sigma_i, sigma_j=sigma_j)
-
-        @property
-        def value(self):
-            return 0.5*(self.sigma_i.value + self.sigma_j.value)
-
-        def _derivative(self, param):
-            """Calculates the derivative of the LowBound object with respect to its parameters.
-
-            Parameters
-            ----------
-            param : str
-                The parameter with respect to which to take the derivative.
-                (Can only be 'sigma_i' or 'sigma_j').
-
-            Returns
-            -------
-            float
-                The calculated derivative value.
-
-            Raises
-            ------
-            ValueError
-                If the parameter argument is not 'sigma_i' or 'sigma_j'.
-
-            """
-            if param == 'sigma_i':
-                return 0.5
-            elif param == 'sigma_j':
-                return 0.5
-            else:
-                raise ValueError('Unknown parameter')
-
-    class HighBound(core.DependentVariable):
-        r"""Dependent variable for the high bound of the depletion pair potential.
-
-        .. math::
-
-            high = \frac{1}{2}(\sigma_i+\sigma_j)+\sigma_d
-
-        Parameters
-        ----------
-        sigma_i : int/float or :py:class:`Variable`
-            The `sigma_i` parameter of the high bound.
-        sigma_j : int/float or :py:class:`Variable`
-            The `sigma_j` parameter of the high bound.
+            The `sigma_j` parameter of the cutoff.
         sigma_d : int/float or :py:class:`Variable`
-            The `sigma_d` parameter of the high bound.
+            The `sigma_d` parameter of the cutoff.
 
         """
         def __init__(self, sigma_i, sigma_j, sigma_d):
@@ -664,7 +615,7 @@ class Depletion(PairPotential):
             return 0.5*(self.sigma_i.value + self.sigma_j.value) + self.sigma_d.value
 
         def _derivative(self, param):
-            """Calculates the derivative of the HighBound object with respect to its parameters.
+            """Calculates the derivative of the Cutoff object with respect to its parameters.
 
             Parameters
             ----------
@@ -696,14 +647,11 @@ class Depletion(PairPotential):
         super().__init__(types=types, params=('P','sigma_i','sigma_j','sigma_d'))
 
     def energy(self, pair, r):
-        # Override parent method to set rmin and rmax as low and high bounds
-        if self.coeff[pair]['rmin'] is False:
-            self.coeff[pair]['rmin'] = self.LowBound(self.coeff[pair]['sigma_i'],
-                                                     self.coeff[pair]['sigma_j'])
+        # Override parent method to set rmax as cutoff
         if self.coeff[pair]['rmax'] is False:
-            self.coeff[pair]['rmax'] = self.HighBound(self.coeff[pair]['sigma_i'],
-                                                      self.coeff[pair]['sigma_j'],
-                                                      self.coeff[pair]['sigma_d'])
+            self.coeff[pair]['rmax'] = self.Cutoff(self.coeff[pair]['sigma_i'],
+                                                   self.coeff[pair]['sigma_j'],
+                                                   self.coeff[pair]['sigma_d'])
         return super().energy(pair, r)
 
     def _energy(self, r, P, sigma_i, sigma_j, sigma_d, **params):
@@ -746,14 +694,11 @@ class Depletion(PairPotential):
         return u
 
     def force(self, pair, r):
-        # Override parent method to set rmin and rmax as low and high bounds
-        if self.coeff[pair]['rmin'] is False:
-            self.coeff[pair]['rmin'] = self.LowBound(self.coeff[pair]['sigma_i'],
-                                                     self.coeff[pair]['sigma_j'])
+        # Override parent method to set rmax as cutoff
         if self.coeff[pair]['rmax'] is False:
-            self.coeff[pair]['rmax'] = self.HighBound(self.coeff[pair]['sigma_i'],
-                                                      self.coeff[pair]['sigma_j'],
-                                                      self.coeff[pair]['sigma_d'])
+            self.coeff[pair]['rmax'] = self.Cutoff(self.coeff[pair]['sigma_i'],
+                                                   self.coeff[pair]['sigma_j'],
+                                                   self.coeff[pair]['sigma_d'])
         return super().force(pair, r)
 
     def _force(self, r, P, sigma_i, sigma_j, sigma_d, **params):
@@ -796,14 +741,11 @@ class Depletion(PairPotential):
         return f
 
     def derivative(self, pair, var, r):
-        # Override parent method to set rmin and rmax as low and high bounds
-        if self.coeff[pair]['rmin'] is False:
-            self.coeff[pair]['rmin'] = self.LowBound(self.coeff[pair]['sigma_i'],
-                                                     self.coeff[pair]['sigma_j'])
+        # Override parent method to set rmax as cutoff
         if self.coeff[pair]['rmax'] is False:
-            self.coeff[pair]['rmax'] = self.HighBound(self.coeff[pair]['sigma_i'],
-                                                      self.coeff[pair]['sigma_j'],
-                                                      self.coeff[pair]['sigma_d'])
+            self.coeff[pair]['rmax'] = self.Cutoff(self.coeff[pair]['sigma_i'],
+                                                   self.coeff[pair]['sigma_j'],
+                                                   self.coeff[pair]['sigma_d'])
         return super().derivative(pair, var, r)
 
     def _derivative(self, param, r, P, sigma_i, sigma_j, sigma_d, **params):

--- a/tests/core/test_variable.py
+++ b/tests/core/test_variable.py
@@ -270,6 +270,12 @@ class test_DependentVariable(unittest.TestCase):
         self.assertDictEqual({p:v.value for p,v in w.depends}, {'t':1.0,'u':2.0,'v':3.0})
         self.assertAlmostEqual(w.value, 6.0)
 
+        #change scalar attribute value
+        w.t = 4.0
+        self.assertCountEqual(w.params, ('t','u','v'))
+        self.assertDictEqual({p:v.value for p,v in w.depends}, {'t':4.0,'u':2.0,'v':3.0})
+        self.assertAlmostEqual(w.value, 10.0)
+
         #test invalid creation with no attributes
         with self.assertRaises(AttributeError):
             w = DepVar()

--- a/tests/core/test_variable.py
+++ b/tests/core/test_variable.py
@@ -264,6 +264,12 @@ class test_DependentVariable(unittest.TestCase):
         self.assertDictEqual({p:v for p,v in w.depends}, {'t':t,'u':u,'v':v})
         self.assertAlmostEqual(w.value, 6.0)
 
+        #test creation with scalar attributes
+        w = DepVar(t=1.0, u=2.0, v=3.0)
+        self.assertCountEqual(w.params, ('t','u','v'))
+        self.assertDictEqual({p:v.value for p,v in w.depends}, {'t':1.0,'u':2.0,'v':3.0})
+        self.assertAlmostEqual(w.value, 6.0)
+
         #test invalid creation with no attributes
         with self.assertRaises(AttributeError):
             w = DepVar()
@@ -438,9 +444,11 @@ class test_SameAs(unittest.TestCase):
         self.assertCountEqual(u.params, ('a',))
         self.assertDictEqual({p:v for p,v in u.depends}, {'a':w})
 
-        #test invalid variable dependence
-        with self.assertRaises(TypeError):
-            u = relentless.SameAs(1.0)
+        #test scalar dependency
+        z = relentless.SameAs(2.0)
+        self.assertAlmostEqual(z.value, 2.0)
+        self.assertCountEqual(z.params, ('a',))
+        self.assertDictEqual({p:v.value for p,v in z.depends}, {'a':2.0})
 
     def test_value(self):
         """Test setting values."""
@@ -508,9 +516,11 @@ class test_ArithmeticMean(unittest.TestCase):
         self.assertCountEqual(w.params, ('a','b'))
         self.assertDictEqual({p:v for p,v in w.depends}, {'a':u,'b':u})
 
-        #test invalid variable dependence
-        with self.assertRaises(TypeError):
-            z = relentless.ArithmeticMean(1.0, 2.0)
+        #test scalar dependencies
+        z = relentless.ArithmeticMean(2.0, 1.0)
+        self.assertAlmostEqual(z.value, 1.5)
+        self.assertCountEqual(z.params, ('a','b'))
+        self.assertDictEqual({p:v.value for p,v in z.depends}, {'a':2.0,'b':1.0})
 
     def test_value(self):
         """Test setting values."""
@@ -598,9 +608,11 @@ class test_GeometricMean(unittest.TestCase):
         self.assertCountEqual(w.params, ('a','b'))
         self.assertDictEqual({p:v for p,v in w.depends}, {'a':v,'b':v})
 
-        #test invalid variable dependence
-        with self.assertRaises(TypeError):
-            z = relentless.GeometricMean(1.0, 2.0)
+        #test scalar dependencies
+        z = relentless.GeometricMean(16.0, 1.0)
+        self.assertAlmostEqual(z.value, 4.0)
+        self.assertCountEqual(z.params, ('a','b'))
+        self.assertDictEqual({p:v.value for p,v in z.depends}, {'a':16.0,'b':1.0})
 
     def test_value(self):
         """Test setting values."""

--- a/tests/core/test_variable.py
+++ b/tests/core/test_variable.py
@@ -274,7 +274,7 @@ class test_DependentVariable(unittest.TestCase):
         w.t = 4.0
         self.assertCountEqual(w.params, ('t','u','v'))
         self.assertDictEqual({p:v.value for p,v in w.depends}, {'t':4.0,'u':2.0,'v':3.0})
-        self.assertAlmostEqual(w.value, 10.0)
+        self.assertAlmostEqual(w.value, 9.0)
 
         #test invalid creation with no attributes
         with self.assertRaises(AttributeError):

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -231,7 +231,7 @@ class test_Spline(unittest.TestCase):
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([1.125,0.625,0])
         param = list(s.knots(('1','1')))[1][1]
-        d = s.derivative(pair=('1','1'), param=param, r=[1.5,2.5,3.5])
+        d = s.derivative(pair=('1','1'), var=param, r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
         #test value mode
@@ -239,7 +239,7 @@ class test_Spline(unittest.TestCase):
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = np.array([0.75,0.75,0])
         param = list(s.knots(('1','1')))[1][1]
-        d = s.derivative(pair=('1','1'), param=param, r=[1.5,2.5,3.5])
+        d = s.derivative(pair=('1','1'), var=param, r=[1.5,2.5,3.5])
         np.testing.assert_allclose(d, d_actual)
 
 class test_Yukawa(unittest.TestCase):
@@ -452,7 +452,7 @@ class test_Depletion(unittest.TestCase):
         self.assertCountEqual(dp.coeff.params, coeff.params)
 
     def test_energy(self):
-        """Test _energy method"""
+        """Test _energy and energy methods"""
         dp = relentless.potential.Depletion(types=('1',))
 
         #test scalar r
@@ -462,8 +462,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(u, u_actual)
 
         #test array r
-        r_input = np.array([1,1.75,4.25,5])
-        u_actual = np.array([-25.25161952,-16.59621119,0,0])
+        r_input = np.array([1.75,4.25])
+        u_actual = np.array([-16.59621119,0])
         u = dp._energy(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         np.testing.assert_allclose(u, u_actual)
 
@@ -475,8 +475,17 @@ class test_Depletion(unittest.TestCase):
         with self.assertRaises(ValueError):
             u = dp._energy(r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
+        #test energy outside of low/high bounds
+        dp.coeff['1','1'].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = np.array([1,5])
+        u_actual = np.array([-16.5962112,0])
+        u = dp.energy(pair=('1','1'), r=r_input)
+        np.testing.assert_allclose(u, u_actual)
+        self.assertAlmostEqual(dp.coeff['1','1']['rmin'].value, 1.75)
+        self.assertAlmostEqual(dp.coeff['1','1']['rmax'].value, 4.25)
+
     def test_force(self):
-        """Test _force method"""
+        """Test _force and force methods"""
         dp = relentless.potential.Depletion(types=('1',))
 
         #test scalar r
@@ -486,8 +495,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(f, f_actual)
 
         #test array r
-        r_input = np.array([1,1.75,4.25,5])
-        f_actual = np.array([-11.54054444,-11.54054444,0,0])
+        r_input = np.array([1.75,4.25])
+        f_actual = np.array([-11.54054444,0])
         f = dp._force(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         np.testing.assert_allclose(f, f_actual)
 
@@ -499,8 +508,17 @@ class test_Depletion(unittest.TestCase):
         with self.assertRaises(ValueError):
             f = dp._force(r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
+        #test force outside of low/high bounds
+        dp.coeff['1','1'].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = np.array([1,5])
+        f_actual = np.array([0,0])
+        f = dp.force(pair=('1','1'), r=r_input)
+        np.testing.assert_allclose(f, f_actual)
+        self.assertAlmostEqual(dp.coeff['1','1']['rmin'].value, 1.75)
+        self.assertAlmostEqual(dp.coeff['1','1']['rmax'].value, 4.25)
+
     def test_derivative(self):
-        """Test _derivative method"""
+        """Test _derivative and derivative methods"""
         dp = relentless.potential.Depletion(types=('1',))
 
         #w.r.t. P
@@ -511,8 +529,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(d, d_actual)
 
         #test array r
-        r_input = np.array([1,1.75,4.25,5])
-        d_actual = np.array([-25.25161952,-16.59621119,0,0])
+        r_input = np.array([1.75,4.25])
+        d_actual = np.array([-16.59621119,0])
         d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         np.testing.assert_allclose(d, d_actual)
 
@@ -524,8 +542,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(d, d_actual)
 
         #test array r
-        r_input = np.array([1,1.75,4.25,5])
-        d_actual = np.array([-11.242872,-8.975979,0,0])
+        r_input = np.array([1.75,4.25])
+        d_actual = np.array([-8.975979,0])
         d = dp._derivative(param='sigma_i', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         np.testing.assert_allclose(d, d_actual)
 
@@ -537,8 +555,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(d, d_actual)
 
         #test array r
-        r_input = np.array([1,1.75,4.25,5])
-        d_actual = np.array([-8.397807,-7.573482,0,0])
+        r_input = np.array([1.75,4.25])
+        d_actual = np.array([-7.573482,0])
         d = dp._derivative(param='sigma_j', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         np.testing.assert_allclose(d, d_actual)
 
@@ -550,8 +568,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(d, d_actual)
 
         #test array r
-        r_input = np.array([1,1.75,4.25,5])
-        d_actual = np.array([-21.454193,-16.549461,0,0])
+        r_input = np.array([1.75,4.25])
+        d_actual = np.array([-16.549461,0])
         d = dp._derivative(param='sigma_d', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         np.testing.assert_allclose(d, d_actual)
 
@@ -566,6 +584,16 @@ class test_Depletion(unittest.TestCase):
         #test invalid param
         with self.assertRaises(ValueError):
             d = dp._derivative(param='sigmaj', r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=1)
+
+        #test derivative outside of low/high bounds
+        P_var = relentless.DesignVariable(value=1.0)
+        dp.coeff['1','1'].update(P=P_var, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = np.array([1,5])
+        d_actual = np.array([-16.5962112,0])
+        d = dp.derivative(pair=('1','1'), var=P_var, r=r_input)
+        np.testing.assert_allclose(d, d_actual)
+        self.assertAlmostEqual(dp.coeff['1','1']['rmin'].value, 1.75)
+        self.assertAlmostEqual(dp.coeff['1','1']['rmax'].value, 4.25)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -334,6 +334,112 @@ class test_Yukawa(unittest.TestCase):
         with self.assertRaises(ValueError):
             u = y._derivative(param='kapppa', r=r_input, epsilon=1.0, kappa=1.0)
 
+class test_LowBound(unittest.TestCase):
+    """Unit tests for relentless.potential.Depletion.LowBound"""
+
+    def test_init(self):
+        """Test creation from data"""
+        #create object dependent on scalars
+        w = relentless.potential.Depletion.LowBound(sigma_i=1.0, sigma_j=2.0)
+        self.assertAlmostEqual(w.value, 1.5)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j'))
+        self.assertDictEqual({p:v.value for p,v in w.depends},
+                             {'sigma_i':1.0, 'sigma_j':2.0})
+
+        #change parameter value
+        w.sigma_j.value = 4.0
+        self.assertAlmostEqual(w.value, 2.5)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j'))
+        self.assertDictEqual({p:v.value for p,v in w.depends},
+                             {'sigma_i':1.0, 'sigma_j':4.0})
+
+        #create object dependent on variables
+        a = relentless.DesignVariable(value=1.0)
+        b = relentless.DesignVariable(value=2.0)
+        w = relentless.potential.Depletion.LowBound(sigma_i=a, sigma_j=b)
+        self.assertAlmostEqual(w.value, 1.5)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j'))
+        self.assertDictEqual({p:v for p,v in w.depends},
+                             {'sigma_i':a, 'sigma_j':b})
+
+        #change parameter value
+        b.value = 4.0
+        self.assertAlmostEqual(w.value, 2.5)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j'))
+        self.assertDictEqual({p:v for p,v in w.depends},
+                             {'sigma_i':a, 'sigma_j':b})
+
+    def test_derivative(self):
+        """Test _derivative method"""
+        w = relentless.potential.Depletion.LowBound(sigma_i=1.0, sigma_j=2.0)
+        #calculate w.r.t. sigma_i
+        dw = w._derivative('sigma_i')
+        self.assertEqual(dw, 0.5)
+
+        #calculate w.r.t. sigma_j
+        dw = w._derivative('sigma_j')
+        self.assertEqual(dw, 0.5)
+
+        #invalid parameter calculation
+        with self.assertRaises(ValueError):
+            dw = w._derivative('sigma')
+
+class test_HighBound(unittest.TestCase):
+    """Unit tests for relentless.potential.Depletion.HighBound"""
+
+    def test_init(self):
+        """Test creation from data"""
+        #create object dependent on scalars
+        w = relentless.potential.Depletion.HighBound(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+        self.assertAlmostEqual(w.value, 1.75)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j','sigma_d'))
+        self.assertDictEqual({p:v.value for p,v in w.depends},
+                             {'sigma_i':1.0, 'sigma_j':2.0, 'sigma_d':0.25})
+
+        #change parameter value
+        w.sigma_j.value = 4.0
+        self.assertAlmostEqual(w.value, 2.75)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j','sigma_d'))
+        self.assertDictEqual({p:v.value for p,v in w.depends},
+                             {'sigma_i':1.0, 'sigma_j':4.0, 'sigma_d':0.25})
+
+        #create object dependent on variables
+        a = relentless.DesignVariable(value=1.0)
+        b = relentless.DesignVariable(value=2.0)
+        c = relentless.DesignVariable(value=0.25)
+        w = relentless.potential.Depletion.HighBound(sigma_i=a, sigma_j=b, sigma_d=c)
+        self.assertAlmostEqual(w.value, 1.75)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j','sigma_d'))
+        self.assertDictEqual({p:v for p,v in w.depends},
+                             {'sigma_i':a, 'sigma_j':b, 'sigma_d':c})
+
+        #change parameter value
+        b.value = 4.0
+        self.assertAlmostEqual(w.value, 2.75)
+        self.assertCountEqual(w.params, ('sigma_i','sigma_j','sigma_d'))
+        self.assertDictEqual({p:v for p,v in w.depends},
+                             {'sigma_i':a, 'sigma_j':b, 'sigma_d':c})
+
+    def test_derivative(self):
+        """Test _derivative method"""
+        w = relentless.potential.Depletion.HighBound(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+
+        #calculate w.r.t. sigma_i
+        dw = w._derivative('sigma_i')
+        self.assertEqual(dw, 0.5)
+
+        #calculate w.r.t. sigma_j
+        dw = w._derivative('sigma_j')
+        self.assertEqual(dw, 0.5)
+
+        #calculate w.r.t. sigma_d
+        dw = w._derivative('sigma_d')
+        self.assertEqual(dw, 1.0)
+
+        #invalid parameter calculation
+        with self.assertRaises(ValueError):
+            dw = w._derivative('sigma')
+
 class test_Depletion(unittest.TestCase):
     """Unit tests for relentless.potential.Depletion"""
 


### PR DESCRIPTION
- Allow DependentVariable to have scalar attributes, cast as IndependentVariables
- Remove cases for _energy/_force/_derivative calculation below low bound and above high bound
- Construct cutoff for Depletion potential as DependentVariables
- Set the rmax Depletion potential coefficient as the cutoff
- Add unit tests for all new cases