### PR TITLE
Refactor Simulation to use an instance of a simulation for data

### DIFF
--- a/relentless/core/ensemble.py
+++ b/relentless/core/ensemble.py
@@ -182,6 +182,42 @@ class Ensemble(object):
         """
         return self._constant
 
+    def aka(self,name):
+        """Check if the ensemble is also known by a common type.
+
+        Parameters
+        ----------
+        name : str
+            Common name of a thermodynamic ensemble. The recognized names are:
+
+            - "NVT" or "canonical" for constant *N*, *V*, and *T*.
+            - "NPT or "isothermal-isobaric for constant *N*, *P*, and *T*.
+            - "muVT" or "grand canonical" for constant :math:`\mu`, *V*, and *T*.
+
+        Returns
+        -------
+        bool:
+            True if the ensemble matches the name, and False otherwise.
+
+        Raises
+        ------
+        ValueError:
+            The name is not one of the recognized types.
+
+        """
+        if name in ("NVT","canonical"):
+            return (self.constant['T'] and self.constant['V']
+                and all(self.constant['N'][t] for t in self.types))
+        elif name in ("NPT","isothermal-isobaric"):
+            return (self.constant['T'] and self.constant['P']
+                and all(self.constant['N'][t] for t in self.types))
+        elif name in ("muVT","grand canonical"):
+            return (self.constant['T'] and self.constant['V']
+                and all(self.constant['mu'][t] for t in self.types))
+        else:
+            raise ValueError("Ensemble name not recognized")
+
+
     @property
     def rdf(self):
         r""":py:class:`PairMatrix`: Radial distribution function per pair."""

--- a/relentless/simulate/dilute.py
+++ b/relentless/simulate/dilute.py
@@ -5,16 +5,18 @@ from relentless.core import RDF
 from relentless.core import Interpolator
 
 class Dilute(Simulation):
-    """:py:class:`Simulation` container for an NVT ensemble."""
-    def initialize(self, ensemble, potentials, options):
-        """Initializes the Dilute simulation.
+    """Simulation of a dilute system.
+
+    The :py:class:`Ensemble` must be canonical (constant *N*, *V*, and *T*).
+
+    """
+    def initialize(self, sim):
+        """Initializes the simulation.
 
         Parameters
-        ensemble : :py:class:`Ensemble`
-            Simulation ensemble; must contain values for *N* and *V*.
-        potentials : :py:class:`PairMatrix`
-            Matrix of tabulated potentials for each pair.
-        options : kwargs
+        ----------
+        sim : :py:class:`relentless.simulate.SimulationInstance`
+            Instance to initialize.
 
         Raises
         ------
@@ -22,12 +24,10 @@ class Dilute(Simulation):
             If the ensemble does not have set constant values for T, V, and N for all types.
 
         """
-        if (not ensemble.constant['T']
-            or not ensemble.constant['V']
-            or not all(ensemble.constant['N'][t] for t in ensemble.types)):
+        if not sim.ensemble.aka("NVT"):
             raise ValueError('Dilute simulations must be run in the NVT ensemble.')
 
-    def analyze(self, ensemble, potentials, options):
+    def analyze(self, sim):
         r"""Creates a copy of the ensemble with cleared fluctuating/conjugate variables.
         The pressure *P* and :math:`g(r)` parameters for the new ensemble are calculated
         as follows:
@@ -37,20 +37,13 @@ class Dilute(Simulation):
             g_{ij}(r)=e^{-\beta u_{ij}(r)}
 
             P=k_BT\sum_i\rho_i+\frac{2}{3}\sum_i\sum_j\rho_i\rho_j\int_0^\infty drr^3f_{ij}(r)g_{ij}(r)
+
             f_{ij}(r)=-\nabla u_{ij}(r)
 
         Parameters
         ----------
-        ensemble : :py:class:`Ensemble`
-            Simulation ensemble; must contain values for *N* and *V*.
-        potentials : :py:class:`PairMatrix`
-            Matrix of tabulated potentials for each pair.
-        options : kwargs
-
-        Returns
-        -------
-        :py:class:`Ensemble`
-            Ensemble with calculated RDF and pressure parameters.
+        sim : :py:class:`SimulationInstance`
+            Instance to analyze.
 
         Raises
         ------
@@ -58,31 +51,33 @@ class Dilute(Simulation):
             If r and u are not both set in the potentials matrix.
 
         """
-        new_ens = ensemble.copy()
+        if not sim.ensemble.aka("NVT"):
+            raise ValueError('Dilute simulations must be run in the NVT ensemble.')
+        new_ens = sim.ensemble.copy()
         new_ens.clear()
 
-        for pair in potentials:
-            r = potentials[pair].get('r')
-            u = potentials[pair].get('u')
+        for pair in sim.potentials:
+            r = sim.potentials[pair].get('r')
+            u = sim.potentials[pair].get('u')
             if r is None or u is None:
                 raise ValueError('r and u must be set in the potentials matrix.')
-            gr = np.exp(-ensemble.beta*u)
+            gr = np.exp(-sim.ensemble.beta*u)
             new_ens.rdf[pair] = RDF(r,gr)
 
         #calculate pressure
         new_ens.P = 0.
-        for a in ensemble.types:
-            rho_a = ensemble.N[a]/ensemble.V.volume
-            new_ens.P += ensemble.kB*ensemble.T*rho_a
-            for b in ensemble.types:
-                rho_b = ensemble.N[b]/ensemble.V.volume
-                r = potentials[a,b].get('r')
-                u = potentials[a,b].get('u')
-                f = potentials[a,b].get('f')
+        for a in new_ens.types:
+            rho_a = new_ens.N[a]/new_ens.V.volume
+            new_ens.P += new_ens.kB*new_ens.T*rho_a
+            for b in new_ens.types:
+                rho_b = new_ens.N[b]/new_ens.V.volume
+                r = sim.potentials[a,b].get('r')
+                u = sim.potentials[a,b].get('u')
+                f = sim.potentials[a,b].get('f')
                 if f is None:
                     ur = Interpolator(r,u)
                     f = -ur.derivative(r,1)
                 gr = new_ens.rdf[pair].table[:,1]
-                new_ens.P += (2.*np.pi/3.)*rho_a*rho_b*np.trapz(f*gr*r**3, x=r)
+                new_ens.P += (2.*np.pi/3.)*rho_a*rho_b*np.trapz(y=f*gr*r**3,x=r)
 
         return new_ens

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -1,4 +1,4 @@
-__all__ = ['Simulation']
+__all__ = ['Simulation','SimulationInstance']
 
 import abc
 
@@ -78,7 +78,19 @@ class Simulation(abc.ABC):
         pass
 
 class SimulationInstance:
-    """Specific instance of a simulation and its data."""
+    """Specific instance of a simulation and its data.
+
+    Parameters
+    ----------
+    ensemble : :py:class:`Ensemble`
+        Simulation ensemble. Must include values for *N* and *V* even if
+        these variables fluctuate.
+    potentials : :py:class:`PairMatrix`
+        Matrix of tabulated potentials for each pair.
+    options : kwargs
+        Optional arguments for the initialize, analyze, and defined "operations" functions.
+
+    """
     def __init__(self, ensemble, potentials, **options):
         self.ensemble = ensemble
         self.potentials = potentials

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -181,6 +181,33 @@ class test_Ensemble(unittest.TestCase):
         with self.assertRaises(AttributeError):
             ens.mu = {'A':0.3,'B':0.4}
 
+    def test_aka(self):
+        """Test checking alternative names of ensembles."""
+        nvt = relentless.Ensemble(T=1.0,V=relentless.Cube(1.0),N={'A':1})
+        self.assertTrue(nvt.aka("NVT"))
+        self.assertTrue(nvt.aka("canonical"))
+        self.assertFalse(nvt.aka("NPT"))
+        self.assertFalse(nvt.aka("muVT"))
+        with self.assertRaises(ValueError):
+            nvt.aka("alchemical")
+
+        npt = relentless.Ensemble(T=1.0,P=0.0,N={'A':1})
+        self.assertFalse(npt.aka("NVT"))
+        self.assertTrue(npt.aka("NPT"))
+        self.assertTrue(npt.aka("isothermal-isobaric"))
+        self.assertFalse(npt.aka("muVT"))
+
+        grand = relentless.Ensemble(T=1.0,V=relentless.Cube(1.0),mu={'A':0.0})
+        self.assertFalse(grand.aka("NVT"))
+        self.assertFalse(grand.aka("NPT"))
+        self.assertTrue(grand.aka("muVT"))
+        self.assertTrue(grand.aka("grand canonical"))
+
+        semigrand = relentless.Ensemble(T=1.0,V=relentless.Cube(1.0),N={'A':1},mu={'B':0.0})
+        self.assertFalse(semigrand.aka("NVT"))
+        self.assertFalse(semigrand.aka("NPT"))
+        self.assertFalse(semigrand.aka("muVT"))
+
     def test_clear(self):
         """Test clear method and modifying attribute values"""
         v_obj = relentless.Cube(L=1.0)

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -10,7 +10,7 @@ class test_SimulationInstance(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        options = {'constant_ens':True, 'constant_pot':True}
+        options = {'constant_ens':True, 'constant_pot':False}
         ens = relentless.Ensemble(T=1.0, V=relentless.Cube(L=2.0), N={'A':2,'B':3})
         pot = relentless.PairMatrix(types=ens.types)
         for pair in pot:
@@ -21,15 +21,15 @@ class test_SimulationInstance(unittest.TestCase):
         sim = relentless.simulate.SimulationInstance(ens, pot)
         self.assertEqual(sim.ensemble, ens)
         self.assertEqual(sim.potentials, pot)
+        with self.assertRaises(AttributeError):
+            sim.constant_ens
 
         #with options
         sim = relentless.simulate.SimulationInstance(ens, pot, **options)
         self.assertEqual(sim.ensemble, ens)
         self.assertEqual(sim.potentials, pot)
-
-        #invalid creation
-        with self.assertRaises(TypeError):
-            sim = relentless.simulate.SimulationInstance()
+        self.assertTrue(sim.constant_ens)
+        self.assertFalse(sim.constant_pot)
 
 class test_Dilute(unittest.TestCase):
     """Unit tests for relentless.Dilute"""

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -9,20 +9,28 @@ class test_Dilute(unittest.TestCase):
     """Unit tests for relentless.Dilute"""
 
     #mock functions for use as operations
-    def update_ens(self, ensemble, potentials, options):
-        if options.get('constant_ens', False):
-            return
-        ensemble.T += 2.0
-        ensemble.V = relentless.Cube(L=4.0)
-        for t in ensemble.types:
-            ensemble.N[t] += 1.0
+    def update_ens(self, sim):
+        try:
+            const = sim.constant_ens
+        except AttributeError:
+            const = False
 
-    def update_pot(self, ensemble, potentials, options):
-        if options.get('constant_pot', False):
-            return
-        for pair in potentials:
-            potentials[pair]['r'] *= 2.0
-            potentials[pair]['u'] *= 3.0
+        if not const:
+            sim.ensemble.T += 2.0
+            sim.ensemble.V = relentless.Cube(L=4.0)
+            for t in sim.ensemble.types:
+                sim.ensemble.N[t] += 1.0
+
+    def update_pot(self, sim):
+        try:
+            const = sim.constant_pot
+        except AttributeError:
+            const = False
+
+        if not const:
+            for pair in sim.potentials:
+                sim.potentials[pair]['r'] *= 2.0
+                sim.potentials[pair]['u'] *= 3.0
 
     def test_init(self):
         """Test creation from data."""

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -5,6 +5,32 @@ import numpy as np
 
 import relentless
 
+class test_SimulationInstance(unittest.TestCase):
+    """Unit tests for relentless.SimulationInstance"""
+
+    def test_init(self):
+        """Test creation from data."""
+        options = {'constant_ens':True, 'constant_pot':True}
+        ens = relentless.Ensemble(T=1.0, V=relentless.Cube(L=2.0), N={'A':2,'B':3})
+        pot = relentless.PairMatrix(types=ens.types)
+        for pair in pot:
+            pot[pair]['r'] = np.array([1.,2.,3.])
+            pot[pair]['u'] = np.array([2.,4.,6.])
+
+        #no options
+        sim = relentless.simulate.SimulationInstance(ens, pot)
+        self.assertEqual(sim.ensemble, ens)
+        self.assertEqual(sim.potentials, pot)
+
+        #with options
+        sim = relentless.simulate.SimulationInstance(ens, pot, **options)
+        self.assertEqual(sim.ensemble, ens)
+        self.assertEqual(sim.potentials, pot)
+
+        #invalid creation
+        with self.assertRaises(TypeError):
+            sim = relentless.simulate.SimulationInstance()
+
 class test_Dilute(unittest.TestCase):
     """Unit tests for relentless.Dilute"""
 


### PR DESCRIPTION
To simplify the arguments we have to pass to operations, I have added a `SimulationInstance` to encapsulate the data. A new `SimulationInstance` is created at the start of each run, so this class is also going to be useful when multiple operations need to share variables. (These can be added as attributes of the `SimulationInstance`.)

@adisr04 I didn't write an explicit unit test for `SimulationInstance`. Would you mind making one that just tests that the constructor works?

I also added a convenience method `aka` to the `Ensemble` object that can be used to test its type compared to a list of known aliases. I covered the common names, and someone can always add a test like this if they want something more specific.