### PR TITLE
Add packaging and doc configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 build
+*.egg-info
 *.pyc
 __pycache__
+dist
 doc/build
 examples/*/workspace

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,5 @@ python:
   install:
     - requirements: requirements.txt
     - requirements: doc/requirements.txt
-    - method: setuptools
+    - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: true
+
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - requirements: doc/requirements.txt
+    - method: setuptools
+      path: .

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
-sphinx_rtd_theme
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0

--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,6 +1,6 @@
 /*
  * Fix wrapping of table cells in RTD style.
- * h/t: https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
+ * h/t: https://sphinx-argparse.readthedocs.io/en/stable/misc.html
  */
 @media screen and (min-width: 767px) {
    .wy-table-responsive table td {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'relentless'
-copyright = '2021, Michael P. Howard'
+copyright = '2021, Auburn University'
 author = 'Michael P. Howard'
 version = '0.1.0'
 release = '0.1.0'
@@ -58,7 +58,7 @@ autosummary_generate = False
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'network': ('https://networkx.org/documentation/stable', None),
+    'networkx': ('https://networkx.org/documentation/stable', None),
     'mpi4py': ('https://mpi4py.readthedocs.io/en/stable', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None)
+    'numpy': ('https://numpy.org/doc/stable', None)
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -40,11 +40,7 @@ exclude_patterns = []
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',
-        ],
-    }
+html_css_files = ['theme_overrides.css']
 
 # -- Options for autodoc & autosummary ---------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = relentless
+version = 0.1.0
+author = Michael P. Howard
+author_email = mphoward@auburn.edu
+description = Computational materials design, with less code
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/mphowardlab/relentless
+project_urls =
+    Documentation = https://relentless.readthedocs.io
+    Source Code = https://github.com/mphowardlab/relentless
+    Issue Tracker = https://github.com/mphowardlab/relentless/issues
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Topic :: Scientific/Engineering :: Chemistry
+    Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+packages = relentless
+python_requires = >=3.6
+install_requires =
+    networkx>=2.4
+    numpy
+    packaging
+    scipy

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+import setuptools
+setuptools.setup()


### PR DESCRIPTION
This adds the configuration needed to build on readthedocs (#2). In the process, it also adds `setup.cfg` for building and installing. We should be able to use this config for PyPI when everything is stable.

Resolves #64 