### PR TITLE
Refactor RelativeEntropy compute method

### DIFF
--- a/relentless/optimize/method.py
+++ b/relentless/optimize/method.py
@@ -333,12 +333,12 @@ class SteepestDescent(Optimizer):
 
         Parameters
         ----------
-        gradient : :class:`~relentless.collections.KeyedArray`
+        gradient : :class:`~relentless.math.KeyedArray`
             The scaled gradient of the objective function.
 
         Returns
         -------
-        :class:`~relentless.collections.KeyedArray`
+        :class:`~relentless.math.KeyedArray`
             The descent amount, keyed on the objective function design variables.
 
         """
@@ -533,12 +533,12 @@ class FixedStepDescent(SteepestDescent):
 
         Parameters
         ----------
-        gradient : :class:`~relentless.collections.KeyedArray`
+        gradient : :class:`~relentless.math.KeyedArray`
             The scaled gradient of the objective function.
 
         Returns
         -------
-        :class:`~relentless.collections.KeyedArray`
+        :class:`~relentless.math.KeyedArray`
             The descent amount, keyed on the objective function design variables.
 
         """

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -265,7 +265,7 @@ class RelativeEntropy(ObjectiveFunction):
         Optionally, a directory can be specified to write the simulation output
         as defined in :meth:`~relentless.simulate.simulate.Simulation.run()`,
         namely the simulation-generated ensemble, which is written to
-        `ensemble.json`, and the values of the pair potential design variables,
+        ``ensemble.json``, and the values of the pair potential design variables,
         which are written to ``pair_potential.i.json`` for the :math:`i`\th pair
         potential.
 

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -301,7 +301,7 @@ class RelativeEntropy(ObjectiveFunction):
 
         Parameters
         ----------
-        sim_ens : :class:`~relentless.ensemble.Ensemble`
+        ensemble : :class:`~relentless.ensemble.Ensemble`
             The ensemble for which to evaluate the gradient.
 
         Returns

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -261,10 +261,11 @@ class RelativeEntropy(ObjectiveFunction):
         Calculating the gradient requires running a simulation, which may be
         computationally expensive.
 
-        Optionally, a directory can be specified both to write the simulation
-        output as defined in :meth:`~relentless.simulate.simulate.Simulation.run()`,
-        and the values of the pair potential design variables, which are written
-        to ``potential.i.json`` for the :math:`i`\th pair potential.
+        Optionally, a directory can be specified to write the simulation output
+        as defined in :meth:`~relentless.simulate.simulate.Simulation.run()`,
+        namely the simulation-generated ensemble, which is written to
+        `ensemble.json`, and the values of the pair potential design variables,
+        which are written to ``potential.i.json`` for the :math:`i`\th pair potential.
 
         Parameters
         ----------
@@ -333,6 +334,7 @@ class RelativeEntropy(ObjectiveFunction):
         if directory is not None and (self.communicator is None or self.communicator.rank == self.communicator.root):
             for n,p in enumerate(self.potentials.pair.potentials):
                 p.save(directory.file('potential.{}.json'.format(n)))
+            sim_ens.save(directory.file('ensemble.json'))
 
         # relative entropy *value* is None
         return self.make_result(None, gradient, directory)

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -158,18 +158,26 @@ class test_RelativeEntropy(unittest.TestCase):
             relent.target = relentless.ensemble.Ensemble(T=1.5, P=1, N={'1':50})
 
     def test_compute(self):
-        """Test compute method"""
+        """Test compute and compute_gradient methods"""
         relent = relentless.optimize.RelativeEntropy(self.target,
                                                      self.simulation,
                                                      self.potentials,
                                                      self.thermo)
 
         res = relent.compute()
-        self.assertIsNone(res.value)
+
+        sim = self.simulation.run(self.target, self.potentials, self.directory.name)
+        ensemble = self.thermo.extract_ensemble(sim)
+        res_grad = relent.compute_gradient(ensemble)
+
         grad_eps = self.relent_grad(self.epsilon)
         grad_sig = self.relent_grad(self.sigma)
+
+        self.assertIsNone(res.value)
         numpy.testing.assert_allclose(res.gradient[self.epsilon], grad_eps, atol=1e-4)
         numpy.testing.assert_allclose(res.gradient[self.sigma], grad_sig, atol=1e-4)
+        numpy.testing.assert_allclose(res_grad[self.epsilon], grad_eps, atol=1e-4)
+        numpy.testing.assert_allclose(res_grad[self.sigma], grad_sig, atol=1e-4)
         self.assertCountEqual(res.design_variables, (self.epsilon,self.sigma))
 
         #test extensive option
@@ -180,11 +188,19 @@ class test_RelativeEntropy(unittest.TestCase):
                                                      extensive=True)
 
         res = relent.compute()
-        self.assertIsNone(res.value)
+
+        sim = self.simulation.run(self.target, self.potentials, self.directory.name)
+        ensemble = self.thermo.extract_ensemble(sim)
+        res_grad = relent.compute_gradient(ensemble)
+
         grad_eps = self.relent_grad(self.epsilon, ext=True)
         grad_sig = self.relent_grad(self.sigma, ext=True)
+
+        self.assertIsNone(res.value)
         numpy.testing.assert_allclose(res.gradient[self.epsilon], grad_eps, atol=1e-1)
         numpy.testing.assert_allclose(res.gradient[self.sigma], grad_sig, atol=1e-1)
+        numpy.testing.assert_allclose(res_grad[self.epsilon], grad_eps, atol=1e-1)
+        numpy.testing.assert_allclose(res_grad[self.sigma], grad_sig, atol=1e-1)
         self.assertCountEqual(res.design_variables, (self.epsilon,self.sigma))
 
     def test_design_variables(self):
@@ -212,7 +228,7 @@ class test_RelativeEntropy(unittest.TestCase):
         d = relentless.data.Directory(self.directory.name)
         res = relent.compute(d)
 
-        with open(d.file('potential.0.json')) as f:
+        with open(d.file('pair_potential.0.json')) as f:
             x = json.load(f)
         self.assertAlmostEqual(x["('1', '1')"]['epsilon'], self.epsilon.value)
         self.assertAlmostEqual(x["('1', '1')"]['sigma'], self.sigma.value)

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -218,6 +218,17 @@ class test_RelativeEntropy(unittest.TestCase):
         self.assertAlmostEqual(x["('1', '1')"]['sigma'], self.sigma.value)
         self.assertAlmostEqual(x["('1', '1')"]['rmax'], 2.7)
 
+        sim = self.simulation.run(self.target, self.potentials, self.directory.name)
+        sim_ens = self.thermo.extract_ensemble(sim)
+        with open(d.file('ensemble.json')) as g:
+            y = json.load(g)
+        self.assertAlmostEqual(y['T'], 1.5)
+        self.assertAlmostEqual(y['N'], {'1':50})
+        self.assertAlmostEqual(y['V']['data'], {'L':10.})
+        self.assertAlmostEqual(y['P'], sim_ens.P)
+        self.assertAlmostEqual(y['kB'], 1.0)
+        numpy.testing.assert_allclose(y['rdf']["('1', '1')"], sim_ens.rdf['1','1'].table.tolist())
+
     def tearDown(self):
         self.directory.cleanup()
         del self.directory


### PR DESCRIPTION
- Modify `RelativeEntropy.compute()` method to save simulation `Ensemble` to file
- Create `RelativeEntropy.compute_gradient()` method for direct computation of gradient using Ensemble
- Modify corresponding documentation and unit tests.