### PR TITLE
Implement generic interface for energy minimizer

### DIFF
--- a/relentless/simulate/generic.py
+++ b/relentless/simulate/generic.py
@@ -210,7 +210,7 @@ class MinimizeEnergy(GenericOperation):
     max_iterations : int
         Maximum number of iterations to run the minimization.
     options : dict
-        Extra options for energy minimizer.
+        Additional options for energy minimizer (defaults to ``None``).
 
     """
     def __init__(self, energy_tolerance, force_tolerance, max_iterations, options=None):

--- a/relentless/simulate/generic.py
+++ b/relentless/simulate/generic.py
@@ -209,12 +209,12 @@ class MinimizeEnergy(GenericOperation):
         Force convergence criterion.
     max_iterations : int
         Maximum number of iterations to run the minimization.
-    options : kwargs
-        Options for energy minimizer.
+    options : dict
+        Extra options for energy minimizer.
 
     """
-    def __init__(self, energy_tolerance, force_tolerance, max_iterations, **options):
-        super().__init__(energy_tolerance, force_tolerance, max_iterations, **options)
+    def __init__(self, energy_tolerance, force_tolerance, max_iterations, options=None):
+        super().__init__(energy_tolerance, force_tolerance, max_iterations, options)
 
 class AddBrownianIntegrator(GenericOperation):
     """Brownian dynamics for a NVT ensemble.

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -401,17 +401,22 @@ class MinimizeEnergy(simulate.SimulationOperation):
         Force convergence criterion.
     max_iterations : int
         Maximum number of iterations to run the minimization.
-    max_displacement : float
-        Maximum step size.
+    options : dict
+        Additional options for energy minimizer.
+
+    Raises
+    ------
+    ValueError
+        If a value for the maximum displacement is not provided.
 
     """
-    def __init__(self, energy_tolerance, force_tolerance, max_iterations, max_displacement):
+    def __init__(self, energy_tolerance, force_tolerance, max_iterations, options):
         self.energy_tolerance = energy_tolerance
         self.force_tolerance = force_tolerance
         self.max_iterations = max_iterations
-        self.max_displacement = max_displacement
-        if self.max_displacement is None:
-           raise ValueError('The HOOMD energy minimizer requires a value for the maximum displacement (dt).')
+        self.options = options
+        if 'max_displacement' not in self.options:
+           raise ValueError('HOOMD energy minimizer requires max_displacement option.')
 
     def __call__(self, sim):
         """Performs the energy minimization operation.
@@ -430,7 +435,7 @@ class MinimizeEnergy(simulate.SimulationOperation):
         """
         with sim.context:
             # setup FIRE minimization
-            fire = hoomd.md.integrate.mode_minimize_fire(dt=self.max_displacement,
+            fire = hoomd.md.integrate.mode_minimize_fire(dt=self.options['max_displacement'],
                                                          Etol=self.energy_tolerance,
                                                          ftol=self.force_tolerance)
             all_ = hoomd.group.all()

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -401,15 +401,17 @@ class MinimizeEnergy(simulate.SimulationOperation):
         Force convergence criterion.
     max_iterations : int
         Maximum number of iterations to run the minimization.
-    dt : float
+    max_displacement : float
         Maximum step size.
 
     """
-    def __init__(self, energy_tolerance, force_tolerance, max_iterations, dt):
+    def __init__(self, energy_tolerance, force_tolerance, max_iterations, max_displacement):
         self.energy_tolerance = energy_tolerance
         self.force_tolerance = force_tolerance
         self.max_iterations = max_iterations
-        self.dt = dt
+        self.max_displacement = max_displacement
+        if self.max_displacement is None:
+           raise ValueError('The HOOMD energy minimizer requires a value for the maximum displacement (dt).')
 
     def __call__(self, sim):
         """Performs the energy minimization operation.
@@ -428,7 +430,7 @@ class MinimizeEnergy(simulate.SimulationOperation):
         """
         with sim.context:
             # setup FIRE minimization
-            fire = hoomd.md.integrate.mode_minimize_fire(dt=self.dt,
+            fire = hoomd.md.integrate.mode_minimize_fire(dt=self.max_displacement,
                                                          Etol=self.energy_tolerance,
                                                          ftol=self.force_tolerance)
             all_ = hoomd.group.all()

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -396,9 +396,9 @@ class MinimizeEnergy(simulate.SimulationOperation):
     Valid ``options`` include:
 
     - ``max_displacement`` (`float`) - the maximum time step size the minimizer
-    is allowed to use.
+      is allowed to use.
     - ``max_evaluations`` (`int`) - the maximum number of time steps the minimizer
-    is allowed to run per iteration. Defaults to 100.
+      is allowed to run per iteration. Defaults to 100.
 
     Parameters
     ----------

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -393,6 +393,13 @@ class InitializeRandomly(Initialize):
 class MinimizeEnergy(simulate.SimulationOperation):
     """Runs an energy minimzation until converged.
 
+    Valid ``options`` include:
+
+    - ``max_displacement`` (`float`) - the maximum time step size the minimizer
+    is allowed to use.
+    - ``max_evaluations`` (`int`) - the maximum number of time steps the minimizer
+    is allowed to run per iteration. Defaults to 100.
+
     Parameters
     ----------
     energy_tolerance : float
@@ -406,7 +413,7 @@ class MinimizeEnergy(simulate.SimulationOperation):
 
     Raises
     ------
-    ValueError
+    KeyError
         If a value for the maximum displacement is not provided.
 
     """
@@ -416,7 +423,9 @@ class MinimizeEnergy(simulate.SimulationOperation):
         self.max_iterations = max_iterations
         self.options = options
         if 'max_displacement' not in self.options:
-           raise ValueError('HOOMD energy minimizer requires max_displacement option.')
+           raise KeyError('HOOMD energy minimizer requires max_displacement option.')
+        if 'max_evaluations' not in self.options:
+            self.options['max_evaluations'] = 100
 
     def __call__(self, sim):
         """Performs the energy minimization operation.
@@ -444,7 +453,7 @@ class MinimizeEnergy(simulate.SimulationOperation):
             # run while not yet converged
             it = 0
             while not fire.has_converged() and it < self.max_iterations:
-                hoomd.run(100)
+                hoomd.run(self.options['max_evaluations'])
                 it += 1
             if not fire.has_converged():
                 raise RuntimeError('Energy minimization failed to converge.')

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -397,7 +397,8 @@ class MinimizeEnergy(simulate.SimulationOperation):
 
     - **max_displacement** (`float`) - the maximum time step size the minimizer
       is allowed to use.
-    - **steps_per_iteration** (`int`) - th number o steps the minimizer runs per iteration. Defaults to 100.
+    - **steps_per_iteration** (`int`) - the number of steps the minimizer runs
+      per iteration. Defaults to 100.
 
     Parameters
     ----------

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -393,11 +393,11 @@ class InitializeRandomly(Initialize):
 class MinimizeEnergy(simulate.SimulationOperation):
     """Runs an energy minimzation until converged.
 
-    Valid ``options`` include:
+    Valid **options** include:
 
-    - ``max_displacement`` (`float`) - the maximum time step size the minimizer
+    - **max_displacement** (`float`) - the maximum time step size the minimizer
       is allowed to use.
-    - ``max_evaluations`` (`int`) - the maximum number of time steps the minimizer
+    - **max_evaluations** (`int`) - the maximum number of time steps the minimizer
       is allowed to run per iteration. Defaults to 100.
 
     Parameters

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -397,8 +397,7 @@ class MinimizeEnergy(simulate.SimulationOperation):
 
     - **max_displacement** (`float`) - the maximum time step size the minimizer
       is allowed to use.
-    - **max_evaluations** (`int`) - the maximum number of time steps the minimizer
-      is allowed to run per iteration. Defaults to 100.
+    - **steps_per_iteration** (`int`) - th number o steps the minimizer runs per iteration. Defaults to 100.
 
     Parameters
     ----------
@@ -424,8 +423,8 @@ class MinimizeEnergy(simulate.SimulationOperation):
         self.options = options
         if 'max_displacement' not in self.options:
            raise KeyError('HOOMD energy minimizer requires max_displacement option.')
-        if 'max_evaluations' not in self.options:
-            self.options['max_evaluations'] = 100
+        if 'steps_per_iteration' not in self.options:
+            self.options['steps_per_iteration'] = 100
 
     def __call__(self, sim):
         """Performs the energy minimization operation.
@@ -453,7 +452,7 @@ class MinimizeEnergy(simulate.SimulationOperation):
             # run while not yet converged
             it = 0
             while not fire.has_converged() and it < self.max_iterations:
-                hoomd.run(self.options['max_evaluations'])
+                hoomd.run(self.options['steps_per_iteration'])
                 it += 1
             if not fire.has_converged():
                 raise RuntimeError('Energy minimization failed to converge.')

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -479,7 +479,7 @@ class MinimizeEnergy(LAMMPSOperation):
         cmds = ['minimize {etol} {ftol} {maxiter} {maxeval}'.format(etol=self.energy_tolerance,
                                                                     ftol=self.force_tolerance,
                                                                     maxiter=self.max_iterations,
-                                                                    maxeval=self.options[max_evaluations])]
+                                                                    maxeval=self.options['max_evaluations'])]
 
         return cmds
 

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -445,14 +445,22 @@ class MinimizeEnergy(LAMMPSOperation):
         Force convergence criterion.
     max_iterations : int
         Maximum number of iterations to run the minimization.
-    max_displacement : float (defaults to `None`).
-        The maximum step size is not required by the LAMMPS energy minimizer.
+    options : dict
+        Additional options for energy minimzer.
+
+    Raises
+    ------
+    ValueError
+        If a value for the maximum evaluations is not provided.
 
     """
-    def __init__(self, energy_tolerance, force_tolerance, max_iterations, max_displacement=None):
+    def __init__(self, energy_tolerance, force_tolerance, max_iterations, options):
         self.energy_tolerance = energy_tolerance
         self.force_tolerance = force_tolerance
         self.max_iterations = max_iterations
+        self.options = options
+        if 'max_evaluations' not in self.options:
+            raise ValueError('LAMMPS energy minimizer requires max_evaluations option.')
 
     def to_commands(self, sim):
         """Performs the energy minimization operation.
@@ -471,7 +479,7 @@ class MinimizeEnergy(LAMMPSOperation):
         cmds = ['minimize {etol} {ftol} {maxiter} {maxeval}'.format(etol=self.energy_tolerance,
                                                                     ftol=self.force_tolerance,
                                                                     maxiter=self.max_iterations,
-                                                                    maxeval=100*self.max_iterations)]
+                                                                    maxeval=self.options[max_evaluations])]
 
         return cmds
 

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -439,8 +439,8 @@ class MinimizeEnergy(LAMMPSOperation):
 
     Valid **options** include:
 
-    - **max_evaluations** (`int`) - the maximum number of time steps the minimizer
-      is allowed to run per iteration. Defaults to 100.
+    - **max_evaluations** (`int`) - the maximum number of force/energy evaluations.
+      Defaults to ``100*max_iterations``.
 
     Parameters
     ----------
@@ -460,7 +460,7 @@ class MinimizeEnergy(LAMMPSOperation):
         self.max_iterations = max_iterations
         self.options = options
         if 'max_evaluations' not in self.options:
-            self.options['max_evaluations'] = 100
+            self.options['max_evaluations'] = 100*self.max_iterations
 
     def to_commands(self, sim):
         """Performs the energy minimization operation.

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -445,11 +445,11 @@ class MinimizeEnergy(LAMMPSOperation):
         Force convergence criterion.
     max_iterations : int
         Maximum number of iterations to run the minimization.
-    dt : float
-        Maximum step size.
+    max_displacement : float (defaults to `None`).
+        The maximum step size is not required by the LAMMPS energy minimizer.
 
     """
-    def __init__(self, energy_tolerance, force_tolerance, max_iterations, dt):
+    def __init__(self, energy_tolerance, force_tolerance, max_iterations, max_displacement=None):
         self.energy_tolerance = energy_tolerance
         self.force_tolerance = force_tolerance
         self.max_iterations = max_iterations

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -440,7 +440,7 @@ class MinimizeEnergy(LAMMPSOperation):
     Valid ``options`` include:
 
     - ``max_evaluations`` (`int`) - the maximum number of time steps the minimizer
-    is allowed to run per iteration. Defaults to 100.
+      is allowed to run per iteration. Defaults to 100.
 
     Parameters
     ----------

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -460,7 +460,7 @@ class MinimizeEnergy(LAMMPSOperation):
         self.max_iterations = max_iterations
         self.options = options
         if 'max_evaluations' not in self.options:
-            self.options['max_evaluations'] = 100*self.max_iterations
+            self.options['max_evaluations'] = None
 
     def to_commands(self, sim):
         """Performs the energy minimization operation.
@@ -476,6 +476,9 @@ class MinimizeEnergy(LAMMPSOperation):
             The LAMMPS commands for this operation.
 
         """
+        if self.options['max_evaluations'] is None:
+            self.options['max_evaluations'] = 100*self.max_iterations
+
         cmds = ['minimize {etol} {ftol} {maxiter} {maxeval}'.format(etol=self.energy_tolerance,
                                                                     ftol=self.force_tolerance,
                                                                     maxiter=self.max_iterations,

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -437,6 +437,11 @@ class InitializeRandomly(Initialize):
 class MinimizeEnergy(LAMMPSOperation):
     """Runs an energy minimization until converged.
 
+    Valid ``options`` include:
+
+    - ``max_evaluations`` (`int`) - the maximum number of time steps the minimizer
+    is allowed to run per iteration. Defaults to 100.
+
     Parameters
     ----------
     energy_tolerance : float
@@ -448,11 +453,6 @@ class MinimizeEnergy(LAMMPSOperation):
     options : dict
         Additional options for energy minimzer.
 
-    Raises
-    ------
-    ValueError
-        If a value for the maximum evaluations is not provided.
-
     """
     def __init__(self, energy_tolerance, force_tolerance, max_iterations, options):
         self.energy_tolerance = energy_tolerance
@@ -460,7 +460,7 @@ class MinimizeEnergy(LAMMPSOperation):
         self.max_iterations = max_iterations
         self.options = options
         if 'max_evaluations' not in self.options:
-            raise ValueError('LAMMPS energy minimizer requires max_evaluations option.')
+            self.options['max_evaluations'] = 100
 
     def to_commands(self, sim):
         """Performs the energy minimization operation.

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -437,9 +437,9 @@ class InitializeRandomly(Initialize):
 class MinimizeEnergy(LAMMPSOperation):
     """Runs an energy minimization until converged.
 
-    Valid ``options`` include:
+    Valid **options** include:
 
-    - ``max_evaluations`` (`int`) - the maximum number of time steps the minimizer
+    - **max_evaluations** (`int`) - the maximum number of time steps the minimizer
       is allowed to run per iteration. Defaults to 100.
 
     Parameters

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -91,7 +91,8 @@ class test_HOOMD(unittest.TestCase):
         with self.assertRaises(ValueError):
             emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                             force_tolerance=1e-7,
-                                                            max_iterations=1000)
+                                                            max_iterations=1000,
+                                                            max_displacement=None)
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -87,6 +87,12 @@ class test_HOOMD(unittest.TestCase):
         h = relentless.simulate.hoomd.HOOMD(operations=op)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
 
+        #error check for missing max_displacement
+        with self.assertRaises(ValueError):
+            emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
+                                                            force_tolerance=1e-7,
+                                                            max_iterations=1000)
+
     def test_integrators(self):
         """Test adding and removing integrator operations."""
         init = relentless.simulate.hoomd.InitializeRandomly(seed=1)

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -82,7 +82,7 @@ class test_HOOMD(unittest.TestCase):
               relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                        force_tolerance=1e-7,
                                                        max_iterations=1000,
-                                                       dt=0.01)
+                                                       max_displacement=0.01)
              ]
         h = relentless.simulate.hoomd.HOOMD(operations=op)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -82,7 +82,7 @@ class test_HOOMD(unittest.TestCase):
               relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                        force_tolerance=1e-7,
                                                        max_iterations=1000,
-                                                       max_displacement=0.01)
+                                                       options={'max_displacement':0.5})
              ]
         h = relentless.simulate.hoomd.HOOMD(operations=op)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
@@ -92,7 +92,7 @@ class test_HOOMD(unittest.TestCase):
             emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                             force_tolerance=1e-7,
                                                             max_iterations=1000,
-                                                            max_displacement=None)
+                                                            options={})
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -82,17 +82,25 @@ class test_HOOMD(unittest.TestCase):
               relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                        force_tolerance=1e-7,
                                                        max_iterations=1000,
-                                                       options={'max_displacement':0.5})
+                                                       options={'max_displacement':0.5,
+                                                                'max_evaluations':50})
              ]
         h = relentless.simulate.hoomd.HOOMD(operations=op)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
 
         #error check for missing max_displacement
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                             force_tolerance=1e-7,
                                                             max_iterations=1000,
                                                             options={})
+
+        #check default value for max_evaluations
+        emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
+                                                        force_tolerance=1e-7,
+                                                        max_iterations=1000,
+                                                        options={'max_displacement':0.5})
+        self.assertEqual(emin.options['max_evaluations'], 100)
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -83,7 +83,7 @@ class test_HOOMD(unittest.TestCase):
                                                        force_tolerance=1e-7,
                                                        max_iterations=1000,
                                                        options={'max_displacement':0.5,
-                                                                'max_evaluations':50})
+                                                                'steps_per_iteration':50})
              ]
         h = relentless.simulate.hoomd.HOOMD(operations=op)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
@@ -100,7 +100,7 @@ class test_HOOMD(unittest.TestCase):
                                                         force_tolerance=1e-7,
                                                         max_iterations=1000,
                                                         options={'max_displacement':0.5})
-        self.assertEqual(emin.options['max_evaluations'], 100)
+        self.assertEqual(emin.options['steps_per_iteration'], 100)
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -90,7 +90,7 @@ class test_LAMMPS(unittest.TestCase):
               relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
                                                         max_iterations=1000,
-                                                        options={'max_evaluations':100000})
+                                                        options={'max_evaluations':10000})
              ]
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
@@ -100,7 +100,7 @@ class test_LAMMPS(unittest.TestCase):
                                                          force_tolerance=1e-7,
                                                          max_iterations=1000,
                                                          options={})
-        self.assertEqual(emin.options['max_evaluations'], 100)
+        self.assertEqual(emin.options['max_evaluations'], 100*emin.max_iterations)
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -100,6 +100,9 @@ class test_LAMMPS(unittest.TestCase):
                                                          force_tolerance=1e-7,
                                                          max_iterations=1000,
                                                          options={})
+        self.assertEqual(emin.options['max_evaluations'], None)
+        l = relentless.simulate.lammps.LAMMPS(operations=emin, quiet=False)
+        sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
         self.assertEqual(emin.options['max_evaluations'], 100*emin.max_iterations)
 
     def test_integrators(self):

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -98,7 +98,6 @@ class test_LAMMPS(unittest.TestCase):
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
 
         #check default value of max_evaluations
-        init = relentless.simulate
         emin = relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                          force_tolerance=1e-7,
                                                          max_iterations=1000,

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -89,10 +89,18 @@ class test_LAMMPS(unittest.TestCase):
         op = [relentless.simulate.lammps.InitializeFromFile(filename=file_),
               relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
-                                                        max_iterations=1000)
+                                                        max_iterations=1000,
+                                                        options={'max_evaluations':100000)
              ]
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
+
+        #error check for missing max_evaluations
+        with self.assertRaises(ValueError):
+            emin = relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
+                                                             force_tolerance=1e-7,
+                                                             max_iterations=1000,
+                                                             options={})
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -90,7 +90,7 @@ class test_LAMMPS(unittest.TestCase):
               relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
                                                         max_iterations=1000,
-                                                        options={'max_evaluations':100000)
+                                                        options={'max_evaluations':100000})
              ]
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -95,12 +95,12 @@ class test_LAMMPS(unittest.TestCase):
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #error check for missing max_evaluations
-        with self.assertRaises(ValueError):
-            emin = relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
-                                                             force_tolerance=1e-7,
-                                                             max_iterations=1000,
-                                                             options={})
+        #check default value of max_evaluations
+        emin = relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
+                                                         force_tolerance=1e-7,
+                                                         max_iterations=1000,
+                                                         options={})
+        self.assertEqual(emin.options['max_evaluations'], 100)
 
     def test_integrators(self):
         """Test adding and removing integrator operations."""

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -83,10 +83,12 @@ class test_LAMMPS(unittest.TestCase):
 
     def test_minimization(self):
         """Test running energy minimization simulation operation."""
-        #MinimizeEnergy
         ens,pot = self.ens_pot()
         file_ = self.create_file()
-        op = [relentless.simulate.lammps.InitializeFromFile(filename=file_),
+        init = relentless.simulate.lammps.InitializeFromFile(filename=file_)
+
+        #MinimizeEnergy
+        op = [init,
               relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
                                                         max_iterations=1000,
@@ -96,12 +98,13 @@ class test_LAMMPS(unittest.TestCase):
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
 
         #check default value of max_evaluations
+        init = relentless.simulate
         emin = relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                          force_tolerance=1e-7,
                                                          max_iterations=1000,
                                                          options={})
         self.assertEqual(emin.options['max_evaluations'], None)
-        l = relentless.simulate.lammps.LAMMPS(operations=emin, quiet=False)
+        l = relentless.simulate.lammps.LAMMPS(operations=[init,emin], quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
         self.assertEqual(emin.options['max_evaluations'], 100*emin.max_iterations)
 

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -89,8 +89,7 @@ class test_LAMMPS(unittest.TestCase):
         op = [relentless.simulate.lammps.InitializeFromFile(filename=file_),
               relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
-                                                        max_iterations=1000,
-                                                        dt=0.01)
+                                                        max_iterations=1000)
              ]
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)


### PR DESCRIPTION
- Modify generic interface for backend `MinimizeEnergy` operation to allow for `options` dictionary argument
- Add keys to `options`: required `max_displacement` for HOOMD and optional `max_evaluations` for LAMMPS, `steps_per_iteration` for HOOMD
- Fix unit tests and documentation

Resolves #49.