### PR TITLE
Add rmin attribute to PairPotentialTabulator

### DIFF
--- a/doc/source/guide/install.rst
+++ b/doc/source/guide/install.rst
@@ -33,7 +33,7 @@ The required dependencies are pretty minimal:
 - `Python <https://www.python.org>`_ (>= 3.6)
 - `NumPy <https://numpy.org>`_
 - `SciPy <https://www.scipy.org>`_
-- `networkx <https://networkx.org>`_ (>= 2.4)
+- `networkx <https://networkx.org>`_ (>= 2.5)
 
 and can be installed from ``requirements.txt``.
 

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -201,9 +201,10 @@ class SimulationOperation(abc.ABC):
 class Potentials:
     """Combination of multiple potentials.
 
-    Initializes a :class:`PairPotentialTabulator` object that can store multiple potentials.
-    Before the :class:`Potentials` object can be used, the ``rmax`` and ``num``
-    attributes of all ``pair``\s (that are not ``None``) must be set.
+    Initializes a :class:`PairPotentialTabulator` object that can store multiple
+    potentials. Before the :class:`Potentials` object can be used, the ``rmax``
+    and ``num`` attributes of all ``pair``\s (that are not ``None``) must be set.
+    Additionally, the ``rmin`` attribute defaults to 0.
 
     Parameters
     ----------
@@ -213,7 +214,11 @@ class Potentials:
 
     """
     def __init__(self, pair_potentials=None):
-        self._pair = PairPotentialTabulator(rmax=None,num=None,neighbor_buffer=0.0,potentials=pair_potentials)
+        self._pair = PairPotentialTabulator(rmin=0.0,
+                                            rmax=None,
+                                            num=None,
+                                            neighbor_buffer=0.0,
+                                            potentials=pair_potentials)
 
     @property
     def pair(self):
@@ -381,6 +386,8 @@ class PairPotentialTabulator(PotentialTabulator):
 
     Parameters
     ----------
+    rmin : float
+        The minimum value of ``r`` at which to tabulate.
     rmax : float
         The maximum value of ``r`` at which to tabulate.
     num : int
@@ -394,8 +401,8 @@ class PairPotentialTabulator(PotentialTabulator):
         The maximum value of force at which to allow evaluation.
 
     """
-    def __init__(self, rmax, num, neighbor_buffer, potentials=None, fmax=None):
-        super().__init__(0,rmax,num,potentials)
+    def __init__(self, rmin, rmax, num, neighbor_buffer, potentials=None, fmax=None):
+        super().__init__(rmin,rmax,num,potentials)
         self.neighbor_buffer = neighbor_buffer
         self.fmax = fmax
 
@@ -403,6 +410,15 @@ class PairPotentialTabulator(PotentialTabulator):
     def r(self):
         """array_like: The values of ``r`` at which to evaluate :meth:`energy`, :meth:`force`, and :meth:`derivative`."""
         return self.x
+
+    @property
+    def rmin(self):
+        """float: The minimum value of ``r`` at which to allow tabulation."""
+        return self.start
+
+    @rmin.setter
+    def rmin(self, val):
+        self.start = val
 
     @property
     def rmax(self):

--- a/relentless/variable.py
+++ b/relentless/variable.py
@@ -90,7 +90,7 @@ class Variable(abc.ABC):
     variable is an abstract property that must be implemented. On creation, the
     :class:`Variable` will be inserted into the :class:`VariableGraph` for the
     project.
-    
+
     Most users should not inherit from this variable directly but should make
     use of the more flexible :class:`IndependentVariable` or
     :class:`DependentVariable` types.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx>=2.4
+networkx>=2.5
 numpy
 packaging
 scipy

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -241,17 +241,19 @@ class test_PairPotentialTabulator(unittest.TestCase):
         """Test creation with data."""
         rs = numpy.array([0.0,0.5,1,1.5])
 
-        #test creation with required param
-        t = relentless.simulate.PairPotentialTabulator(rmax=1.5,num=4,neighbor_buffer=0.4)
+        #test creation with only required parameters
+        t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=1.5,num=4,neighbor_buffer=0.4)
         numpy.testing.assert_allclose(t.r,rs)
+        self.assertAlmostEqual(t.rmin, 0.0)
         self.assertAlmostEqual(t.rmax, 1.5)
         self.assertEqual(t.num, 4)
         self.assertEqual(t.neighbor_buffer, 0.4)
         self.assertEqual(t.fmax, None)
 
-        #test creation with required param, fmax, fcut, shift
-        t = relentless.simulate.PairPotentialTabulator(rmax=1.5,num=4,neighbor_buffer=0.4,fmax=1.5)
+        #test creation with required parameters and fmax
+        t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=1.5,num=4,neighbor_buffer=0.4,fmax=1.5)
         numpy.testing.assert_allclose(t.r, rs)
+        self.assertAlmostEqual(t.rmin, 0.0)
         self.assertAlmostEqual(t.rmax, 1.5)
         self.assertEqual(t.num, 4)
         self.assertEqual(t.neighbor_buffer, 0.4)
@@ -264,7 +266,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         p2 = QuadPairPot(types=('1','2'), params=('m',))
         for pair in p2.coeff.pairs:
             p2.coeff[pair]['m'] = 1.0
-        t = relentless.simulate.PairPotentialTabulator(rmax=5,num=6,neighbor_buffer=0.4,potentials=[p1,p2])
+        t = relentless.simulate.PairPotentialTabulator(rmin=0,rmax=5,num=6,neighbor_buffer=0.4,potentials=[p1,p2])
 
         # test energy method
         u = t.energy(('1','1'))
@@ -293,7 +295,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         p1 = QuadPairPot(types=('1',), params=('m',))
         p1.coeff['1','1']['m'] = 3.0
 
-        t = relentless.simulate.PairPotentialTabulator(rmax=6.0,num=7,neighbor_buffer=0.4,potentials=p1,fmax=4)
+        t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=6.0,num=7,neighbor_buffer=0.4,potentials=p1,fmax=4)
         f = t.force(('1','1'))
         numpy.testing.assert_allclose(f, numpy.array([4,4,4,0,-4,-4,-4]))
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -16,23 +16,23 @@ class test_FixedKeyDict(unittest.TestCase):
         #test construction with tuple input
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
         self.assertCountEqual(d.keys(), keys)
-        self.assertEqual([d[k] for k in d.keys()], [None, None])
+        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
 
         #test construction with list input
         d = relentless.collections.FixedKeyDict(keys=['A','B'])
         self.assertCountEqual(d.keys(), keys)
-        self.assertEqual([d[k] for k in d.keys()], [None, None])
+        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
 
         #test construction with defined default input
         d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertCountEqual(d.keys(), keys)
-        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         #test construction with single-key tuple input
         keys = ('A',)
         d = relentless.collections.FixedKeyDict(keys=('A',))
         self.assertCountEqual(d.keys(), keys)
-        self.assertEqual([d[k] for k in d.keys()], [None])
+        self.assertCountEqual([d[k] for k in d.keys()], [None])
 
     def test_accessors(self):
         """Test get and set methods on keys."""
@@ -40,15 +40,15 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test setting and getting values
         d['A'] = 1.0
-        self.assertEqual([d[k] for k in d.keys()], [1.0, None])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, None])
         d['B'] = 1.0
-        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         #test re-setting and getting values
         d['A'] = 2.0
-        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.0])
         d['B'] = 1.5
-        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
+        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
         #test getting invalid key
         with self.assertRaises(KeyError):
@@ -58,21 +58,21 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test update method to get and set keys."""
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
 
-        self.assertEqual([d[k] for k in d.keys()], [None, None])
+        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
 
         #test updating both keys
         d.update({'A':1.0, 'B':2.0})  #using dict
-        self.assertEqual([d[k] for k in d.keys()], [1.0, 2.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 2.0])
 
         d.update(A=1.5, B=2.5)  #using kwargs
-        self.assertEqual([d[k] for k in d.keys()], [1.5, 2.5])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.5, 2.5])
 
         #test updating only one key at a time
         d.update({'A':1.1})   #using dict
-        self.assertEqual([d[k] for k in d.keys()], [1.1, 2.5])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.1, 2.5])
 
         d.update(B=2.2)   #using kwargs
-        self.assertEqual([d[k] for k in d.keys()], [1.1, 2.2])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.1, 2.2])
 
         #test using *args length > 1
         with self.assertRaises(TypeError):
@@ -80,7 +80,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test using both *args and **kwargs
         d.update({'A':3.0, 'B':2.0}, B=2.2)
-        self.assertEqual([d[k] for k in d.keys()], [3.0, 2.2])
+        self.assertCountEqual([d[k] for k in d.keys()], [3.0, 2.2])
 
         #test using invalid kwarg
         with self.assertRaises(KeyError):
@@ -90,19 +90,19 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test clear method to reset keys to default."""
         #test clear with no default set
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
-        self.assertEqual([d[k] for k in d.keys()], [None, None])
+        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
         d.update(A=2, B=3)
-        self.assertEqual([d[k] for k in d.keys()], [2.0, 3.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 3.0])
         d.clear()
-        self.assertEqual([d[k] for k in d.keys()], [None, None])
+        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
 
         #test clear with set default
         d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
-        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
         d.update(A=2, B=3)
-        self.assertEqual([d[k] for k in d.keys()], [2.0, 3.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 3.0])
         d.clear()
-        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
     def test_iteration(self):
         """Test iteration on the dictionary."""
@@ -111,18 +111,18 @@ class test_FixedKeyDict(unittest.TestCase):
         #test iteration for setting values
         for k in d:
             d[k] = 1.0
-        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         #test manual re-setting of values
         d['A'] = 2.0
-        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.0])
         d['B'] = 1.5
-        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
+        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
         #test iteration for re-setting values
         for k in d:
             d[k] = 3.0
-        self.assertEqual([d[k] for k in d.keys()], [3.0, 3.0])
+        self.assertCountEqual([d[k] for k in d.keys()], [3.0, 3.0])
 
     def test_copy(self):
         """Test copying custom dict to standard dict."""


### PR DESCRIPTION
- Add `rmin` property to `PairPotentialTabulator` class
- Default `rmin` to 0 in `Potentials` class
- Modify corresponding documentation and unit tests


Additional changes: fix unit tests for list equality in `test_collections.py`, fix `networkx` version in `requirements.txt`