### PR TITLE
Resolve real path in Directory

### DIFF
--- a/relentless/core/data.py
+++ b/relentless/core/data.py
@@ -46,7 +46,7 @@ class Directory:
 
     """
     def __init__(self, path):
-        self.path = os.path.abspath(path)
+        self.path = os.path.realpath(path)
         if not os.path.exists(self.path):
             os.makedirs(self.path)
         self._start = []


### PR DESCRIPTION
These tests were failing on my mac with homebrew because `TemporaryDirectory.name` is a symlink. This PR forces the `Directory` to resolve the symlink using `realpath`, and corrects the unit test paths to also compare the real path.

I was also getting warnings about not tearing down the `TemporaryDirectory` properly when tests failed. (Due to the exception, `f.cleanup()` was not reached.) I fixed this by adding a `tearDown` method that is always invoked.