### PR TITLE
Install subpackages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
 
 [options]
-packages = relentless
+packages = find:
 python_requires = >=3.6
 install_requires =
     networkx>=2.4


### PR DESCRIPTION
The install command was missing subpackages (e.g., `relentless.optimize`). These should be automatically found.