### PR TITLE
Use HOOMD 2.9.6 for testing

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-hoomd=2.9.3
+hoomd=2.9.6
 freud=2.2.0
 gsd=2.2.0
 lammps=2020.10.29


### PR DESCRIPTION
This version of HOOMD will properly select the CPU build in conda so that we don't waste time installing the CUDA toolkit.

See discussion:
https://groups.google.com/g/hoomd-users/c/YRwaUESfeIA