### PR TITLE
Refactor ensemble to be less strict about type

### DIFF
--- a/relentless/ensemble.py
+++ b/relentless/ensemble.py
@@ -1,7 +1,7 @@
 import copy
 import json
 
-import numpy as np
+import numpy
 
 from ._collections import FixedKeyDict,PairMatrix
 from ._math import Interpolator
@@ -23,102 +23,60 @@ class RDF(Interpolator):
     """
     def __init__(self, r, g):
         super().__init__(r,g)
-        self.table = np.column_stack((r,g))
+        self.table = numpy.column_stack((r,g))
 
-class Ensemble(object):
+class Ensemble:
     r"""Thermodynamic ensemble.
 
-    The parameters of the ensemble are defined as follows:
-        - The temperature (``T``) is always a constant.
-        - Either the pressure (``P``) or the volume (``V``) can be specified.
-        - Either the chemical potential (``mu``) or the particle number (``N``)
-          can be specified for each type. The particle types in the Ensemble are
-          determined from the keys in the ``mu`` and ``N`` dictionaries.
-
-    The variables that are "constants" of the ensemble (e.g. *N*, *V*, and *T*
-    for the canonical ensemble) are determined from the arguments specified in the
-    constructor. The fluctuating (conjugate) variables must be set subsequently.
-    It is an error to set both variables in a conjugate pair (e.g. *P* and *V*)
-    during construction.
+    An ensemble is defined by:
+        - The temperature ``T``.
+        - The number ``N`` for each particle type. The particle types are
+          strings determined from the keys of ``N``.
+        - The volume ``V`` and/or pressure ``P``.
 
     Parameters
     ----------
     T : float
         Temperature of the system.
-    P : float
-        Pressure of the system (defaults to None).
+    N : dict
+        The number of particles for each specified type.
     V : :class:`Volume`
         Volume of the system (defaults to None).
-    mu : dict
-        The chemical potential for each specified type (defaults to None).
-    N : dict
-        The number of particles for each specified type (defaults to None).
+    P : float
+        Pressure of the system (defaults to None).
     kB : float
         Boltzmann constant (defaults to 1.0).
 
     Raises
     ------
-    ValueError
-        If neither ``P`` nor ``V`` is set.
-    ValueError
-        If both ``P`` and ``V`` are set.
+    TypeError
+        If the types in ``N`` are not all strings.
     TypeError
         If all values of ``N`` are not integers or None.
-    ValueError
-        If both ``mu`` and ``N`` are set for a type.
-    ValueError
-        If both ``mu`` and ``N`` are None.
 
     """
-    def __init__(self, T, P=None, V=None, mu=None, N=None, kB=1.0):
-        # P-V checking
-        if P is None and V is None:
-            raise ValueError('Either P or V must be set.')
-        elif P is not None and V is not None:
-            raise ValueError('Both P and V cannot be set.')
-
-        # mu-N checking
-        if mu is None:
-            mu = dict()
-        if N is None:
-            N = dict()
-        # type list
-        types = list(mu.keys()) + list(N.keys())
-        types = tuple(set(types))
-        if len(types) == 0:
-            raise ValueError('At least one type must be specified by N or mu.')
-        for t in types:
-            mu_i = mu.get(t)
-            N_i = N.get(t)
-            if mu_i is not None and N_i is not None:
-                raise ValueError('Both mu and N cannot be set for type {}.'.format(t))
-            elif N_i is not None and not isinstance(N_i,int):
-                raise TypeError('Value of N for type {} must be an integer or None.'.format(t))
-
-        # temperature
+    def __init__(self, T, N, V=None, P=None, kB=1.0):
+        # T
         self.kB = kB
         self.T = T
+
+        # N
+        types = tuple(N.keys())
+        for t in types:
+            if not isinstance(t,str):
+                raise TypeError('Particle type must be a string')
+            N_i = N.get(t)
+            if N_i is not None and not isinstance(N_i,int):
+                raise TypeError('N for type {} must be an integer.'.format(t))
+        self._N = FixedKeyDict(keys=types)
+        self.N.update(N)
 
         # P-V
         self.P = P
         self.V = V
 
-        # mu-N
-        self._mu = FixedKeyDict(keys=types)
-        self._N = FixedKeyDict(keys=types)
-        self.mu.update(mu)
-        self.N.update(N)
-
         # rdf per-pair
         self._rdf = PairMatrix(types=types)
-
-        # build the set of constant variables from the constructor
-        self._constant = {'T': True,
-                          'P': self.P is not None,
-                          'V': self.V is not None,
-                          'mu': {t: (self.mu[t] is not None) for t in types},
-                          'N': {t: (self.N[t] is not None) for t in types}
-                         }
 
     @property
     def T(self):
@@ -165,11 +123,6 @@ class Ensemble(object):
         return self._N
 
     @property
-    def mu(self):
-        r""":class:`FixedKeyDict`: Chemical potential of each type."""
-        return self._mu
-
-    @property
     def types(self):
         r"""tuple: The types in the ensemble."""
         return self.N.keys
@@ -180,82 +133,9 @@ class Ensemble(object):
         return self.rdf.pairs
 
     @property
-    def constant(self):
-        r"""dict: The constant variables in the system.
-
-        Each key of the dictionary indicates which variables were defined as
-        constants when the Ensemble was constructed. The user **must not**
-        mutate the values in this dictionary.
-
-        """
-        return self._constant
-
-    def aka(self,name):
-        """Check if the ensemble is also known by a common type.
-
-        Parameters
-        ----------
-        name : str
-            Common name of a thermodynamic ensemble. The recognized names are:
-
-            - "NVT" or "canonical" for constant *N*, *V*, and *T*.
-            - "NPT or "isothermal-isobaric for constant *N*, *P*, and *T*.
-            - "muVT" or "grand canonical" for constant :math:`\mu`, *V*, and *T*.
-
-        Returns
-        -------
-        bool:
-            True if the ensemble matches the name, and False otherwise.
-
-        Raises
-        ------
-        ValueError:
-            The name is not one of the recognized types.
-
-        """
-        if name in ("NVT","canonical"):
-            return (self.constant['T'] and self.constant['V']
-                and all(self.constant['N'][t] for t in self.types))
-        elif name in ("NPT","isothermal-isobaric"):
-            return (self.constant['T'] and self.constant['P']
-                and all(self.constant['N'][t] for t in self.types))
-        elif name in ("muVT","grand canonical"):
-            return (self.constant['T'] and self.constant['V']
-                and all(self.constant['mu'][t] for t in self.types))
-        else:
-            raise ValueError("Ensemble name not recognized")
-
-
-    @property
     def rdf(self):
         r""":class:`PairMatrix`: Radial distribution function per pair."""
         return self._rdf
-
-    def clear(self):
-        r"""Clear the value of all conjugate (fluctuating) variables in the ensemble.
-
-        The values of the non-constant variables and all radial distribution
-        functions become None.
-
-        Returns
-        -------
-        :class:`Ensemble`
-            This Ensemble with cleared parameters.
-
-        """
-        if not self.constant['V']:
-            self._V = None
-        if not self.constant['P']:
-            self._P = None
-        for t in self.types:
-            if not self.constant['N'][t]:
-                self._N[t] = None
-            if not self.constant['mu'][t]:
-                self._mu[t] = None
-        for pair in self.rdf:
-            self.rdf[pair] = None
-
-        return self
 
     def copy(self):
         r"""Make a copy of the ensemble.
@@ -278,14 +158,12 @@ class Ensemble(object):
 
         """
         data = {'T': self.T,
-                'P': self.P,
+                'N': self.N.todict(),
                 'V': {'__name__':type(self.V).__name__,
                       'data':self.V.to_json()
                      },
-                'mu': self.mu.todict(),
-                'N': self.N.todict(),
+                'P': self.P,
                 'kB': self.kB,
-                'constant': self.constant,
                 'rdf': {}
                }
 
@@ -318,42 +196,23 @@ class Ensemble(object):
         with open(filename) as f:
             data = json.load(f)
 
-        # retrieve thermodynamic parameters
+        # create initial ensemble
         VolumeType = getattr(volume,data['V']['__name__'])
         thermo = {'T': data['T'],
-                  'P': data['P'],
+                  'N': data['N'],
                   'V': VolumeType.from_json(data['V']['data']),
-                  'mu': data['mu'],
-                  'N': data['N']
+                  'P': data['P'],
+                  'kB': data['kB']
                  }
+        ens = Ensemble(**thermo)
 
-        # create Ensemble with constant variables only
-        thermo_const = copy.deepcopy(thermo)
-        for var in thermo:
-            if var == 'mu' or var == 'N':
-                for t in thermo[var]:
-                    if not data['constant'][var][t]:
-                        thermo_const[var][t] = None
-            elif not data['constant'][var]:
-                thermo_const[var] = None
-        ens = Ensemble(kB=data['kB'],**thermo_const)
-
-        # then set values of fluctuating variables
-        for var in thermo:
-            if var == 'mu' or var == 'N':
-                for t in thermo[var]:
-                    if not data['constant'][var][t]:
-                        getattr(ens,var).update({t:thermo[var][t]})
-            elif not data['constant'][var]:
-                setattr(ens,var,thermo[var])
-
-        # set rdf values
+        # unpack rdfs
         for pair in ens.rdf:
             pair_ = str(pair)
             if data['rdf'][pair_] is None:
                 continue
             r = [i[0] for i in data['rdf'][pair_]]
             g = [i[1] for i in data['rdf'][pair_]]
-            ens.rdf[pair] = RDF(r=r, g=g)
+            ens.rdf[pair] = RDF(r,g)
 
         return ens

--- a/relentless/simulate/dilute.py
+++ b/relentless/simulate/dilute.py
@@ -80,11 +80,7 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
             If r and u are not both set in the potentials matrix.
 
         """
-        if not sim.ensemble.aka("NVT"):
-            raise ValueError('Dilute simulations must be run in the NVT ensemble.')
-
         ens = sim.ensemble.copy()
-        ens.clear()
 
         # pair distribution function
         for pair in ens.pairs:

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -231,7 +231,7 @@ class InitializeFromFile(Initialize):
             sim.system = hoomd.init.read_gsd(self.filename,**self.options)
 
             # check that the boxes are consistent in constant volume sims.
-            if sim.ensemble.constant['V']:
+            if sim.ensemble.V is not None:
                 system_box = sim.system.box
                 box_from_file = np.array([system_box.Lx,
                                           system_box.Ly,
@@ -880,9 +880,6 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
             If the simulation ensemble does not have constant N.
 
         """
-        if not all([sim.ensemble.constant['N'][t] for t in sim.ensemble.types]):
-            return ValueError('This analyzer requires constant N.')
-
         with sim.context:
             # thermodynamic properties
             sim[self].logger = hoomd.analyze.log(filename=None,

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -463,9 +463,6 @@ class AddBrownianIntegrator(AddMDIntegrator):
             If the simulation ensemble is not NVT.
 
         """
-        if not sim.ensemble.aka('NVT'):
-            raise ValueError('Simulation ensemble is not NVT.')
-
         self.attach_integrator(sim)
         with sim.context:
             all_ = hoomd.group.all()
@@ -534,9 +531,6 @@ class AddLangevinIntegrator(AddMDIntegrator):
             If the simulation ensemble is not NVT.
 
         """
-        if not sim.ensemble.aka('NVT'):
-            raise ValueError('Simulation ensemble is not NVT.')
-
         self.attach_integrator(sim)
         with sim.context:
             all_ = hoomd.group.all()
@@ -605,9 +599,6 @@ class AddNPTIntegrator(AddMDIntegrator):
             If the simulation ensemble is not NPT.
 
         """
-        if not sim.ensemble.aka('NPT'):
-            raise ValueError('Simulation ensemble is not NPT.')
-
         self.attach_integrator(sim)
         with sim.context:
             all_ = hoomd.group.all()
@@ -674,9 +665,6 @@ class AddNVTIntegrator(AddMDIntegrator):
             If the simulation ensemble is not NVT.
 
         """
-        if not sim.ensemble.aka('NVT'):
-            raise ValueError('Simulation ensemble is not NVT.')
-
         self.attach_integrator(sim)
         with sim.context:
             all_ = hoomd.group.all()
@@ -931,7 +919,6 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
 
         """
         ens = sim.ensemble.copy()
-        ens.clear()
 
         thermo_recorder = sim[self].thermo_callback
         ens.T = thermo_recorder.T

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -608,9 +608,6 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
         self.rdf_dr = rdf_dr
 
     def to_commands(self, sim):
-        if not all([sim.ensemble.constant['N'][t] for t in sim.ensemble.types]):
-            return ValueError('This analyzer requires constant N.')
-
         # check that IDs reserved for analysis do not yet exist
         reserved_ids = (('fix','thermo_avg'),
                         ('compute','rdf'),

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -380,9 +380,6 @@ class AddLangevinIntegrator(LAMMPSOperation):
         self._fix_nve = self.new_fix_id()
 
     def to_commands(self, sim):
-        if not sim.ensemble.aka('NVT'):
-            raise ValueError('Simulation ensemble is not NVT.')
-
         # obtain per-type mass (arrays 1-indexed using lammps convention)
         Ntypes = len(sim.ensemble.types)
         mass = sim.lammps.numpy.extract_atom('mass')
@@ -469,8 +466,6 @@ class AddNPTIntegrator(LAMMPSOperation):
         self._fix = super().new_fix_id()
 
     def to_commands(self, sim):
-        if not sim.ensemble.aka('NPT'):
-            raise ValueError('Simulation ensemble is not NPT.')
         cmds = ['fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp} iso {Pstart} {Pstop} {Pdamp}'.format(idx=self._fix,
                                                                                                               group_idx='all',
                                                                                                               Tstart=sim.ensemble.T,
@@ -525,8 +520,6 @@ class AddNVTIntegrator(LAMMPSOperation):
         self._fix = super().new_fix_id()
 
     def to_commands(self, sim):
-        if not sim.ensemble.aka('NVT'):
-            raise ValueError('Simulation ensemble is not NVT.')
         cmds = ['fix {idx} {group_idx} nvt temp {Tstart} {Tstop} {Tdamp}'.format(idx=self._fix,
                                                                                  group_idx='all',
                                                                                  Tstart=sim.ensemble.T,
@@ -694,7 +687,6 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
 
         """
         ens = sim.ensemble.copy()
-        ens.clear()
 
         # extract thermo properties
         # we skip the first 2 rows, which are LAMMPS junk, and slice out the timestep from col. 0

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -34,12 +34,6 @@ class test_Dilute(unittest.TestCase):
         ens_ = analyzer.extract_ensemble(sim)
         self.assertAlmostEqual(ens_.P, -207.5228556)
 
-        #invalid ensemble (non-NVT)
-        ens_ = relentless.ensemble.Ensemble(T=1, V=relentless.volume.Cube(1), N={'A':2}, mu={'B':0.2})
-        d = relentless.simulate.dilute.Dilute(analyzer)
-        with self.assertRaises(ValueError):
-            d.run(ensemble=ens_, potentials=pots, directory=self.directory)
-
     def tearDown(self):
         self._tmp.cleanup()
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -37,21 +37,15 @@ class test_Ensemble(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #P and mu set
-        ens = relentless.ensemble.Ensemble(T=10, P=2.0, mu={'A':0.1,'B':0.2})
+        #P and N set
+        ens = relentless.ensemble.Ensemble(T=10, P=2.0, N={'A':1,'B':2})
         self.assertCountEqual(ens.types, ('A','B'))
         self.assertCountEqual(ens.rdf.pairs, (('A','B'),('A','A'),('B','B')))
         self.assertAlmostEqual(ens.kB, 1.0)
         self.assertAlmostEqual(ens.T, 10)
         self.assertAlmostEqual(ens.P, 2.0)
         self.assertEqual(ens.V, None)
-        self.assertDictEqual(ens.mu.todict(), {'A':0.1,'B':0.2})
-        self.assertDictEqual(ens.N.todict(), {'A':None,'B':None})
-        self.assertDictEqual(ens.constant, {'T': True,
-                                            'P':True,
-                                            'V':False,
-                                            'mu':{'A':True,'B':True},
-                                            'N':{'A':False,'B':False}})
+        self.assertDictEqual(ens.N.todict(), {'A':1,'B':2})
         self.assertAlmostEqual(ens.beta, 0.1)
 
         #V and N set, non-default value of kB
@@ -64,17 +58,11 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(ens.mu.todict(), {'A':None,'B':None})
         self.assertDictEqual(ens.N.todict(), {'A':1,'B':2})
-        self.assertDictEqual(ens.constant, {'T': True,
-                                            'P':False,
-                                            'V':True,
-                                            'mu':{'A':False,'B':False},
-                                            'N':{'A':True,'B':True}})
         self.assertAlmostEqual(ens.beta, 0.025)
 
-        #mu and N used for one type each
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
+        # one N is None
+        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':None, 'B':2})
         self.assertCountEqual(ens.types, ('A','B'))
         self.assertCountEqual(ens.rdf.pairs, (('A','B'),('A','A'),('B','B')))
         self.assertAlmostEqual(ens.kB, 1.0)
@@ -82,17 +70,11 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(ens.mu.todict(), {'A':0.1,'B':None})
         self.assertDictEqual(ens.N.todict(), {'A':None,'B':2})
-        self.assertDictEqual(ens.constant, {'T': True,
-                                            'P':False,
-                                            'V':True,
-                                            'mu':{'A':True,'B':False},
-                                            'N':{'A':False,'B':True}})
         self.assertAlmostEqual(ens.beta, 0.01)
 
         #test creation with single type
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1})
+        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':10})
         self.assertCountEqual(ens.types, ('A',))
         self.assertCountEqual(ens.rdf.pairs, (('A','A'),))
         self.assertAlmostEqual(ens.kB, 1.0)
@@ -100,17 +82,11 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(ens.mu.todict(), {'A':0.1})
-        self.assertDictEqual(ens.N.todict(), {'A':None})
-        self.assertDictEqual(ens.constant, {'T': True,
-                                            'P':False,
-                                            'V':True,
-                                            'mu':{'A':True},
-                                            'N':{'A':False}})
+        self.assertDictEqual(ens.N.todict(), {'A':10})
         self.assertAlmostEqual(ens.beta, 0.01)
 
         #test setting rdf
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
+        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
         r = [1,2,3]
         ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])
         ens.rdf['A','A'] = relentless.ensemble.RDF(r=r, g=[3,7,4])
@@ -125,27 +101,12 @@ class test_Ensemble(unittest.TestCase):
                                                                      [2,9],
                                                                      [3,3]]))
 
-        #test invalid setting of neither P nor V
-        with self.assertRaises(ValueError):
-            ens = relentless.ensemble.Ensemble(T=10, mu={'A':0.1,'B':0.2})
-
-        #test invalid setting of neither mu nor N
-        with self.assertRaises(ValueError):
-            ens = relentless.ensemble.Ensemble(T=10, P=2.0)
-
-        #test invalid setting of both P and V
-        with self.assertRaises(ValueError):
-            ens = relentless.ensemble.Ensemble(T=10, P=2.0, V=v_obj)
-
-        #test invalid setting of both mu and N
-        with self.assertRaises(ValueError):
-            ens = relentless.ensemble.Ensemble(T=10, mu={'A':0.1,'B':0.2}, N={'A':1,'B':2})
-        with self.assertRaises(ValueError):
-            ens = relentless.ensemble.Ensemble(T=10, mu={'A':0.1,'B':0.2}, N={'B':2})
-
         #test setting N as a float
         with self.assertRaises(TypeError):
             ens = relentless.ensemble.Ensemble(T=10, P=1.0, N={'A':1.0})
+        #test setting N with non-string type
+        with self.assertRaises(TypeError):
+            ens = relentless.ensemble.Ensemble(T=10, P=1.0, N={1:2})
 
     def test_set_params(self):
         """Test setting constant and fluctuating parameter values."""
@@ -157,10 +118,9 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(ens.mu.todict(), {'A':None,'B':None})
         self.assertDictEqual(ens.N.todict(), {'A':1,'B':2})
 
-        #set constant values
+        #set values
         ens.V = v_obj1
         self.assertIs(ens.V,v_obj1)
         self.assertAlmostEqual(ens.V.volume, 64.0)
@@ -168,103 +128,20 @@ class test_Ensemble(unittest.TestCase):
         ens.N['B'] = 3
         self.assertDictEqual(ens.N.todict(), {'A':2,'B':3})
 
-        #set fluctuating/conjugate values
+        #set other values
         ens.P = 2.0
         self.assertAlmostEqual(ens.P, 2.0)
-        ens.mu['A'] = 0.2
-        ens.mu['B'] = 0.3
-        self.assertDictEqual(ens.mu.todict(), {'A':0.2,'B':0.3})
 
-        #test invalid setting of N, mu dicts directly
+        #test invalid setting of N directly
         with self.assertRaises(AttributeError):
             ens.N = {'A':3,'B':4}
-        with self.assertRaises(AttributeError):
-            ens.mu = {'A':0.3,'B':0.4}
-
-    def test_aka(self):
-        """Test checking alternative names of ensembles."""
-        nvt = relentless.ensemble.Ensemble(T=1.0,V=relentless.volume.Cube(1.0),N={'A':1})
-        self.assertTrue(nvt.aka("NVT"))
-        self.assertTrue(nvt.aka("canonical"))
-        self.assertFalse(nvt.aka("NPT"))
-        self.assertFalse(nvt.aka("muVT"))
-        with self.assertRaises(ValueError):
-            nvt.aka("alchemical")
-
-        npt = relentless.ensemble.Ensemble(T=1.0,P=0.0,N={'A':1})
-        self.assertFalse(npt.aka("NVT"))
-        self.assertTrue(npt.aka("NPT"))
-        self.assertTrue(npt.aka("isothermal-isobaric"))
-        self.assertFalse(npt.aka("muVT"))
-
-        grand = relentless.ensemble.Ensemble(T=1.0,V=relentless.volume.Cube(1.0),mu={'A':0.0})
-        self.assertFalse(grand.aka("NVT"))
-        self.assertFalse(grand.aka("NPT"))
-        self.assertTrue(grand.aka("muVT"))
-        self.assertTrue(grand.aka("grand canonical"))
-
-        semigrand = relentless.ensemble.Ensemble(T=1.0,V=relentless.volume.Cube(1.0),N={'A':1},mu={'B':0.0})
-        self.assertFalse(semigrand.aka("NVT"))
-        self.assertFalse(semigrand.aka("NPT"))
-        self.assertFalse(semigrand.aka("muVT"))
-
-    def test_clear(self):
-        """Test clear method and modifying attribute values"""
-        v_obj = relentless.volume.Cube(L=1.0)
-
-        #P and mu set
-        ens = relentless.ensemble.Ensemble(T=10, P=2.0, mu={'A':0.1,'B':0.2})
-        ens.V = v_obj
-        ens.N['A'] = 1
-        ens.N['B'] = 2
-        ens.clear()
-        self.assertAlmostEqual(ens.P, 2.0)
-        self.assertEqual(ens.V, None)
-        self.assertAlmostEqual(ens.mu.todict(), {'A':0.1,'B':0.2})
-        self.assertEqual(ens.N.todict(), {'A':None,'B':None})
-
-        #V and N set
-        ens = relentless.ensemble.Ensemble(T=20, V=v_obj, N={'A':1,'B':2})
-        ens.P = 1.0
-        ens.mu['A'] = 0.2
-        ens.mu['B'] = 0.3
-        ens.clear()
-        self.assertAlmostEqual(ens.P, None)
-        self.assertAlmostEqual(ens.V.volume, 1.0)
-        self.assertAlmostEqual(ens.mu.todict(), {'A':None,'B':None})
-        self.assertEqual(ens.N.todict(), {'A':1,'B':2})
-
-        #mu and N used for one type each
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
-        ens.P = 1.0
-        ens.mu['B'] = 0.2
-        ens.N['A'] = 1
-        ens.clear()
-        self.assertAlmostEqual(ens.P, None)
-        self.assertAlmostEqual(ens.V.volume, 1.0)
-        self.assertDictEqual(ens.mu.todict(), {'A':0.1,'B':None})
-        self.assertDictEqual(ens.N.todict(), {'A':None,'B':2})
-
-        #test resetting rdf
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
-        r = [1,2,3]
-        ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])
-        ens.rdf['A','A'] = relentless.ensemble.RDF(r=r, g=[3,7,4])
-        ens.rdf['B','B'] = relentless.ensemble.RDF(r=r, g=[1,9,3])
-        ens.clear()
-        self.assertEqual(ens.rdf['A','B'], None)
-        self.assertEqual(ens.rdf['A','A'], None)
-        self.assertEqual(ens.rdf['B','B'], None)
 
     def test_copy(self):
         """Test copy method"""
         v_obj = relentless.volume.Cube(L=1.0)
 
         #P and mu set
-        ens = relentless.ensemble.Ensemble(T=10, P=2.0, mu={'A':0.1,'B':0.2})
-        ens.V = v_obj
-        ens.N['A'] = 1
-        ens.N['B'] = 2
+        ens = relentless.ensemble.Ensemble(T=10, P=2.0, V=v_obj, N={'A':1,'B':2})
         ens_ = ens.copy()
         self.assertIsNot(ens, ens_)
         self.assertCountEqual(ens.types, ens_.types)
@@ -273,43 +150,10 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.P, ens_.P)
         self.assertIsInstance(ens_.V, relentless.volume.Cube)
         self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(ens.mu.todict(), ens_.mu.todict())
-        self.assertDictEqual(ens_.N.todict(), ens.N.todict())
-
-        #V and N set
-        ens = relentless.ensemble.Ensemble(T=20, V=v_obj, N={'A':1,'B':2})
-        ens.P = 1.0
-        ens.mu['A'] = 0.1
-        ens.mu['B'] = 0.2
-        ens_ = ens.copy()
-        self.assertIsNot(ens_, ens)
-        self.assertCountEqual(ens.types, ens_.types)
-        self.assertCountEqual(ens.rdf.pairs, ens_.rdf.pairs)
-        self.assertAlmostEqual(ens.T, ens_.T)
-        self.assertAlmostEqual(ens.P, ens_.P)
-        self.assertIsInstance(ens_.V, relentless.volume.Cube)
-        self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(ens.mu.todict(), ens_.mu.todict())
-        self.assertDictEqual(ens_.N.todict(), ens.N.todict())
-
-        #mu and N used for one type each
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
-        ens.P = 1.0
-        ens.mu['B'] = 0.2
-        ens.N['A'] = 1
-        ens_ = ens.copy()
-        self.assertIsNot(ens_, ens)
-        self.assertCountEqual(ens.types, ens_.types)
-        self.assertCountEqual(ens.rdf.pairs, ens_.rdf.pairs)
-        self.assertAlmostEqual(ens.T, ens_.T)
-        self.assertAlmostEqual(ens.P, ens_.P)
-        self.assertIsInstance(ens_.V, relentless.volume.Cube)
-        self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(ens.mu.todict(), ens_.mu.todict())
         self.assertDictEqual(ens_.N.todict(), ens.N.todict())
 
         #test copying rdf
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
+        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
         r = [1,2,3]
         ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])
         ens.rdf['A','A'] = relentless.ensemble.RDF(r=r, g=[3,7,4])
@@ -326,12 +170,7 @@ class test_Ensemble(unittest.TestCase):
         temp = tempfile.NamedTemporaryFile()
 
         v_obj = relentless.volume.Cube(L=1.0)
-
-        #P and mu set
-        ens = relentless.ensemble.Ensemble(T=10, P=2.0, mu={'A':0.1,'B':0.2})
-        ens.V = v_obj
-        ens.N['A'] = 1
-        ens.N['B'] = 2
+        ens = relentless.ensemble.Ensemble(T=20, V=v_obj, P=1.0, N={'A':1,'B':2})
         ens.save(temp.name)
         ens_ = relentless.ensemble.Ensemble.from_file(temp.name)
         self.assertIsNot(ens_, ens)
@@ -341,48 +180,10 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.P, ens_.P)
         self.assertIsInstance(ens_.V, relentless.volume.Cube)
         self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(ens.mu.todict(), ens_.mu.todict())
         self.assertDictEqual(ens_.N.todict(), ens.N.todict())
-        self.assertDictEqual(ens_.constant, ens.constant)
-
-        #V and N set
-        ens = relentless.ensemble.Ensemble(T=20, V=v_obj, N={'A':1,'B':2})
-        ens.P = 1.0
-        ens.mu['A'] = 0.1
-        ens.mu['B'] = 0.2
-        ens.save(temp.name)
-        ens_ = relentless.ensemble.Ensemble.from_file(temp.name)
-        self.assertIsNot(ens_, ens)
-        self.assertCountEqual(ens.types, ens_.types)
-        self.assertCountEqual(ens.rdf.pairs, ens_.rdf.pairs)
-        self.assertAlmostEqual(ens.T, ens_.T)
-        self.assertAlmostEqual(ens.P, ens_.P)
-        self.assertIsInstance(ens_.V, relentless.volume.Cube)
-        self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(ens.mu.todict(), ens_.mu.todict())
-        self.assertDictEqual(ens_.N.todict(), ens.N.todict())
-        self.assertDictEqual(ens_.constant, ens.constant)
-
-        #mu and N used for one type each
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
-        ens.P = 1.0
-        ens.mu['B'] = 0.2
-        ens.N['A'] = 1
-        ens.save(temp.name)
-        ens_ = relentless.ensemble.Ensemble.from_file(temp.name)
-        self.assertIsNot(ens_, ens)
-        self.assertCountEqual(ens.types, ens_.types)
-        self.assertCountEqual(ens.rdf.pairs, ens_.rdf.pairs)
-        self.assertAlmostEqual(ens.T, ens_.T)
-        self.assertAlmostEqual(ens.P, ens_.P)
-        self.assertIsInstance(ens_.V, relentless.volume.Cube)
-        self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(ens.mu.todict(), ens_.mu.todict())
-        self.assertDictEqual(ens_.N.todict(), ens.N.todict())
-        self.assertDictEqual(ens_.constant, ens.constant)
 
         #test saving/constructing rdf
-        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, mu={'A':0.1}, N={'B':2})
+        ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
         r = [1,2,3]
         ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])
         ens.rdf['A','A'] = relentless.ensemble.RDF(r=r, g=[3,7,4])


### PR DESCRIPTION
This PR relaxes the requirement for an ensemble to conform to a given type. It also temporarily removes support for chemical potentials, since this might take some future planning. Rather than need to change the interface, I think we do not need to support it right now.