### PR TITLE
Refactor MPI communicator

### DIFF
--- a/relentless/mpi.py
+++ b/relentless/mpi.py
@@ -139,6 +139,11 @@ class Communicator:
         """int: Index of the root rank in the MPI communicator."""
         return self._root
 
+    @property
+    def rank_is_root(self):
+        """bool: True if the MPI rank is the root rank."""
+        return self.rank == self.root
+
     def barrier(self):
         """Create barrier for all ranks in the MPI communicator."""
         if self.enabled and self.size > 1:
@@ -173,7 +178,7 @@ class Communicator:
         .. code::
 
             comm = relentless.mpi.Communicator()
-            if comm.rank == comm.root:
+            if comm.rank_is_root:
                 x = 42
             else:
                 x = None
@@ -218,7 +223,7 @@ class Communicator:
         .. code::
 
             comm = relentless.mpi.Communicator()
-            if comm.rank == comm.root:
+            if comm.rank_is_root:
                 x = numpy.array([1,2,3], dtype=numpy.int32)
             else:
                 x = None
@@ -229,7 +234,7 @@ class Communicator:
         .. code::
 
             comm = relentless.mpi.Communicator()
-            if comm.rank == comm.root:
+            if comm.rank_is_root:
                 x = numpy.array([1,2,3], dtype=numpy.int32)
             else:
                 x = numpy.empty(3, dtype=numpy.int32)

--- a/relentless/optimize/method.py
+++ b/relentless/optimize/method.py
@@ -53,7 +53,9 @@ import abc
 
 import numpy
 
+from relentless import data
 from relentless import math
+from relentless import mpi
 from relentless import variable
 from .criteria import ConvergenceTest,Tolerance
 
@@ -83,7 +85,7 @@ class Optimizer(abc.ABC):
             The objective function to be optimized.
         design_variables: :class:`~relentless.variable.DesignVariable` or tuple
             Design variable(s) to optimize.
-        directory : :class:`~relentless.data.Directory`
+        directory : str or :class:`~relentless.data.Directory`
             Directory for writing output during optimization. Default of ``None``
             requests no output is written.
 
@@ -169,7 +171,7 @@ class LineSearch:
             The objective function evaluated at the start of the search interval.
         end : :class:`~relentless.optimize.objective.ObjectiveFunctionResult`
             The objective function evaluated at the end of the search interval.
-        directory : :class:`~relentless.data.Directory`
+        directory : str or :class:`~relentless.data.Directory`
             Directory for writing output during search. Default of ``None``
             requests no output is written.
 
@@ -191,6 +193,8 @@ class LineSearch:
             If the relative tolerance is not between 0 and 1.
 
         """
+        if directory is not None:
+            directory = data.Directory.cast(directory)
         ovars = {x: x.value for x in start.variables}
 
         # compute search direction
@@ -370,7 +374,7 @@ class SteepestDescent(Optimizer):
             The objective function to be optimized.
         design_variables: :class:`~relentless.variable.DesignVariable` or tuple
             Design variable(s) to optimize.
-        directory : :class:`~relentless.data.Directory`
+        directory : str or :class:`~relentless.data.Directory`
             Directory for writing output during optimization. Default of `None`
             requests no output is written.
 
@@ -384,6 +388,9 @@ class SteepestDescent(Optimizer):
         design_variables = variable.graph.check_variables_and_types(design_variables, variable.DesignVariable)
         if len(design_variables) == 0:
             return None
+
+        if directory is not None:
+            directory = data.Directory.cast(directory)
 
         #fix scaling parameters
         scale = math.KeyedArray(keys=design_variables)

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -132,16 +132,6 @@ class test_RelativeEntropy(unittest.TestCase):
         self.assertEqual(relent.simulation, self.simulation)
         self.assertEqual(relent.potentials, self.potentials)
         self.assertEqual(relent.thermo, self.thermo)
-        self.assertIsNone(relent.communicator)
-
-        #test communicator argument
-        comm = relentless.mpi.world
-        relent.communicator = comm
-        self.assertEqual(relent.target, self.target)
-        self.assertEqual(relent.simulation, self.simulation)
-        self.assertEqual(relent.potentials, self.potentials)
-        self.assertEqual(relent.thermo, self.thermo)
-        self.assertEqual(relent.communicator, comm)
 
         #test invalid target ensemble
         with self.assertRaises(ValueError):

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -100,14 +100,14 @@ class test_SimulationInstance(unittest.TestCase):
         pots = relentless.simulate.Potentials()
 
         #no options
-        sim = relentless.simulate.SimulationInstance(None, ens, pots, self.directory, relentless.mpi.world)
+        sim = relentless.simulate.SimulationInstance(None, ens, pots, self.directory)
         self.assertEqual(sim.ensemble, ens)
         self.assertEqual(sim.potentials, pots)
         with self.assertRaises(AttributeError):
             sim.constant_ens
 
         #with options
-        sim = relentless.simulate.SimulationInstance(None, ens, pots, self.directory, relentless.mpi.world, **options)
+        sim = relentless.simulate.SimulationInstance(None, ens, pots, self.directory, **options)
         self.assertEqual(sim.ensemble, ens)
         self.assertEqual(sim.potentials, pots)
         self.assertTrue(sim.constant_ens)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -41,7 +41,7 @@ class test_Communicator(unittest.TestCase):
 
     def test_bcast(self):
         # broadcast from default root
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             x = 42
         else:
             x = None
@@ -51,7 +51,7 @@ class test_Communicator(unittest.TestCase):
         # broadcast from specified root
         if self.comm.size >= 2:
             root = 1
-            if self.comm.rank == root:
+            if self.comm.rank_is_root:
                 x = 7
             else:
                 x = None
@@ -60,7 +60,7 @@ class test_Communicator(unittest.TestCase):
 
     def test_bcast_numpy(self):
         # float array
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             x = numpy.array([1.,2.],dtype=numpy.float64)
         else:
             x = None
@@ -72,7 +72,7 @@ class test_Communicator(unittest.TestCase):
         # float array from specified root
         if self.comm.size >= 2:
             root = 1
-            if self.comm.rank == root:
+            if self.comm.rank_is_root:
                 x = numpy.array([3.,4.],dtype=numpy.float64)
             else:
                 x = None
@@ -82,7 +82,7 @@ class test_Communicator(unittest.TestCase):
             numpy.testing.assert_allclose(x,[3.,4.])
 
         # prealloc'd float array
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             x = numpy.array([5.,6.],dtype=numpy.float64)
         else:
             x = numpy.zeros((2,),dtype=numpy.float64)
@@ -93,13 +93,12 @@ class test_Communicator(unittest.TestCase):
         numpy.testing.assert_allclose(y,[5.,6.])
 
         # incorrectly alloc'd float array
-        print('')
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             x = numpy.array([5.,6.],dtype=numpy.float64)
         else:
             x = numpy.zeros((2,),dtype=numpy.int32)
         y = self.comm.bcast_numpy(x)
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             self.assertTrue(y is x)
         else:
             self.assertTrue(y is not x)
@@ -109,7 +108,7 @@ class test_Communicator(unittest.TestCase):
 
     def test_loadtxt(self):
         # create file
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             tmp = tempfile.NamedTemporaryFile(delete=False)
             tmp.write(b'1 2\n 3 4\n')
             tmp.close()
@@ -122,7 +121,7 @@ class test_Communicator(unittest.TestCase):
         dat = self.comm.loadtxt(filename)
 
         # unlink before testing in case an exception gets raised
-        if self.comm.rank == self.comm.root:
+        if self.comm.rank_is_root:
             os.unlink(tmp.name)
 
         numpy.testing.assert_allclose(dat, [[1.,2.],[3.,4.]])


### PR DESCRIPTION
This PR removes the `communicator` argument throughout the code base and defaults to the global `mpi.world` everywhere. We can think about the best way to implement subcommunicators later if we have a strong reason for doing so.

This PR is based off #96 and should be rebased before review and merging.

Resolves #95 