### PR TITLE
Expand documentation for modules

### DIFF
--- a/doc/source/api/collections.rst
+++ b/doc/source/api/collections.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless._collections

--- a/doc/source/api/data.rst
+++ b/doc/source/api/data.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.data

--- a/doc/source/api/ensemble.rst
+++ b/doc/source/api/ensemble.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.ensemble

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,3 +1,5 @@
 Overview
 ========
 Overview of the API docs.
+
+.. automodule:: relentless

--- a/doc/source/api/math.rst
+++ b/doc/source/api/math.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless._math

--- a/doc/source/api/simulate/dilute.rst
+++ b/doc/source/api/simulate/dilute.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.simulate.dilute

--- a/doc/source/api/simulate/generic.rst
+++ b/doc/source/api/simulate/generic.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.simulate.generic

--- a/doc/source/api/simulate/hoomd.rst
+++ b/doc/source/api/simulate/hoomd.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.simulate.hoomd

--- a/doc/source/api/simulate/index.rst
+++ b/doc/source/api/simulate/index.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.simulate

--- a/doc/source/api/simulate/lammps.rst
+++ b/doc/source/api/simulate/lammps.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.simulate.lammps

--- a/doc/source/api/simulate/simulate.rst
+++ b/doc/source/api/simulate/simulate.rst
@@ -1,1 +1,0 @@
-.. automodule:: relentless.simulate.simulate

--- a/doc/source/api/simulate/simulate.rst
+++ b/doc/source/api/simulate/simulate.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.simulate.simulate

--- a/doc/source/api/volume.rst
+++ b/doc/source/api/volume.rst
@@ -1,0 +1,1 @@
+.. automodule:: relentless.volume

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,7 +19,9 @@ relentless
     api/mpi
     api/collections
     api/math
+    api/ensemble
     api/potential/index
+    api/simulate/index
     api/optimize/index
     api/variable
     api/volume

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,10 +15,13 @@ relentless
     :caption: API
 
     api/index
+    api/data
     api/mpi
+    api/math
     api/potential/index
     api/optimize/index
     api/variable
+    api/volume
 
 .. toctree::
     :maxdepth: 1

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,6 +17,7 @@ relentless
     api/index
     api/data
     api/mpi
+    api/collections
     api/math
     api/potential/index
     api/optimize/index

--- a/relentless/_collections.py
+++ b/relentless/_collections.py
@@ -1,3 +1,24 @@
+"""
+Collections
+===========
+
+This module contains some data structures used in ``relentless`` as an alternative
+to Python's general purpose containers, for ease of use in constructing potentials
+and performing computations during the optimization workflow.
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: FixedKeyDict
+    :members:
+.. autoclass:: PairMatrix
+    :members:
+.. autoclass:: KeyedArray
+    :members:
+.. autoclass:: DefaultDict
+    :members:
+
+"""
 import collections
 
 import numpy as np
@@ -10,7 +31,7 @@ class FixedKeyDict:
     keys : array_like
         List of keys to be fixed.
     default : scalar
-        Initial value to fill in the dictionary, defaults to `None`.
+        Initial value to fill in the dictionary, defaults to ``None``.
 
     Examples
     --------
@@ -48,7 +69,7 @@ class FixedKeyDict:
         >>> print(d)
         {'A':0.5, 'B':1.0}
 
-    Single-key dictionary still needs `keys` as a tuple::
+    Single-key dictionary still needs ``keys`` as a tuple::
 
         FixedKeyDict(keys=('A',))
 
@@ -102,8 +123,8 @@ class FixedKeyDict:
     def update(self, *data, **values):
         """Partially reassigns key values.
 
-        If both positional argument (data) and keyword arguments (values)
-        are given as parameters, any keys in values will take precedence over data.
+        If both positional argument (``data``) and keyword arguments (``values``)
+        are given as parameters, any keys in ``values`` will take precedence over ``data``.
 
         Parameters
         ----------
@@ -145,16 +166,16 @@ class FixedKeyDict:
 class PairMatrix:
     """Generic matrix of values per-pair.
 
-    Defines a symmetric matrix of parameters corresponding to `(i,j)` pairs.
-    The matrix is essentially a dictionary of dictionaries, keyed on `(i,j)`.
-    There is an equivalent virtual entry for `(j,i)`. (The pairs that are
-    actually saved have `j >= i`.) The dictionary associated with each pair
+    Defines a symmetric matrix of parameters corresponding to ``(i,j)`` pairs.
+    The matrix is essentially a dictionary of dictionaries, keyed on ``(i,j)``.
+    There is an equivalent virtual entry for ``(j,i)``. (The pairs that are
+    actually saved have ``j >= i``.) The dictionary associated with each pair
     can have any number of entries in it, although a common use case is to have
     the same parameter stored per-pair.
 
-    The pairs in the matrix are frozen from the list of `types` specified when
+    The pairs in the matrix are frozen from the list of types specified when
     the object is constructed. It is an error to access pairs that cannot be
-    formed from `types`.
+    formed from ``types``.
 
     The pair matrix emulates a dictionary, and its pairs are iterable.
 
@@ -166,9 +187,9 @@ class PairMatrix:
     Raises
     ------
     ValueError
-        If initialization occurs with empty types
+        If initialization occurs with empty ``types``.
     TypeError
-        If types does not consist of only strings
+        If ``types`` does not consist of only strings.
 
     Examples
     --------
@@ -201,7 +222,7 @@ class PairMatrix:
         >>> m['A','B']
         {'energy': -1.0, 'mass': 1.0}
 
-    Single-type matrix still needs types as a tuple::
+    Single-type matrix still needs ``types`` as a tuple::
 
         PairMatrix(types=('A',))
 
@@ -283,7 +304,7 @@ class KeyedArray(FixedKeyDict):
     keys : array_like
         List of keys to be fixed.
     default : scalar
-        Initial value to fill in the dictionary, defaults to `None`.
+        Initial value to fill in the dictionary, defaults to ``None``.
 
     Examples
     --------
@@ -498,7 +519,7 @@ class KeyedArray(FixedKeyDict):
         return k
 
     def norm(self):
-        r"""Vector :math:`ell^2`-norm.
+        r"""Vector :math:`\ell^2`-norm.
 
         For a vector :math:`\mathbf{x}=\left[x_1,\ldots,x_n\right]`, the
         Euclidean 2-norm :math:`\lVert\mathbf{x}\rVert` is computed as:

--- a/relentless/_math.py
+++ b/relentless/_math.py
@@ -1,3 +1,19 @@
+"""
+Math functions
+==============
+
+Contains a interpolator using `Akima 1D splines <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.Akima1DInterpolator.html>`_.
+The function's value and derivatives can be evaluated.
+
+.. autosummary::
+    :nosignatures:
+
+    Interpolator
+
+.. autoclass:: Interpolator
+    :members:
+
+"""
 import numpy as np
 import scipy.interpolate
 

--- a/relentless/_math.py
+++ b/relentless/_math.py
@@ -2,8 +2,8 @@
 Math functions
 ==============
 
-Contains a interpolator using `Akima 1D splines <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.Akima1DInterpolator.html>`_.
-The function's value and derivatives can be evaluated.
+This module contains a interpolator using Akima 1D splines. The function's value
+and derivatives can be evaluated.
 
 .. autosummary::
     :nosignatures:
@@ -18,7 +18,7 @@ import numpy as np
 import scipy.interpolate
 
 class Interpolator:
-    """Interpolating function.
+    r"""Interpolating function.
 
     Interpolates through a function :math:`y(x)` on the domain
     :math:`a \le x \le b` using Akima splines. Outside this domain, `y` is
@@ -28,20 +28,20 @@ class Interpolator:
     Parameters
     ----------
     x : array_like
-        1-d array of x coordinates that must be continually increasing.
+        1-d array of :math:`x` coordinates that must be continually increasing.
     y : array_like
-        1-d array of y coordinates.
+        1-d array of :math:`y` coordinates.
 
     Raises
     ------
     ValueError
-        If x is a scalar
+        If ``x`` is a scalar.
     ValueError
-        If x is not 1-dimensional
+        If ``x`` is not 1-dimensional.
     ValueError
-        If y is not the same shape as x
+        If ``y`` is not the same shape as ``x``.
     ValueError
-        If x is not strictly increasing
+        If ``x`` is not strictly increasing.
 
     Examples
     --------
@@ -56,7 +56,7 @@ class Interpolator:
         >>> f([-0.5,0.5])
         (-1.0, 1.0)
 
-    Evaluate the n-th derivative of the function::
+    Evaluate the :math:`n`th derivative of the function::
 
         >>> f.derivative(x=0.5, n=1)
         2.0
@@ -87,17 +87,17 @@ class Interpolator:
             self._spline = scipy.interpolate.InterpolatedUnivariateSpline(x=x, y=y, k=1)
 
     def __call__(self, x):
-        """Evaluate the interpolating function.
+        r"""Evaluate the interpolating function.
 
         Parameters
         ----------
         x : float or array_like
-            1-d array of x coordinates to evaluate.
+            1-d array of :math:`x` coordinates to evaluate.
 
         Returns
         -------
         result : float or numpy.ndarray
-            Interpolated values having the same form as `x`.
+            Interpolated values having the same form as ``x``.
 
         """
         scalar_x = np.isscalar(x)
@@ -122,24 +122,24 @@ class Interpolator:
         return result
 
     def derivative(self, x, n):
-        """Evaluate the n-th derivative of the interpolating function.
+        r"""Evaluate the :math:`n`th derivative of the interpolating function.
 
         Parameters
         ----------
         x : float or array_like
-            1-d array of x coordinates to evaluate.
+            1-d array of :math:`x` coordinates to evaluate.
         n : int
             The order of the derivative to take.
 
         Returns
         -------
         result : float or numpy.ndarray
-            Interpolated derivative values having the same form as `x`.
+            Interpolated derivative values having the same form as ``x``.
 
         Raises
         ------
         ValueError
-            If n is not a positive integer.
+            If ``n`` is not a positive integer.
 
         """
         if not isinstance(n, int) and n <= 0:

--- a/relentless/data.py
+++ b/relentless/data.py
@@ -3,7 +3,7 @@ Data management
 ===============
 The :class:`Directory` class provides an interface for creating hierarchical
 filesystem directories and files within those directories using either an absolute
-or relative `path`. Additionally, project simulation and optimization data
+or relative path. Additionally, project simulation and optimization data
 can be stored using a :class:`Project`, which includes options for ``workspace``
 and ``scratch`` directories.
 
@@ -26,14 +26,14 @@ import shutil
 class Directory:
     """Context for a filesystem directory.
 
-    The directory specified by `path` (which can be either absolute or relative)
+    The directory specified by ``path`` (which can be either absolute or relative)
     is created if it does not already exist. This process is recursive, so
-    `path` may include multiple directories that do not yet exist. This object
-    represents the final directory in `path`.
+    ``path`` may include multiple directories that do not yet exist. This object
+    represents the final directory in ``path``.
 
     A :class:`Directory` is a context that can be used to manage the current
     working directory. Entering the context changes the current working
-    directory to *path*, and exiting restores the working directory before the
+    directory to ``path``, and exiting restores the working directory before the
     context was entered.
 
     Parameters
@@ -52,7 +52,7 @@ class Directory:
 
         d = Directory('foo')
 
-    Using the context to open a file `foo/bar.txt` in a directory::
+    Using the context to open a file ``foo/bar.txt`` in a directory::
 
         with Directory('foo') as d:
             f = open('bar.txt')
@@ -65,7 +65,7 @@ class Directory:
     def __enter__(self):
         """Enter the directory context.
 
-        The working directory is changed to the `path` of this object.
+        The working directory is changed to the ``path`` of this object.
 
         Returns
         -------
@@ -157,7 +157,7 @@ class Directory:
 
         Examples
         --------
-        Making nested directories `foo/bar`::
+        Making nested directories ``foo/bar``::
 
             foo = Directory('foo')
             bar = foo.directory('bar')

--- a/relentless/data.py
+++ b/relentless/data.py
@@ -1,8 +1,23 @@
-"""Core data management.
+"""
+Data management
+===============
+The :class:`Directory` class provides an interface for creating hierarchical
+filesystem directories and files within those directories using either an absolute
+or relative `path`. Additionally, project simulation and optimization data
+can be stored using a :class:`Project`, which includes options for ``workspace``
+and ``scratch`` directories.
 
-Todo
-----
-Improve this documentation for developers!
+.. autosummary::
+    :nosignatures:
+
+    Directory
+    Project
+
+.. autoclass:: Directory
+    :members:
+
+.. autoclass:: Project
+    :members:
 
 """
 import os

--- a/relentless/ensemble.py
+++ b/relentless/ensemble.py
@@ -2,11 +2,24 @@
 Ensemble
 ========
 
+This module defines a statistical mechanical thermodynamic ensemble. It is parametrized
+by a temperature, a particle type number, and either the volume or pressure of
+the system. For each pair in the ensemble, the radial distribution function (RDF)
+is also defined using an Akima spline.
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: Ensemble
+    :members:
+.. autoclass:: RDF
+    :members:
+
 """
 import copy
 import json
 
-import numpy as np
+import numpy
 
 from ._collections import FixedKeyDict,PairMatrix
 from ._math import Interpolator
@@ -28,102 +41,60 @@ class RDF(Interpolator):
     """
     def __init__(self, r, g):
         super().__init__(r,g)
-        self.table = np.column_stack((r,g))
+        self.table = numpy.column_stack((r,g))
 
-class Ensemble(object):
+class Ensemble:
     r"""Thermodynamic ensemble.
 
-    The parameters of the ensemble are defined as follows:
-        - The temperature (``T``) is always a constant.
-        - Either the pressure (``P``) or the volume (``V``) can be specified.
-        - Either the chemical potential (``mu``) or the particle number (``N``)
-          can be specified for each type. The particle types in the Ensemble are
-          determined from the keys in the ``mu`` and ``N`` dictionaries.
-
-    The variables that are "constants" of the ensemble (e.g. *N*, *V*, and *T*
-    for the canonical ensemble) are determined from the arguments specified in the
-    constructor. The fluctuating (conjugate) variables must be set subsequently.
-    It is an error to set both variables in a conjugate pair (e.g. *P* and *V*)
-    during construction.
+    An ensemble is defined by:
+        - The temperature ``T``.
+        - The number ``N`` for each particle type. The particle types are
+          strings determined from the keys of ``N``.
+        - The volume ``V`` and/or pressure ``P``.
 
     Parameters
     ----------
     T : float
         Temperature of the system.
+    N : dict
+        The number of particles for each specified type.
+    V : :class:`~relentless.volume.Volume`
+        Volume of the system (defaults to None).
     P : float
         Pressure of the system (defaults to None).
-    V : :class:`Volume`
-        Volume of the system (defaults to None).
-    mu : dict
-        The chemical potential for each specified type (defaults to None).
-    N : dict
-        The number of particles for each specified type (defaults to None).
     kB : float
         Boltzmann constant (defaults to 1.0).
 
     Raises
     ------
-    ValueError
-        If neither ``P`` nor ``V`` is set.
-    ValueError
-        If both ``P`` and ``V`` are set.
+    TypeError
+        If the types in ``N`` are not all strings.
     TypeError
         If all values of ``N`` are not integers or None.
-    ValueError
-        If both ``mu`` and ``N`` are set for a type.
-    ValueError
-        If both ``mu`` and ``N`` are None.
 
     """
-    def __init__(self, T, P=None, V=None, mu=None, N=None, kB=1.0):
-        # P-V checking
-        if P is None and V is None:
-            raise ValueError('Either P or V must be set.')
-        elif P is not None and V is not None:
-            raise ValueError('Both P and V cannot be set.')
-
-        # mu-N checking
-        if mu is None:
-            mu = dict()
-        if N is None:
-            N = dict()
-        # type list
-        types = list(mu.keys()) + list(N.keys())
-        types = tuple(set(types))
-        if len(types) == 0:
-            raise ValueError('At least one type must be specified by N or mu.')
-        for t in types:
-            mu_i = mu.get(t)
-            N_i = N.get(t)
-            if mu_i is not None and N_i is not None:
-                raise ValueError('Both mu and N cannot be set for type {}.'.format(t))
-            elif N_i is not None and not isinstance(N_i,int):
-                raise TypeError('Value of N for type {} must be an integer or None.'.format(t))
-
-        # temperature
+    def __init__(self, T, N, V=None, P=None, kB=1.0):
+        # T
         self.kB = kB
         self.T = T
+
+        # N
+        types = tuple(N.keys())
+        for t in types:
+            if not isinstance(t,str):
+                raise TypeError('Particle type must be a string')
+            N_i = N.get(t)
+            if N_i is not None and not isinstance(N_i,int):
+                raise TypeError('N for type {} must be an integer.'.format(t))
+        self._N = FixedKeyDict(keys=types)
+        self.N.update(N)
 
         # P-V
         self.P = P
         self.V = V
 
-        # mu-N
-        self._mu = FixedKeyDict(keys=types)
-        self._N = FixedKeyDict(keys=types)
-        self.mu.update(mu)
-        self.N.update(N)
-
         # rdf per-pair
         self._rdf = PairMatrix(types=types)
-
-        # build the set of constant variables from the constructor
-        self._constant = {'T': True,
-                          'P': self.P is not None,
-                          'V': self.V is not None,
-                          'mu': {t: (self.mu[t] is not None) for t in types},
-                          'N': {t: (self.N[t] is not None) for t in types}
-                         }
 
     @property
     def T(self):
@@ -170,11 +141,6 @@ class Ensemble(object):
         return self._N
 
     @property
-    def mu(self):
-        r""":class:`FixedKeyDict`: Chemical potential of each type."""
-        return self._mu
-
-    @property
     def types(self):
         r"""tuple: The types in the ensemble."""
         return self.N.keys
@@ -185,82 +151,9 @@ class Ensemble(object):
         return self.rdf.pairs
 
     @property
-    def constant(self):
-        r"""dict: The constant variables in the system.
-
-        Each key of the dictionary indicates which variables were defined as
-        constants when the Ensemble was constructed. The user **must not**
-        mutate the values in this dictionary.
-
-        """
-        return self._constant
-
-    def aka(self,name):
-        """Check if the ensemble is also known by a common type.
-
-        Parameters
-        ----------
-        name : str
-            Common name of a thermodynamic ensemble. The recognized names are:
-
-            - "NVT" or "canonical" for constant *N*, *V*, and *T*.
-            - "NPT or "isothermal-isobaric for constant *N*, *P*, and *T*.
-            - "muVT" or "grand canonical" for constant :math:`\mu`, *V*, and *T*.
-
-        Returns
-        -------
-        bool:
-            True if the ensemble matches the name, and False otherwise.
-
-        Raises
-        ------
-        ValueError:
-            The name is not one of the recognized types.
-
-        """
-        if name in ("NVT","canonical"):
-            return (self.constant['T'] and self.constant['V']
-                and all(self.constant['N'][t] for t in self.types))
-        elif name in ("NPT","isothermal-isobaric"):
-            return (self.constant['T'] and self.constant['P']
-                and all(self.constant['N'][t] for t in self.types))
-        elif name in ("muVT","grand canonical"):
-            return (self.constant['T'] and self.constant['V']
-                and all(self.constant['mu'][t] for t in self.types))
-        else:
-            raise ValueError("Ensemble name not recognized")
-
-
-    @property
     def rdf(self):
         r""":class:`PairMatrix`: Radial distribution function per pair."""
         return self._rdf
-
-    def clear(self):
-        r"""Clear the value of all conjugate (fluctuating) variables in the ensemble.
-
-        The values of the non-constant variables and all radial distribution
-        functions become None.
-
-        Returns
-        -------
-        :class:`Ensemble`
-            This Ensemble with cleared parameters.
-
-        """
-        if not self.constant['V']:
-            self._V = None
-        if not self.constant['P']:
-            self._P = None
-        for t in self.types:
-            if not self.constant['N'][t]:
-                self._N[t] = None
-            if not self.constant['mu'][t]:
-                self._mu[t] = None
-        for pair in self.rdf:
-            self.rdf[pair] = None
-
-        return self
 
     def copy(self):
         r"""Make a copy of the ensemble.
@@ -283,14 +176,12 @@ class Ensemble(object):
 
         """
         data = {'T': self.T,
-                'P': self.P,
+                'N': self.N.todict(),
                 'V': {'__name__':type(self.V).__name__,
                       'data':self.V.to_json()
                      },
-                'mu': self.mu.todict(),
-                'N': self.N.todict(),
+                'P': self.P,
                 'kB': self.kB,
-                'constant': self.constant,
                 'rdf': {}
                }
 
@@ -323,42 +214,23 @@ class Ensemble(object):
         with open(filename) as f:
             data = json.load(f)
 
-        # retrieve thermodynamic parameters
+        # create initial ensemble
         VolumeType = getattr(volume,data['V']['__name__'])
         thermo = {'T': data['T'],
-                  'P': data['P'],
+                  'N': data['N'],
                   'V': VolumeType.from_json(data['V']['data']),
-                  'mu': data['mu'],
-                  'N': data['N']
+                  'P': data['P'],
+                  'kB': data['kB']
                  }
+        ens = Ensemble(**thermo)
 
-        # create Ensemble with constant variables only
-        thermo_const = copy.deepcopy(thermo)
-        for var in thermo:
-            if var == 'mu' or var == 'N':
-                for t in thermo[var]:
-                    if not data['constant'][var][t]:
-                        thermo_const[var][t] = None
-            elif not data['constant'][var]:
-                thermo_const[var] = None
-        ens = Ensemble(kB=data['kB'],**thermo_const)
-
-        # then set values of fluctuating variables
-        for var in thermo:
-            if var == 'mu' or var == 'N':
-                for t in thermo[var]:
-                    if not data['constant'][var][t]:
-                        getattr(ens,var).update({t:thermo[var][t]})
-            elif not data['constant'][var]:
-                setattr(ens,var,thermo[var])
-
-        # set rdf values
+        # unpack rdfs
         for pair in ens.rdf:
             pair_ = str(pair)
             if data['rdf'][pair_] is None:
                 continue
             r = [i[0] for i in data['rdf'][pair_]]
             g = [i[1] for i in data['rdf'][pair_]]
-            ens.rdf[pair] = RDF(r=r, g=g)
+            ens.rdf[pair] = RDF(r,g)
 
         return ens

--- a/relentless/mpi.py
+++ b/relentless/mpi.py
@@ -75,7 +75,7 @@ class Communicator:
     ----------
     comm : :class:`mpi4py.MPI.Comm`
         Communicator backend. Defaults to ``None``, which is converted to
-        :class:`mpi4py.MPI.COMM_WORLD` if running under MPI.
+        :data:`mpi4py.MPI.COMM_WORLD` if running under MPI.
     root : int
         Root rank index (defaults to 0).
 

--- a/relentless/optimize/method.py
+++ b/relentless/optimize/method.py
@@ -82,7 +82,7 @@ class Optimizer(abc.ABC):
         objective : :class:`~relentless.optimize.objective.ObjectiveFunction`
             The objective function to be optimized.
         directory : :class:`~relentless.data.Directory`
-            Directory for writing output during optimization. Default of `None`
+            Directory for writing output during optimization. Default of ``None``
             requests no output is written.
 
         """
@@ -168,7 +168,7 @@ class LineSearch:
         end : :class:`~relentless.optimize.objective.ObjectiveFunctionResult`
             The objective function evaluated at the end of the search interval.
         directory : :class:`~relentless.data.Directory`
-            Directory for writing output during search. Default of `None`
+            Directory for writing output during search. Default of ``None``
             requests no output is written.
 
         Raises

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -113,7 +113,7 @@ class ObjectiveFunction(abc.ABC):
             with respect to which it is taken.
         directory : :class:`~relentless.data.Directory`
             Directory holding written output associated with result. Setting
-            a value of `None` indicates no written output.
+            a value of ``None`` indicates no written output.
 
         Returns
         -------
@@ -138,7 +138,7 @@ class ObjectiveFunctionResult:
         with respect to which it is taken.
     directory : :class:`~relentless.data.Directory`
         Directory holding written output associated with result. Setting
-        a value of `None` indicates no written output.
+        a value of ``None`` indicates no written output.
 
     """
     def __init__(self, objective, value, gradient, directory):
@@ -189,8 +189,8 @@ class RelativeEntropy(ObjectiveFunction):
     The relative entropy :math:`S_{\rm rel}` (or Kullback-Leibler divergence)
     quantifies the overlap of two probability distributions. For a known target
     statistical mechanical ensemble having distribution :math:`p_0` and a simulated
-    model ensemble having distribution *p* and parametrized on a set of design
-    variables **x**, the relative entropy from the model to the target is:
+    model ensemble having distribution :math:`p` and parametrized on a set of design
+    variables :math:`\mathbf{x}`, the relative entropy from the model to the target is:
 
     .. math::
 
@@ -204,8 +204,8 @@ class RelativeEntropy(ObjectiveFunction):
     The value of the relative entropy is not readily determined in  molecular
     simulations, so this :class:`ObjectiveFunction` does not return a value.
     However, the gradient of the relative entropy with respect to the design
-    variables **x** is much easier to compute as ensemble averages. Currently,
-    the :class:`RelativeEntropy` objective function supports only
+    variables :math:`\mathbf{x}` is much easier to compute as ensemble averages.
+    Currently, the :class:`RelativeEntropy` objective function supports only
     :class:`~relentless.potential.pair.PairPotential` interactions. These interactions
     are characterized by :math:`g_{ij}(r)`, an :class:`~relentless.ensemble.RDF`
     for each pair of interacting types :math:`(i,j)` in each
@@ -216,9 +216,9 @@ class RelativeEntropy(ObjectiveFunction):
         \nabla_\mathbf{x} S_{\rm rel} = -\frac{1}{2}\sum_{i,j}\int{dr\left(4\pi r^2\right)\left[\frac{\beta N_i N_j}{V} g_{ij}(r)-\frac{\beta_0 N_{i,0} N_{j,0}}{V_0} g_{ij,0}(r)\right]\nabla_\mathbf{x} u_{ij}(r)}
 
     where :math:`\beta=1/(k_{\rm B}T)`, :math:`N_i` is the number of particles
-    of type *i*, *V* is the volume, and :math:`u_{ij}(r)` is the pair potential
+    of type :math:`i`, :math:`V` is the volume, and :math:`u_{ij}(r)` is the pair potential
     in the *model* ensemble. The corresponding properties of the *target*
-    ensemble are denoted with subscript 0.
+    ensemble are denoted with subscript :math:`0`.
 
     :math:`S_{\rm rel}` is extensive as written, meaning that it depends on the
     size of the system. This can be undesirable for optimization because it means
@@ -229,14 +229,14 @@ class RelativeEntropy(ObjectiveFunction):
     Parameters
     ----------
     target : :class:`~relentless.ensemble.Ensemble`
-        The target ensemble (must have specified :math:`V` and :math:`N`).
+        The target ensemble (must have specified ``V`` and ``N``).
     simulation : :class:`~relentless.simulate.Simulation`
         The simulation engine to use, with specified simulation operations.
     potentials : :class:`~relentless.simulate.Potentials`
         The pair potentials to use in the simulations.
     thermo : :class:`~relentless.simulate.SimulationOperation`
         The thermodynamic analyzer operation for the simulation ensemble and rdf
-        (usually :meth:`AddEnsembleAnalyzer()`). The model ensemble will be
+        (usually :meth:`~relentless.simulate.AddEnsembleAnalyzer()`). The model ensemble will be
         extracted from this operation.
     communicator : :class:`~relentless.mpi.Communicator`
         The communicator used to run the ``simulation`` (defaults to
@@ -262,7 +262,7 @@ class RelativeEntropy(ObjectiveFunction):
         computationally expensive.
 
         Optionally, a directory can be specified both to write the simulation
-        output as defined in :meth:`Simulation.run()`, and the values of the pair
+        output as defined in :meth:`~relentless.simulate.Simulation.run()`, and the values of the pair
         potential design variables, which are written to ``potential.i.json``
         for the :math:`i`\th pair potential.
 
@@ -358,7 +358,7 @@ class RelativeEntropy(ObjectiveFunction):
     @property
     def target(self):
         r""":class:`~relentless.ensemble.Ensemble`: The target ensemble. Must have
-        both :math:`V` and :math:`N` parameters set."""
+        both ``V`` and ``N`` parameters set."""
         return self._target
 
     @target.setter

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -62,7 +62,7 @@ from . import potential
 class PairParameters(potential.Parameters):
     """Parameters for pairs of types.
 
-    A pair is a tuple of two types, and each type is a :class:`str`. A named
+    A pair is a tuple of two types, and each type is a `str`. A named
     list of parameters can be set for each pair of types. The parameters for a
     pair are assumed to be symmetric, so the pair *(i,j)* is the same as the
     pair *(j,i)*. An optional shared value can be set for any of the parameters,
@@ -237,7 +237,7 @@ class PairPotential(potential.Potential):
             \end{cases}.
 
     The pair potential can also be shifted to zero at :math:`r_{\rm max}`.
-    Shifting subtracts :math:`u_0(r_{\rm max})` from all pieces of u(r) and
+    Shifting subtracts :math:`u_0(r_{\rm max})` from all pieces of :math:`u(r)` and
     :math:`-f_0(r_{\rm max})` from all parameter derivatives. The force is
     unaffected by shifting the pair potential.
 
@@ -562,17 +562,17 @@ class Depletion(PairPotential):
         u(r) = -\frac{\pi P}{12 r} \left[\frac{1}{2}(\sigma_i+\sigma_j)+\sigma_d-r\right]^2
             \left[r^2+r(\sigma_i+\sigma_j+2\sigma_d)-\frac{3}{4}(\sigma_i-\sigma_j)^2\right]
 
-    where *r* is the distance between two particles. The parameters for
-    each *(i,j)* pair are:
+    where :math:`r` is the distance between two particles. The parameters for
+    each :math:`(i,j)` pair are:
 
     +-------------+--------------------------------------------------+-----------+
     | Parameter   | Description                                      | Initial   |
     +=============+==================================================+===========+
-    | ``P``       | Osmotic pressure *P* of depletant.               |           |
+    | ``P``       | Osmotic pressure :math:`P` of depletant.         |           |
     +-------------+--------------------------------------------------+-----------+
-    | ``sigma_i`` | Diameter :math:`\sigma_i` of type *i*.           |           |
+    | ``sigma_i`` | Diameter :math:`\sigma_i` of type :math:`i`.     |           |
     +-------------+--------------------------------------------------+-----------+
-    | ``sigma_j`` | Diameter :math:`\sigma_j` of type *j*.           |           |
+    | ``sigma_j`` | Diameter :math:`\sigma_j` of type :math:`j`.     |           |
     +-------------+--------------------------------------------------+-----------+
     | ``sigma_d`` | Diameter :math:`\sigma_d` of depletant.          |           |
     +-------------+--------------------------------------------------+-----------+
@@ -746,8 +746,8 @@ class LennardJones(PairPotential):
         u(r) = 4 \varepsilon\left[\left(\frac{\sigma}{r}\right)^{12}
                 - \left(\frac{\sigma}{r}\right)^6 \right]
 
-    where *r* is the distance between two particles. The parameters for
-    each *(i,j)* pair are:
+    where :math:`r` is the distance between two particles. The parameters for
+    each :math:`(i,j)` pair are:
 
     +-------------+-----------------------------------------------+-----------+
     | Parameter   | Description                                   | Initial   |
@@ -862,17 +862,17 @@ class PairSpline(PairPotential):
         Number of knots.
     mode : str
         Mode for storing the values of the knots in :class:`~relentless.variable.DesignVariable`
-        that can be optimized. If ``mode`` is 'value', the knot amplitudes are stored
-        directly. If ``mode`` is 'diff', the amplitude of the *last* knot is stored
+        that can be optimized. If ``mode='value'``, the knot amplitudes are stored
+        directly. If ``mode='diff'``, the amplitude of the *last* knot is stored
         directly, and differences between neighboring knots are stored for all
-        other knots. Defaults to 'diff'.
+        other knots. Defaults to ``'diff'``.
 
     Raises
     ------
     ValueError
         If there are not at least two knots.
     ValueError
-        If the mode is not 'value' or 'diff'.
+        If the mode is not ``'value'`` or ``'diff'``.
 
     Examples
     --------
@@ -1090,8 +1090,8 @@ class Yukawa(PairPotential):
 
         u(r) = \varepsilon \frac{e^{-\kappa r}}{r}
 
-    where *r* is the distance between two particles. The parameters for
-    each *(i,j)* pair are:
+    where :math:`r` is the distance between two particles. The parameters for
+    each :math:`(i,j)` pair are:
 
     +-------------+-----------------------------------------------+-----------+
     | Parameter   | Description                                   | Initial   |

--- a/relentless/potential/potential.py
+++ b/relentless/potential/potential.py
@@ -178,7 +178,7 @@ class Parameters:
 
     @property
     def shared(self):
-        """:class:`~relentless.FixedKeyDict`: The shared parameters."""
+        """:class:`~relentless._collections.FixedKeyDict`: The shared parameters."""
         return self._shared
 
 class Potential(abc.ABC):
@@ -216,7 +216,7 @@ class Potential(abc.ABC):
         key
             Key parametrizing the potential in :attr:`coeff<container>`.
         x : float or list
-            Potential coordinate.
+            Potential energy coordinate.
 
         Returns
         -------
@@ -238,7 +238,7 @@ class Potential(abc.ABC):
         key
             Key parametrizing the potential in :attr:`coeff<container>`.
         x : float or list
-            Potential coordinate.
+            Potential energy coordinate.
 
         Returns
         -------

--- a/relentless/simulate/__init__.py
+++ b/relentless/simulate/__init__.py
@@ -12,6 +12,15 @@ for generic simulation operations is provided:
 
     generic
 
+These operations are compatible with the following simulation interfaces:
+
+.. toctree::
+    :maxdepth: 1
+
+    dilute
+    hoomd
+    lammps
+
 .. automodule:: relentless.simulate.simulate
 
 """

--- a/relentless/simulate/__init__.py
+++ b/relentless/simulate/__init__.py
@@ -1,3 +1,20 @@
+"""
+Simulations
+===========
+
+A generalizable and human-readable interface for molecular simulations is provided.
+Molecular simulations are used to evolve a system described by a potential and
+generate ensemble-averaged descriptions of the system's properties. A framework
+for generic simulation operations is provided:
+
+.. toctree::
+    :maxdepth: 1
+
+    generic
+
+.. automodule:: relentless.simulate.simulate
+
+"""
 from .simulate import (Simulation,
                        SimulationInstance,
                        SimulationOperation,

--- a/relentless/simulate/dilute.py
+++ b/relentless/simulate/dilute.py
@@ -1,3 +1,16 @@
+"""
+Dilute system
+=============
+
+Provides the :meth:`EnzembleAnalyzer()` operation for a dilute system.
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: AddEnsembleAnalyzer
+    :members:
+
+"""
 import numpy as np
 
 from relentless.ensemble import RDF
@@ -58,7 +71,7 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
 
     def __call__(self, sim):
         r"""Creates a copy of the ensemble with cleared fluctuating/conjugate variables.
-        The pressure *P* and :math:`g(r)` parameters for the new ensemble are calculated
+        The pressure :math:`P` and :math:`g(r)` parameters for the new ensemble are calculated
         as follows:
 
         .. math::
@@ -77,10 +90,14 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
         Raises
         ------
         ValueError
-            If r and u are not both set in the potentials matrix.
+            If ``r`` and ``u`` are not both set in the potentials matrix.
 
         """
+        if not sim.ensemble.aka("NVT"):
+            raise ValueError('Dilute simulations must be run in the NVT ensemble.')
+
         ens = sim.ensemble.copy()
+        ens.clear()
 
         # pair distribution function
         for pair in ens.pairs:

--- a/relentless/simulate/dilute.py
+++ b/relentless/simulate/dilute.py
@@ -95,11 +95,7 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
             If ``r`` and ``u`` are not both set in the potentials matrix.
 
         """
-        if not sim.ensemble.aka("NVT"):
-            raise ValueError('Dilute simulations must be run in the NVT ensemble.')
-
         ens = sim.ensemble.copy()
-        ens.clear()
 
         # pair distribution function
         for pair in ens.pairs:

--- a/relentless/simulate/dilute.py
+++ b/relentless/simulate/dilute.py
@@ -2,13 +2,15 @@
 Dilute system
 =============
 
-Provides the :meth:`EnzembleAnalyzer()` operation for a dilute system.
+Provides the :meth:`AddEnzembleAnalyzer()` operation for a dilute system.
 
 .. autosummary::
     :nosignatures:
 
 .. autoclass:: AddEnsembleAnalyzer
-    :members:
+    :member-order: bysource
+    :members: __call__,
+        extract_ensemble
 
 """
 import numpy as np

--- a/relentless/simulate/generic.py
+++ b/relentless/simulate/generic.py
@@ -1,3 +1,49 @@
+"""
+Generic simulation operations
+=============================
+
+.. toctree::
+    :maxdepth: 1
+
+    dilute
+    hoomd
+    lammps
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: GenericOperation
+    :members:
+.. autoclass:: InitializeFromFile
+    :members:
+.. autoclass:: InitializeRandomly
+    :members:
+.. autoclass:: MinimizeEnergy
+    :members:
+.. autoclass:: AddBrownianIntegrator
+    :members:
+.. autoclass:: RemoveBrownianIntegrator
+    :members:
+.. autoclass:: AddLangevinIntegrator
+    :members:
+.. autoclass:: RemoveLangevinIntegrator
+    :members:
+.. autoclass:: AddNPTIntegrator
+    :members:
+.. autoclass:: RemoveNPTIntegrator
+    :members:
+.. autoclass:: AddNVTIntegrator
+    :members:
+.. autoclass:: RemoveNVTIntegrator
+    :members:
+.. autoclass:: Run
+    :members:
+.. autoclass:: RunUpTo
+    :members:
+.. autoclass:: AddEnsembleAnalyzer
+    :members:
+
+"""
 import importlib
 import inspect
 
@@ -73,8 +119,8 @@ class GenericOperation(simulate.SimulationOperation):
         ----------
         backend : :class:`Simulation`
             Class to add as a backend.
-        module : module or str or `None`
-            Module in which the backend is defined. If `None` (default), try to
+        module : module or str or ``None``
+            Module in which the backend is defined. If ``None`` (default), try to
             deduce the module from ``backend.__module__``. ``module`` will be
             imported if it has not already been.
 
@@ -299,7 +345,7 @@ class AddEnsembleAnalyzer(GenericOperation):
     check_rdf_every : int
         Interval of time steps at which to log the rdf of the simulation.
     rdf_dr : float
-        The width (in units *r*) of a bin in the histogram of the rdf.
+        The width (in units ``r``) of a bin in the histogram of the rdf.
 
     """
     def __init__(self, check_thermo_every, check_rdf_every, rdf_dr):

--- a/relentless/simulate/generic.py
+++ b/relentless/simulate/generic.py
@@ -2,6 +2,16 @@
 Generic simulation operations
 =============================
 
+A common set of generic simulation operations for all the compatible simulation
+interfaces (HOOMD-blue, LAMMPS, dilute system) is provided. This grants the user
+immense ease of use as a single command can be used to achieve the same function
+using multiple simulation packages. The supported generic operations are initialization
+of a system from file or randomly, energy minimization, simulation run, and a number
+of integrators (Brownian, Langevin, NPT, NVT), as well as an operation to extract
+the model ensemble and RDF at a given timestep interval.
+
+The generic simulation operations are compatible with the following simulation packages:
+
 .. toctree::
     :maxdepth: 1
 

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -73,7 +73,7 @@ except ImportError:
     _freud_found = False
 
 class HOOMD(simulate.Simulation):
-    """:class:`Simulation` using HOOMD framework.
+    """:class:`~relentless.simulation.Simulation` using HOOMD framework.
 
     Raises
     ------
@@ -132,7 +132,7 @@ class Initialize(simulate.SimulationOperation):
 
         Parameters
         ----------
-        sim : :class:`Simulation`
+        sim : :class:`~relentless.simulation.Simulation`
             Simulation object.
 
         Returns
@@ -174,7 +174,7 @@ class Initialize(simulate.SimulationOperation):
 
         Returns
         -------
-        :module:`hoomd.data` snapshot
+        :class:`hoomd.data` snapshot
             Particle simulation snapshot.
         :class:`freud.Box`
             Particle simulation box.

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -1,3 +1,53 @@
+"""
+HOOMD operations
+================
+
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: HOOMD
+    :members:
+.. autoclass:: Initialize
+    :members:
+.. autoclass:: InitializeFromFile
+    :members:
+.. autoclass:: InitializeRandomly
+    :members:
+.. autoclass:: MinimizeEnergy
+    :members:
+.. autoclass:: AddMDIntegrator
+    :members:
+.. autoclass:: RemoveMDIntegrator
+    :members:
+.. autoclass:: AddBrownianIntegrator
+    :members:
+.. autoclass:: RemoveBrownianIntegrator
+    :members:
+.. autoclass:: AddLangevinIntegrator
+    :members:
+.. autoclass:: RemoveLangevinIntegrator
+    :members:
+.. autoclass:: AddNPTIntegrator
+    :members:
+.. autoclass:: RemoveNPTIntegrator
+    :members:
+.. autoclass:: AddNVTIntegrator
+    :members:
+.. autoclass:: RemoveNVTIntegrator
+    :members:
+.. autoclass:: Run
+    :members:
+.. autoclass:: RunUpTo
+    :members:
+.. autoclass:: ThermodynamicsCallback
+    :members:
+.. autoclass:: RDFCallback
+    :members:
+.. autoclass:: AddEnsembleAnalyzer
+    :members:
+
+"""
 import os
 from packaging import version
 
@@ -28,9 +78,9 @@ class HOOMD(simulate.Simulation):
     Raises
     ------
     ImportError
-        If the `hoomd` package is not found, or is not version 2.x.
+        If the ``hoomd`` package is not found, or is not version 2.x.
     ImportError
-        If the `freud` package is not found, or is not version 2.x.
+        If the ``freud`` package is not found, or is not version 2.x.
 
     """
     def __init__(self, operations=None, **options):
@@ -77,7 +127,7 @@ class Initialize(simulate.SimulationOperation):
         self.neighbor_buffer = neighbor_buffer
 
     def extract_box_params(self, sim):
-        """Extracts HOOMD box parameters (*Lx*, *Ly*, *Lz*, *xy*, *xz*, *yz*)
+        """Extracts HOOMD box parameters (``Lx``, ``Ly``, ``Lz``, ``xy``, ``xz``, ``yz``)
         from the simulation's ensemble volume.
 
         Parameters
@@ -95,7 +145,7 @@ class Initialize(simulate.SimulationOperation):
         ValueError
             If the volume is not set.
         TypeError
-            If the volume does not derive from :class:`TriclinicBox`.
+            If the volume does not derive from :class:`~relentless.volume.TriclinicBox`.
 
         """
         # cast simulation box in HOOMD parameters
@@ -124,7 +174,7 @@ class Initialize(simulate.SimulationOperation):
 
         Returns
         -------
-        `hoomd.data` snapshot
+        :module:`hoomd.data` snapshot
             Particle simulation snapshot.
         :class:`freud.Box`
             Particle simulation box.
@@ -167,7 +217,7 @@ class Initialize(simulate.SimulationOperation):
         Raises
         ------
         ValueError
-            If the length of the *r*, *u*, and *f* arrays are not all equal.
+            If the length of the ``r``, ``u``, and ``f`` arrays are not all equal.
 
         """
         with sim.context:
@@ -231,7 +281,7 @@ class InitializeFromFile(Initialize):
             sim.system = hoomd.init.read_gsd(self.filename,**self.options)
 
             # check that the boxes are consistent in constant volume sims.
-            if sim.ensemble.V is not None:
+            if sim.ensemble.constant['V']:
                 system_box = sim.system.box
                 box_from_file = np.array([system_box.Lx,
                                           system_box.Ly,
@@ -440,7 +490,7 @@ class AddBrownianIntegrator(AddMDIntegrator):
     seed : int
         Seed used to randomly generate a uniform force.
     options : kwargs
-        Options used in :class:`hoomd.md.integrate.brownian()`.
+        Options used in :meth:`hoomd.md.integrate.brownian()`.
 
     """
     def __init__(self, dt, friction, seed, **options):
@@ -456,11 +506,6 @@ class AddBrownianIntegrator(AddMDIntegrator):
         ----------
         sim : :class:`Simulation`
             The simulation object.
-
-        Raises
-        ------
-        ValueError
-            If the simulation ensemble is not NVT.
 
         """
         self.attach_integrator(sim)
@@ -508,7 +553,7 @@ class AddLangevinIntegrator(AddMDIntegrator):
     seed : int
         Seed used to randomly generate a uniform force.
     options : kwargs
-        Options used in :class:`hoomd.md.integrate.langevin()`.
+        Options used in :meth:`hoomd.md.integrate.langevin()`.
 
     """
     def __init__(self, dt, friction, seed, **options):
@@ -524,11 +569,6 @@ class AddLangevinIntegrator(AddMDIntegrator):
         ----------
         sim : :class:`Simulation`
             The simulation object.
-
-        Raises
-        ------
-        ValueError
-            If the simulation ensemble is not NVT.
 
         """
         self.attach_integrator(sim)
@@ -576,7 +616,7 @@ class AddNPTIntegrator(AddMDIntegrator):
     tau_P : float
         Coupling constant for the barostat.
     options : kwargs
-        Options used in :class:`hoomd.md.integrate.npt()`.
+        Options used in :meth:`hoomd.md.integrate.npt()`.
 
     """
     def __init__(self, dt, tau_T, tau_P, **options):
@@ -592,11 +632,6 @@ class AddNPTIntegrator(AddMDIntegrator):
         ----------
         sim : :class:`Simulation`
             The simulation object.
-
-        Raises
-        ------
-        ValueError
-            If the simulation ensemble is not NPT.
 
         """
         self.attach_integrator(sim)
@@ -643,7 +678,7 @@ class AddNVTIntegrator(AddMDIntegrator):
     tau_T : float
         Coupling constant for the thermostat.
     options : kwargs
-        Options used in :class:`hoomd.md.integrate.nvt()`.
+        Options used in :meth:`hoomd.md.integrate.nvt()`.
 
     """
     def __init__(self, dt, tau_T, **options):
@@ -658,11 +693,6 @@ class AddNVTIntegrator(AddMDIntegrator):
         ----------
         sim : :class:`Simulation`
             The simulation object.
-
-        Raises
-        ------
-        ValueError
-            If the simulation ensemble is not NVT.
 
         """
         self.attach_integrator(sim)
@@ -730,7 +760,7 @@ class ThermodynamicsCallback:
 
     Parameters
     ----------
-    logger : `hoomd.analyze` logger
+    logger : :module:`hoomd.analyze` logger
         Logger from which to retrieve data.
     communicator : :class:`~relentless.mpi.Communicator`
         The MPI communicator to use.
@@ -763,7 +793,7 @@ class ThermodynamicsCallback:
             self._V[key] += val
 
     def reset(self):
-        """Resets sample number, *T*, *P*, and all *V* parameters to 0."""
+        """Resets sample number, ``T``, ``P``, and all ``V`` parameters to 0."""
         self.num_samples = 0
         self._T = 0.
         self._P = 0.
@@ -877,9 +907,12 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
         Raises
         ------
         ValueError
-            If the simulation ensemble does not have constant N.
+            If the simulation ensemble does not have constant ``N``.
 
         """
+        if not all([sim.ensemble.constant['N'][t] for t in sim.ensemble.types]):
+            return ValueError('This analyzer requires constant N.')
+
         with sim.context:
             # thermodynamic properties
             sim[self].logger = hoomd.analyze.log(filename=None,
@@ -916,6 +949,7 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
 
         """
         ens = sim.ensemble.copy()
+        ens.clear()
 
         thermo_recorder = sim[self].thermo_callback
         ens.T = thermo_recorder.T

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -2,6 +2,7 @@
 HOOMD operations
 ================
 
+Implements the generic simulation operations using HOOMD-blue.
 
 .. autosummary::
     :nosignatures:
@@ -281,7 +282,7 @@ class InitializeFromFile(Initialize):
             sim.system = hoomd.init.read_gsd(self.filename,**self.options)
 
             # check that the boxes are consistent in constant volume sims.
-            if sim.ensemble.constant['V']:
+            if sim.ensemble.V is not None:
                 system_box = sim.system.box
                 box_from_file = np.array([system_box.Lx,
                                           system_box.Ly,
@@ -910,9 +911,6 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
             If the simulation ensemble does not have constant ``N``.
 
         """
-        if not all([sim.ensemble.constant['N'][t] for t in sim.ensemble.types]):
-            return ValueError('This analyzer requires constant N.')
-
         with sim.context:
             # thermodynamic properties
             sim[self].logger = hoomd.analyze.log(filename=None,
@@ -949,7 +947,6 @@ class AddEnsembleAnalyzer(simulate.SimulationOperation):
 
         """
         ens = sim.ensemble.copy()
-        ens.clear()
 
         thermo_recorder = sim[self].thermo_callback
         ens.T = thermo_recorder.T

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -2,6 +2,7 @@
 LAMMPS operations
 =================
 
+Implements the generic simulation operations using LAMMPS.
 
 .. autosummary::
     :nosignatures:
@@ -504,7 +505,7 @@ class AddNPTIntegrator(LAMMPSOperation):
         self._fix = super().new_fix_id()
 
     def to_commands(self, sim):
-       cmds = ['fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp} iso {Pstart} {Pstop} {Pdamp}'.format(idx=self._fix,
+        cmds = ['fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp} iso {Pstart} {Pstop} {Pdamp}'.format(idx=self._fix,
                                                                                                               group_idx='all',
                                                                                                               Tstart=sim.ensemble.T,
                                                                                                               Tstop=sim.ensemble.T,
@@ -513,7 +514,7 @@ class AddNPTIntegrator(LAMMPSOperation):
                                                                                                               Pstop=sim.ensemble.P,
                                                                                                               Pdamp=self.tau_P)]
 
-       return cmds
+        return cmds
 
 class RemoveNPTIntegrator(LAMMPSOperation):
     """Removes the NPT integrator operation.
@@ -644,9 +645,6 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
         self.rdf_dr = rdf_dr
 
     def to_commands(self, sim):
-        if not all([sim.ensemble.constant['N'][t] for t in sim.ensemble.types]):
-            return ValueError('This analyzer requires constant N.')
-
         # check that IDs reserved for analysis do not yet exist
         reserved_ids = (('fix','thermo_avg'),
                         ('compute','rdf'),
@@ -723,7 +721,6 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
 
         """
         ens = sim.ensemble.copy()
-        ens.clear()
 
         # extract thermo properties
         # we skip the first 2 rows, which are LAMMPS junk, and slice out the timestep from col. 0

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -513,7 +513,7 @@ class AddNPTIntegrator(LAMMPSOperation):
                                                                                                               Pstop=sim.ensemble.P,
                                                                                                               Pdamp=self.tau_P)]
 
-        return cmds
+       return cmds
 
 class RemoveNPTIntegrator(LAMMPSOperation):
     """Removes the NPT integrator operation.

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -1,3 +1,43 @@
+"""
+LAMMPS operations
+=================
+
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: LAMMPS
+    :members:
+.. autoclass:: LAMMPSOperation
+    :members:
+.. autoclass:: Initialize
+    :members:
+.. autoclass:: InitializeFromFile
+    :members:
+.. autoclass:: InitializeRandomly
+    :members:
+.. autoclass:: MinimizeEnergy
+    :members:
+.. autoclass:: AddLangevinIntegrator
+    :members:
+.. autoclass:: RemoveLangevinIntegrator
+    :members:
+.. autoclass:: AddNPTIntegrator
+    :members:
+.. autoclass:: RemoveNPTIntegrator
+    :members:
+.. autoclass:: AddNVTIntegrator
+    :members:
+.. autoclass:: RemoveNVTIntegrator
+    :members:
+.. autoclass:: Run
+    :members:
+.. autoclass:: RunUpTo
+    :members:
+.. autoclass:: AddEnsembleAnalyzer
+    :members:
+
+"""
 import abc
 import os
 
@@ -22,7 +62,7 @@ class LAMMPS(simulate.Simulation):
     Raises
     ------
     ImportError
-        If the `lammps` package is not found.
+        If the ``lammps`` package is not found.
 
     """
     def __init__(self, operations=None, quiet=True, **options):
@@ -120,9 +160,9 @@ class Initialize(LAMMPSOperation):
     neighbor_buffer : float
         Buffer width.
     units : str
-        The LAMMPS style of units used in the simulation (defaults to `lj`).
+        The LAMMPS style of units used in the simulation (defaults to ``lj``).
     atom_style : str
-        The LAMMPS style of atoms used in a simulation (defaults to `atomic`).
+        The LAMMPS style of atoms used in a simulation (defaults to ``atomic``).
 
     """
     def __init__(self, neighbor_buffer, units='lj', atom_style='atomic'):
@@ -138,7 +178,7 @@ class Initialize(LAMMPSOperation):
         return cmds
 
     def extract_box_params(self, sim):
-        """Extracts LAMMPS box parameters (*Lx*, *Ly*, *Lz*, *xy*, *xz*, *yz*)
+        """Extracts LAMMPS box parameters (``Lx``, ``Ly``, ``Lz``, ``xy``, ``xz``, ``yz``)
         from the simulation's ensemble volume.
 
         Parameters
@@ -156,7 +196,7 @@ class Initialize(LAMMPSOperation):
         ValueError
             If the volume is not set.
         TypeError
-            If the volume does not derive from :class:`TriclinicBox`.
+            If the volume does not derive from :class:`~relentless.volume.TriclinicBox`.
 
         """
         # cast simulation box in LAMMPS parameters
@@ -196,7 +236,7 @@ class Initialize(LAMMPSOperation):
         ValueError
             If there are not at least two points in the tabulated potential.
         ValueError
-            If the pair potentials do not have equally spaced r.
+            If the pair potentials do not have equally spaced ``r``.
 
         """
         # lammps requires r > 0
@@ -264,9 +304,9 @@ class InitializeFromFile(Initialize):
     neighbor_buffer : float
         Buffer width.
     units : str
-        The LAMMPS style of units used in the simulation (defaults to `lj`).
+        The LAMMPS style of units used in the simulation (defaults to ``lj``).
     atom_style : str
-        The LAMMPS style of atoms used in a simulation (defaults to `atomic`).
+        The LAMMPS style of atoms used in a simulation (defaults to ``atomic``).
 
     """
     def __init__(self, filename, neighbor_buffer, units='lj', atom_style='atomic'):
@@ -292,9 +332,9 @@ class InitializeRandomly(Initialize):
     neighbor_buffer : float
         Buffer width.
     units : str
-        The LAMMPS style of units used in the simulation (defaults to `lj`).
+        The LAMMPS style of units used in the simulation (defaults to ``lj``).
     atom_style : str
-        The LAMMPS style of atoms used in a simulation (defaults to `atomic`).
+        The LAMMPS style of atoms used in a simulation (defaults to ``atomic``).
 
     """
     def __init__(self, seed, neighbor_buffer, units='lj', atom_style='atomic'):
@@ -359,7 +399,7 @@ class MinimizeEnergy(LAMMPSOperation):
 class AddLangevinIntegrator(LAMMPSOperation):
     """Langevin dynamics for a NVE ensemble.
 
-    The simulation ensemble must be NVT, with all per-type particle masses set.
+    The simulation ensemble must have all per-type particle masses set.
     The friction factor can be a single value or defined per-type for all types.
 
     Parameters
@@ -447,8 +487,6 @@ class RemoveLangevinIntegrator(LAMMPSOperation):
 class AddNPTIntegrator(LAMMPSOperation):
     r"""NPT integration via Nos\'e-Hoover thermostat/barostat.
 
-    The simulation ensemble must be NPT.
-
     Parameters
     ----------
     dt : float
@@ -466,7 +504,7 @@ class AddNPTIntegrator(LAMMPSOperation):
         self._fix = super().new_fix_id()
 
     def to_commands(self, sim):
-        cmds = ['fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp} iso {Pstart} {Pstop} {Pdamp}'.format(idx=self._fix,
+       cmds = ['fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp} iso {Pstart} {Pstop} {Pdamp}'.format(idx=self._fix,
                                                                                                               group_idx='all',
                                                                                                               Tstart=sim.ensemble.T,
                                                                                                               Tstop=sim.ensemble.T,
@@ -503,8 +541,6 @@ class RemoveNPTIntegrator(LAMMPSOperation):
 
 class AddNVTIntegrator(LAMMPSOperation):
     r"""NVT integration via Nos\'e-Hoover thermostat.
-
-    The simulation ensemble must be NVT.
 
     Parameters
     ----------
@@ -589,8 +625,8 @@ class RunUpTo(LAMMPSOperation):
 class AddEnsembleAnalyzer(LAMMPSOperation):
     """Analyzes the simulation ensemble and rdf at specified timestep intervals.
 
-    The simulation ensemble must have constant N, and only one LAMMPS
-    :class:AddEnsembleAnalyzer` can be initialized at a time.
+    The simulation ensemble must have constant ``N``, and only one LAMMPS
+    :class:`AddEnsembleAnalyzer` can be initialized at a time.
 
     Parameters
     ----------
@@ -599,7 +635,7 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
     check_rdf_every : int
         Interval of time steps at which to log the rdf of the simulation.
     rdf_dr : float
-        The width (in units *r*) of a bin in the histogram of the rdf.
+        The width (in units ``r``) of a bin in the histogram of the rdf.
 
     """
     def __init__(self, check_thermo_every, check_rdf_every, rdf_dr):
@@ -608,6 +644,9 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
         self.rdf_dr = rdf_dr
 
     def to_commands(self, sim):
+        if not all([sim.ensemble.constant['N'][t] for t in sim.ensemble.types]):
+            return ValueError('This analyzer requires constant N.')
+
         # check that IDs reserved for analysis do not yet exist
         reserved_ids = (('fix','thermo_avg'),
                         ('compute','rdf'),
@@ -684,6 +723,7 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
 
         """
         ens = sim.ensemble.copy()
+        ens.clear()
 
         # extract thermo properties
         # we skip the first 2 rows, which are LAMMPS junk, and slice out the timestep from col. 0

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -1,3 +1,33 @@
+"""
+Simulation interface
+====================
+
+Molecular simulation runs are performed in a :class:`Simulation` ensemble container,
+which initializes and runs a set of :class:`SimulationOperations`. Each simulation
+run requires the input of an ensemble, the interaction potentials, a directory
+to write the output data, and an optional MPI communicator to use, which are all
+used to construct a :class:`SimulationInstance`.
+
+The simulations can use a combination of multiple :class:`~relentless.potential.Potential`s or
+:class:`~relentless.potential.PairPotential`s tabulated together, the interface for
+which is given here using :class:`Potentials` and the tabulators :class:`PotentialTabulator`
+and :class:`PairPotentialTabulator`.
+
+.. autosummary::
+    :nosignatures:
+
+.. autoclass:: Simulation
+    :members:
+.. autoclass:: SimulationInstance
+    :members:
+.. autoclass:: Potentials
+    :members:
+.. autoclass:: PotentialTabulator
+    :members:
+.. autoclass:: PairPotentialTabulator
+    :members:
+
+"""
 import abc
 
 import numpy as np
@@ -34,7 +64,7 @@ class Simulation:
         Parameters
         ----------
         ensemble : :class:`Ensemble`
-            Simulation ensemble. Must include values for *N* and *V* even if
+            Simulation ensemble. Must include values for ``N`` and ``V`` even if
             these variables fluctuate.
         potentials : :class:`Potentials`
             The interaction potentials.
@@ -93,7 +123,7 @@ class SimulationInstance:
     backend : type
         Type of the simulation class.
     ensemble : :class:`Ensemble`
-        Simulation ensemble. Must include values for *N* and *V* even if
+        Simulation ensemble. Must include values for ``N`` and ``V`` even if
         these variables fluctuate.
     potentials : :class:`Potentials`
         The interaction potentials.
@@ -133,12 +163,12 @@ class Potentials:
 
     Iniitializes a :class:`PairPotentialTabulator` object that can store multiple potentials.
     Before the :class:`Potentials` object can be used, the ``rmax`` and ``num``
-    attributes of all ``pair``s (that are not `None`) must be set.
+    attributes of all ``pair``s (that are not ``None``) must be set.
 
     Parameters
     ----------
     pair_potentials : array_like
-        The pair potentials to be combined and tabulated. (Defaults to `None`,
+        The pair potentials to be combined and tabulated. (Defaults to ``None``,
         resulting in an empty :class:`PairPotentialTabulator` object).
 
     """
@@ -154,19 +184,19 @@ class PotentialTabulator:
     """Tabulates one or more potentials.
 
     Enables evaluation of energy, force, and derivative at different
-    positional values (i.e. *x*).
+    positional values (i.e. ``x``).
 
     Parameters
     ----------
     start : float
-        The positional value of *x* at which to begin tabulation.
+        The positional value of ``x`` at which to begin tabulation.
     stop : float
-        The positional value of *x* at which to end tabulation.
+        The positional value of ``x`` at which to end tabulation.
     num : int
-        The number of points (value of *x*) at which to tabulate and evaluate the potential.
+        The number of points (value of ``x``) at which to tabulate and evaluate the potential.
     potentials : :class:`Potential` or array_like
         The potential(s) to be tabulated. If array_like, all elements must
-        be :class:`Potential`s. (Defaults to `None`).
+        be :class:`Potential`s. (Defaults to ``None``).
 
     """
     def __init__(self, start, stop, num, potentials=None):
@@ -192,7 +222,7 @@ class PotentialTabulator:
 
     @property
     def start(self):
-        """float: The *x* value at which to start tabulation."""
+        """float: The ``x`` value at which to start tabulation."""
         return self._start
 
     @start.setter
@@ -202,7 +232,7 @@ class PotentialTabulator:
 
     @property
     def stop(self):
-        """float: The *x* value at which to stop tabulation."""
+        """float: The ``x`` value at which to stop tabulation."""
         return self._stop
 
     @stop.setter
@@ -225,7 +255,7 @@ class PotentialTabulator:
 
     @property
     def x(self):
-        """array_like: The values of *x* at which to evaluate energy, force, and derivative."""
+        """array_like: The values of ``x`` at which to evaluate :meth:`energy`, :meth:`force`, and :meth:`derivative`."""
         if self._compute_x:
             if self.start is None:
                 raise ValueError('Start of range must be set.')
@@ -248,7 +278,7 @@ class PotentialTabulator:
         Returns
         -------
         array_like
-            Accumulated energy at each *x* value.
+            Accumulated energy at each ``x`` value.
 
         """
         u = np.zeros_like(self.x)
@@ -270,7 +300,7 @@ class PotentialTabulator:
         Returns
         -------
         array_like
-            Accumulated force at each *x* value.
+            Accumulated force at each ``x`` value.
 
         """
         f = np.zeros_like(self.x)
@@ -292,7 +322,7 @@ class PotentialTabulator:
         Returns
         -------
         array_like
-            Accumulated force at each *x* value.
+            Accumulated force at each ``x`` value.
 
         """
         d = np.zeros_like(self.x)
@@ -307,17 +337,17 @@ class PairPotentialTabulator(PotentialTabulator):
     """Tabulates one or more pair potentials.
 
     Enables evaluation of energy, force, and derivative at different
-    positional values (i.e. *r*).
+    positional values (i.e. ``r``).
 
     Parameters
     ----------
     rmax : float
-        The maximum value of *r* at which to tabulate.
+        The maximum value of ``r`` at which to tabulate.
     num : int
-        The number of points (value of *r) at which to tabulate and evaluate the potential.
+        The number of points (value of ``r``) at which to tabulate and evaluate the potential.
     potentials : :class:`PairPotential` or array_like
         The pair potential(s) to be tabulated. If array_like, all elements must
-        be :class:`PairPotential`s. (Defaults to `None`).
+        be :class:`PairPotential`s. (Defaults to ``None``).
     fmax : float
         The maximum value of force at which to allow evaluation.
 
@@ -328,12 +358,12 @@ class PairPotentialTabulator(PotentialTabulator):
 
     @property
     def r(self):
-        """array_like: The values of *r* at which to evaluate energy, force, and derivative."""
+        """array_like: The values of ``r`` at which to evaluate :meth:`energy`, :meth:`force`, and :meth:`derivative`."""
         return self.x
 
     @property
     def rmax(self):
-        """float: The maximum value of *r* at which to allow tabulation."""
+        """float: The maximum value of ``r`` at which to allow tabulation."""
         return self.stop
 
     @rmax.setter
@@ -355,7 +385,7 @@ class PairPotentialTabulator(PotentialTabulator):
     def energy(self, pair):
         """Evaluates and accumulates energy for all potentials.
 
-        Shifts the energy to be 0 at rmax.
+        Shifts the energy to be 0 at :attr:``rmax``.
 
         Parameters
         ----------
@@ -365,7 +395,7 @@ class PairPotentialTabulator(PotentialTabulator):
         Returns
         -------
         array_like
-            Accumulated energy at each *r* value.
+            Accumulated energy at each ``r`` value.
 
         """
         u = super().energy(pair)
@@ -385,7 +415,7 @@ class PairPotentialTabulator(PotentialTabulator):
         Returns
         -------
         array_like
-            Accumulated force at each *r* value.
+            Accumulated force at each ``r`` value.
 
         """
         f = super().force(pair)
@@ -398,7 +428,7 @@ class PairPotentialTabulator(PotentialTabulator):
     def derivative(self, pair, var):
         """Evaluates and accumulates derivative for all potentials.
 
-        Shifts the derivative to be 0 at rmax.
+        Shifts the derivative to be 0 at :attr:`rmax`.
 
         Parameters
         ----------
@@ -408,7 +438,7 @@ class PairPotentialTabulator(PotentialTabulator):
         Returns
         -------
         array_like
-            Accumulated derivative at each *r* value.
+            Accumulated derivative at each ``r`` value.
 
         """
         d = super().derivative(pair, var)

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -3,13 +3,13 @@ Simulation interface
 ====================
 
 Molecular simulation runs are performed in a :class:`Simulation` ensemble container,
-which initializes and runs a set of :class:`SimulationOperations`. Each simulation
+which initializes and runs a set of :class:`SimulationOperation`s. Each simulation
 run requires the input of an ensemble, the interaction potentials, a directory
 to write the output data, and an optional MPI communicator to use, which are all
 used to construct a :class:`SimulationInstance`.
 
-The simulations can use a combination of multiple :class:`~relentless.potential.Potential`s or
-:class:`~relentless.potential.PairPotential`s tabulated together, the interface for
+The simulations can use a combination of multiple :class:`~relentless.potential.Potential`\s or
+:class:`~relentless.potential.PairPotential`\s tabulated together, the interface for
 which is given here using :class:`Potentials` and the tabulators :class:`PotentialTabulator`
 and :class:`PairPotentialTabulator`.
 
@@ -19,6 +19,8 @@ and :class:`PairPotentialTabulator`.
 .. autoclass:: Simulation
     :members:
 .. autoclass:: SimulationInstance
+    :members:
+.. autoclass:: SimulationOperation
     :members:
 .. autoclass:: Potentials
     :members:
@@ -43,7 +45,7 @@ class Simulation:
     Parameters
     ----------
     operations : array_like
-        Array of :class:`SimulationOperation` to call.
+        Array of :class:`SimulationOperation`s to call.
     options : kwargs
         Optional arguments to attach to each instance of a simulation.
 
@@ -63,12 +65,12 @@ class Simulation:
 
         Parameters
         ----------
-        ensemble : :class:`Ensemble`
+        ensemble : :class:`~relentless.ensemble.Ensemble`
             Simulation ensemble. Must include values for ``N`` and ``V`` even if
             these variables fluctuate.
         potentials : :class:`Potentials`
             The interaction potentials.
-        directory : :class:`Directory`
+        directory : :class:`~relentless.data.Directory`
             Directory to use for writing data.
         communicator: :class:`~relentless.mpi.Communicator`
             The MPI communicator to use. Defaults to ``None``.
@@ -122,12 +124,12 @@ class SimulationInstance:
     ----------
     backend : type
         Type of the simulation class.
-    ensemble : :class:`Ensemble`
+    ensemble : :class:`~relentless.ensemble.Ensemble`
         Simulation ensemble. Must include values for ``N`` and ``V`` even if
         these variables fluctuate.
     potentials : :class:`Potentials`
         The interaction potentials.
-    directory : :class:`Directory`
+    directory : :class:`~relentless.data.Directory`
         Directory for output.
     communicator: :class:`~relentless.mpi.Communicator`
         The MPI communicator to use.
@@ -194,9 +196,9 @@ class PotentialTabulator:
         The positional value of ``x`` at which to end tabulation.
     num : int
         The number of points (value of ``x``) at which to tabulate and evaluate the potential.
-    potentials : :class:`Potential` or array_like
+    potentials : :class:`~relentless.potential.Potential` or array_like
         The potential(s) to be tabulated. If array_like, all elements must
-        be :class:`Potential`s. (Defaults to ``None``).
+        be :class:`~relentless.potential.Potential`\s. (Defaults to ``None``).
 
     """
     def __init__(self, start, stop, num, potentials=None):
@@ -345,9 +347,9 @@ class PairPotentialTabulator(PotentialTabulator):
         The maximum value of ``r`` at which to tabulate.
     num : int
         The number of points (value of ``r``) at which to tabulate and evaluate the potential.
-    potentials : :class:`PairPotential` or array_like
+    potentials : :class:`~relentless.potential.PairPotential` or array_like
         The pair potential(s) to be tabulated. If array_like, all elements must
-        be :class:`PairPotential`s. (Defaults to ``None``).
+        be :class:`~relentless.potential.PairPotential`\s. (Defaults to ``None``).
     fmax : float
         The maximum value of force at which to allow evaluation.
 
@@ -385,7 +387,7 @@ class PairPotentialTabulator(PotentialTabulator):
     def energy(self, pair):
         """Evaluates and accumulates energy for all potentials.
 
-        Shifts the energy to be 0 at :attr:``rmax``.
+        Shifts the energy to be 0 at :property:``rmax``.
 
         Parameters
         ----------

--- a/relentless/variable.py
+++ b/relentless/variable.py
@@ -326,7 +326,7 @@ class DependentVariable(Variable):
 
     Dependencies are typically other :class:`Variable` objects, but they can also
     be set to scalar values. In these case, the scalar is converted to an
-    :class:`IndepedentVariable` first.
+    :class:`IndependentVariable` first.
 
     Parameters
     ----------
@@ -562,7 +562,7 @@ class BinaryOperator(DependentVariable):
 class ArithmeticMean(BinaryOperator):
     r"""Arithmetic mean of two values.
 
-    The arithmetic mean *v* of two values *a* and *b* is:
+    The arithmetic mean :math:`v` of two values :math:`a` and :math:`b` is:
 
     .. math::
 
@@ -593,7 +593,7 @@ class ArithmeticMean(BinaryOperator):
 class GeometricMean(BinaryOperator):
     r"""Geometric mean of two values.
 
-    The geometric mean *v* of two values *a* and *b* is:
+    The geometric mean :math:`v` of two values :math:`a` and :math:`b` is:
 
     .. math::
 

--- a/relentless/volume.py
+++ b/relentless/volume.py
@@ -1,7 +1,7 @@
 """
 Volumes
 =======
-A :class:`Volume` represents a 3D region of space with a fixed volume. It corresponds
+A :class:`Volume` represents a 3D region of space with a fixed, scalar volume. It corresponds
 to the "box" used in simulations. The following box types have been implemented:
 
 .. autosummary::

--- a/relentless/volume.py
+++ b/relentless/volume.py
@@ -1,3 +1,56 @@
+"""
+Volumes
+=======
+A :class:`Volume` represents a 3D region of space with a fixed volume. It corresponds
+to the "box" used in simulations. The following box types have been implemented:
+
+.. autosummary::
+    :nosignatures:
+
+    Parallelepiped
+    TriclinicBox
+    Cuboid
+    Cube
+
+The TriclinicBox can be constructed using both the LAMMPS and HOOMD-blue conventions
+for applying tilt factors.
+
+Examples
+--------
+Construct a simulation box with defined basis vectors and volume::
+
+    v = relentless.volume.Cube(L=3)
+    >>> print(v.a)
+    [3.0 0.0 0.0]
+    >>> print(v.b)
+    [0.0 3.0 0.0]
+    >>> print(v.c)
+    [0.0 0.0 3.0]
+    >>> print(v.volume)
+    27.0
+
+.. rubric:: Developer notes
+
+To implement your own simulation box, create a class that derives from :class:`Volume`
+and define the required methods.
+
+.. autosummary::
+    :nosignatures:
+
+    Volume
+
+.. autoclass:: Volume
+    :members:
+.. autoclass:: Parallelepiped
+    :members:
+.. autoclass:: TriclinicBox
+    :members:
+.. autoclass:: Cuboid
+    :members:
+.. autoclass:: Cube
+    :members:
+
+"""
 import abc
 from enum import Enum
 
@@ -39,7 +92,7 @@ class Volume(abc.ABC):
 
         Returns
         -------
-        Volume
+        :class:`Volume`
             The object reconstructed from the ``data``.
 
         """
@@ -53,7 +106,7 @@ class Parallelepiped(Volume):
 
     .. math::
 
-        V = (\mathbf{a} \cross \mathbf{b}) \cdot \mathbf{c} > 0
+        V = (\mathbf{a} \times \mathbf{b}) \cdot \mathbf{c} > 0
 
     Parameters
     ----------
@@ -131,24 +184,8 @@ class TriclinicBox(Parallelepiped):
     elements of the matrix of box vectors. As a result, the **a** vector is
     always aligned along the *x*-axis, while the other two vectors may be tilted.
 
-    The tilt factors can be defined using one of two :class:`TriclinicBox.Convention`.
-    In the `LAMMPS <https://lammps.sandia.gov/doc/Howto_triclinic.html>`_
-    simulation convention, specified using ``TriclinicBox.Convention.LAMMPS``,
-
-    .. math::
-
-        \mathbf{a} = (L_x,0,0)
-        \mathbf{b} = (xy,L_y,0)
-        \mathbf{c} = (xz,yz,L_z)
-
-    In the `HOOMD-blue <https://hoomd-blue.readthedocs.io/en/stable/box.html>`_
-    simulation convention, specified using ``TriclinicBox.Convention.HOOMD``,
-
-    .. math::
-
-        \mathbf{a} = (L_x,0,0)
-        \mathbf{b} = (xy*L_y,L_y,0)
-        \mathbf{c} = (xz*L_z,yz*L_z,L_z)
+    The tilt factors can be defined using one of two options in :class:`TriclinicBox.Convention`.
+    By default, the LAMMPS convention is applied to calculate the basis vectors.
 
     Parameters
     ----------
@@ -170,29 +207,33 @@ class TriclinicBox(Parallelepiped):
     ValueError
         If *Lx*, *Ly*, *Lz* are not all positive.
     ValueError
-        If the convention is not `TriclinicBox.Convention.LAMMPS` or
-        `TriclinicBox.Convention.HOOMD`.
+        If the convention is not ``TriclinicBox.Convention.LAMMPS`` or
+        ``TriclinicBox.Convention.HOOMD``.
 
     """
 
     class Convention(Enum):
         r"""Convention by which the tilt factors are applied to the basis vectors.
 
-        Calculation of the basis vectors by the `LAMMPS convention <https://lammps.sandia.gov/doc/Howto_triclinic.html>`_:
+        In the `LAMMPS <https://lammps.sandia.gov/doc/Howto_triclinic.html>`_
+        simulation convention, specified using ``TriclinicBox.Convention.LAMMPS``,
+        the basis vectors are
 
         .. math::
 
             \mathbf{a} = (L_x,0,0)
-            \mathbf{b} = (xy,L_y,0)
-            \mathbf{c} = (xz,yz,L_z)
+            \quad \mathbf{b} = (xy,L_y,0)
+            \quad \mathbf{c} = (xz,yz,L_z)
 
-        Calculation of the basis vectors by the `HOOMD convention <https://hoomd-blue.readthedocs.io/en/stable/box.html>`_:
+        In the `HOOMD-blue <https://hoomd-blue.readthedocs.io/en/stable/box.html>`_
+        simulation convention, specified using ``TriclinicBox.Convention.HOOMD``,
+        the basis vectors are
 
         .. math::
 
             \mathbf{a} = (L_x,0,0)
-            \mathbf{b} = (xy*L_y,L_y,0)
-            \mathbf{c} = (xz*L_z,yz*L_z,L_z)
+            \quad \mathbf{b} = (xy \cdot L_y,L_y,0)
+            \quad \mathbf{c} = (xz \cdot L_z,yz \cdot L_z,L_z)
 
         Attributes
         ----------

--- a/relentless/volume.py
+++ b/relentless/volume.py
@@ -101,8 +101,8 @@ class Volume(abc.ABC):
 class Parallelepiped(Volume):
     r"""Parallelepiped box defined by three vectors.
 
-    The three vectors **a**, **b**, and **c** must form a right-hand basis
-    so that the box volume *V* is positive:
+    The three vectors :math:`\mathbf{a}`, :math:`\mathbf{b}`, and :math:`\mathbf{c}`
+    must form a right-hand basis so that the box volume :math:`V` is positive:
 
     .. math::
 
@@ -120,7 +120,7 @@ class Parallelepiped(Volume):
     Raises
     ------
     TypeError
-        If a, b, and c are not all 3-element vectors.
+        If ``a``, ``b``, and ``c`` are not all 3-element vectors.
     ValueError
         If the volume is not positive.
 
@@ -141,8 +141,7 @@ class Parallelepiped(Volume):
     def to_json(self):
         r"""Serialize as a dictionary.
 
-        The dictionary contains the three box vectors **a**, **b**, and **c**
-        as tuples.
+        The dictionary contains the three box vectors ``a``, ``b``, and ``c`` as tuples.
 
         Returns
         -------
@@ -179,22 +178,23 @@ class TriclinicBox(Parallelepiped):
 
     A TriclinicBox is a special type of :class:`Parallelepiped`. The box is
     defined by an orthorhombic box oriented along the Cartesian axes and having
-    three vectors of length ``Lx``, ``Ly``, and ``Lz``, respectively. The box is
-    then tilted by factors ``xy``, ``xy``, and ``xz``, which are upper off-diagonal
-    elements of the matrix of box vectors. As a result, the **a** vector is
-    always aligned along the *x*-axis, while the other two vectors may be tilted.
+    three vectors of length :math:`L_x`, :math:`L_y`, and :math:`L_z`, respectively.
+    The box is then tilted by factors :math:`xy`, :math:`xz`, and :math:`yz`, which
+    are upper off-diagonal elements of the matrix of box vectors. As a result,
+    the :math:`\mathbf{a}` vector is always aligned along the :math:`x` axis, while
+    the other two vectors may be tilted.
 
-    The tilt factors can be defined using one of two options in :class:`TriclinicBox.Convention`.
+    The tilt factors can be defined using one of two :class:`TriclinicBox.Convention`\s.
     By default, the LAMMPS convention is applied to calculate the basis vectors.
 
     Parameters
     ----------
     Lx : float
-        Length along the *x* axis.
+        Length along the :math:`x` axis.
     Ly : float
-        Length along the *y* axis.
+        Length along the :math:`y` axis.
     Lz : float
-        Length along the *z* axis.
+        Length along the :math:`z` axis.
     xy : float
         First tilt factor.
     xz : float
@@ -205,7 +205,7 @@ class TriclinicBox(Parallelepiped):
     Raises
     ------
     ValueError
-        If *Lx*, *Ly*, *Lz* are not all positive.
+        If ``Lx``, ``Ly``, and ``Lz`` are not all positive.
     ValueError
         If the convention is not ``TriclinicBox.Convention.LAMMPS`` or
         ``TriclinicBox.Convention.HOOMD``.
@@ -333,18 +333,18 @@ class Cuboid(TriclinicBox):
     r"""Orthorhombic box.
 
     A Cuboid is a special type of :class:`TriclinicBox`. The three box vectors
-    point along the *x*, *y*, and *z* axes, so they are all orthogonal (i.e. the
-    tilt factors ``xy``, ``xz``, and ``yz`` are all 0). Each vector can have a
-    different length, *Lx*, *Ly*, and *Lz*.
+    point along the :math:`x`, :math:`y`, and :math:`z` axes, so they are all
+    orthogonal (i.e. :math:`xy=xz=yz=0`). Each vector can have a different length,
+    :math:`L_x`, :math:`L_y`, and :math:`L_z`.
 
     Parameters
     ----------
     Lx : float
-        Length along the *x* axis.
+        Length along the :math:`x` axis.
     Ly : float
-        Length along the *y* axis.
+        Length along the :math:`y` axis.
     Lz : float
-        Length along the *z* axis.
+        Length along the :math:`z` axis.
 
     """
     def __init__(self, Lx, Ly, Lz):
@@ -389,7 +389,7 @@ class Cube(Cuboid):
     r"""Cubic box.
 
     A Cube is a special type of :class:`Cuboid` where all vectors have the
-    same length *L*.
+    same length :math:`L`.
 
     Parameters
     ----------


### PR DESCRIPTION
- Implement and extend documentation (docstrings and Sphinx) for core (`data`, `ensemble`, `volume`, `_collections`, `_math`) and `simulate` modules
- Fix typos and hyperlinks in all module docs