### PR TITLE
Use communicator in Directory

### DIFF
--- a/relentless/mpi.py
+++ b/relentless/mpi.py
@@ -139,6 +139,11 @@ class Communicator:
         """int: Index of the root rank in the MPI communicator."""
         return self._root
 
+    def barrier(self):
+        """Create barrier for all ranks in the MPI communicator."""
+        if self.enabled and self.size > 1:
+            self.comm.barrier()
+
     def bcast(self, data, root=None):
         """Broadcast Python object to all ranks.
 

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -74,6 +74,7 @@ import abc
 
 import numpy
 
+from relentless import data
 from relentless import mpi
 
 class Simulation:
@@ -110,8 +111,8 @@ class Simulation:
             these variables fluctuate.
         potentials : :class:`Potentials`
             The interaction potentials.
-        directory : :class:`~relentless.data.Directory`
-            Directory to use for writing data.
+        directory : str or :class:`~relentless.data.Directory`
+            Directory for output.
         communicator: :class:`~relentless.mpi.Communicator`
             The MPI communicator to use. Defaults to ``None``.
 
@@ -169,7 +170,7 @@ class SimulationInstance:
         these variables fluctuate.
     potentials : :class:`Potentials`
         The interaction potentials.
-    directory : :class:`~relentless.data.Directory`
+    directory : str or :class:`~relentless.data.Directory`
         Directory for output.
     communicator: :class:`~relentless.mpi.Communicator`
         The MPI communicator to use.
@@ -181,8 +182,16 @@ class SimulationInstance:
         self.backend = backend
         self.ensemble = ensemble
         self.potentials = potentials
+
+        # configure directory and check communicators match
+        if directory is not None:
+            if not isinstance(directory,data.Directory):
+                directory = data.Directory(directory,communicator)
+            if directory.communicator is not communicator:
+                raise ValueError('Communicator for directory and for simulation must be the same')
         self.directory = directory
         self.communicator = communicator
+
         for opt,val in options.items():
             setattr(self,opt,val)
         self._opdata = {}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -128,18 +128,6 @@ class test_Directory(unittest.TestCase):
         self.assertEqual(d.path, real_foo)
         self.assertTrue(os.path.exists(foo))
 
-        # set path by property
-        bar = os.path.join(self.f.name,'bar')
-        real_bar = os.path.realpath(bar)
-        d.path = bar
-        self.assertEqual(d.path, real_bar)
-        self.assertTrue(os.path.exists(bar))
-
-        # cannot set path in context
-        with d:
-            with self.assertRaises(OSError):
-                d.path = foo
-
     def test_move_contents(self):
         foo = os.path.join(self.f.name,'foo')
         bar = os.path.join(self.f.name,'bar')


### PR DESCRIPTION
This PR fixes a potential race condition in the `Directory` when running under MPI. The path is now guaranteed when the `Directory` is created, and file operations are also wrapped.

The simulation `Communicator` now needs to match the one for the directory. An error will be raised if it does not. The simulation `run` command now can accept a string instead of a directory to simplify this process (the `Directory` object is automagically created).

Fixes #91 