### PR TITLE
Fix spline design_variables, other stylistic errors

### DIFF
--- a/relentless/collections.py
+++ b/relentless/collections.py
@@ -64,7 +64,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
     Partially reassign/update values::
 
         d.update({'A':0.5})
-        d.update(A=0.5)  #equivalent statement
+        d.update(A=0.5)  # equivalent statement
         >>> print(d)
         {'A':0.5, 'B':1.0}
 

--- a/relentless/collections.py
+++ b/relentless/collections.py
@@ -110,7 +110,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
         self._data[key] = self.default
 
     def __iter__(self):
-        yield from self._keys
+        return iter(self._keys)
 
     def __len__(self):
         return len(self._data)

--- a/relentless/collections.py
+++ b/relentless/collections.py
@@ -110,7 +110,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
         self._data[key] = self.default
 
     def __iter__(self):
-        return iter(self._data)
+        yield from self._keys
 
     def __len__(self):
         return len(self._data)

--- a/relentless/data.py
+++ b/relentless/data.py
@@ -73,7 +73,7 @@ class Directory:
     @classmethod
     def cast(cls, directory):
         """Try to cast an object to a directory.
-        
+
         Ensure that a `str` or :class:`Directory` is a :class:`Directory`. No
         action is taken if the object is already a :class:`Directory`. Otherwise,
         a new one is constructed.

--- a/relentless/optimize/criteria.py
+++ b/relentless/optimize/criteria.py
@@ -194,7 +194,7 @@ class GradientTest(ConvergenceTest):
 
     .. code::
 
-        test = GradientTest(1.e-3)
+        test = GradientTest(1.e-3, (x,y))
         test.tolerance[x] = 1.e-2
 
     The result is converged with respect to an unconstrained design variable

--- a/relentless/optimize/method.py
+++ b/relentless/optimize/method.py
@@ -392,7 +392,7 @@ class SteepestDescent(Optimizer):
         if directory is not None:
             directory = data.Directory.cast(directory)
 
-        #fix scaling parameters
+        # fix scaling parameters
         scale = math.KeyedArray(keys=design_variables)
         for x in design_variables:
             if numpy.isscalar(self.scale):
@@ -410,13 +410,13 @@ class SteepestDescent(Optimizer):
             grad_y = scale*cur_res.gradient
             update = self.descent_amount(grad_y)*grad_y
 
-            #steepest descent update
+            # steepest descent update
             for x in design_variables:
                 x.value = cur_res.variables[x] - update[x]
             next_dir = cur_dir.directory('.next') if cur_dir is not None else None
             next_res = objective.compute(design_variables, next_dir)
 
-            #if line search, attempt backtracking in interval
+            # if line search, attempt backtracking in interval
             if self.line_search is not None:
                 line_dir = cur_dir.directory('.line') if cur_dir is not None else None
                 line_res = self.line_search.find(objective=objective,

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -336,7 +336,7 @@ class RelativeEntropy(ObjectiveFunction):
                 us = self.potentials.pair.energy((i,j))
                 dus = self.potentials.pair.derivative((i,j),var)
 
-                #only count (continuous range of) finite values
+                # only count (continuous range of) finite values
                 flags = numpy.isinf(us)
                 first_finite = 0
                 while flags[first_finite] and first_finite < len(rs):
@@ -346,7 +346,7 @@ class RelativeEntropy(ObjectiveFunction):
                 if first_finite == len(rs):
                     continue
 
-                #interpolate derivative wrt design variable with r
+                # interpolate derivative wrt design variable with r
                 dudvar = math.Interpolator(rs,dus)
 
                 # find common domain to compare rdfs

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -98,16 +98,16 @@ class ObjectiveFunctionResult:
     Parameters
     ----------
     variables : :class:`~relentless.variable.Variable` or tuple
-        Variables to stash values
+        Variables to stash values (defaults to ``None``).
     value : float
-        The value of the objective function.
+        The value of the objective function (defaults to ``None``).
     gradient : dict
         The gradient of the objective function. Each partial derivative is
         keyed on the :class:`~relentless.variable.DesignVariable`
-        with respect to which it is taken.
+        with respect to which it is taken (defaults to ``None``).
     directory : :class:`~relentless.data.Directory`
         Directory holding written output associated with result. Setting
-        a value of ``None`` indicates no written output.
+        a value of ``None`` indicates no written output (defaults to ``None``).
 
     Raises
     ------
@@ -177,14 +177,14 @@ class ObjectiveFunctionResult:
 
     def _assert_keys_match(self, vars, grad):
         """Assert that the keys of the variables and gradient match.
-        
+
         Parameters
         ----------
         vars : dict
             Variable dictionary-like object
         grad : dict
             Gradient dictionary-like object.
-        
+
         Raises
         ------
         AssertionError

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -1075,11 +1075,12 @@ class PairSpline(PairPotential):
     def design_variables(self):
         """tuple: Designable variables of the spline."""
         dvars = []
-        for r,k in self.knots:
-            if isinstance(r, variable.DesignVariable):
-                dvars.append(r)
-            if isinstance(k, variable.DesignVariable):
-                dvars.append(k)
+        for pair in self.coeff:
+            for r,k in self.knots(pair):
+                if isinstance(r, variable.DesignVariable):
+                    dvars.append(r)
+                if isinstance(k, variable.DesignVariable):
+                    dvars.append(k)
         return tuple(dvars)
 
 class Yukawa(PairPotential):

--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -1001,7 +1001,7 @@ class PairSpline(PairPotential):
         r,d,s = self._zeros(r)
         h = 0.001
 
-        #perturb knot param value
+        # perturb knot param value
         knot_p = params[param]
         params[param] = knot_p + h
         f_high = self._interpolate(params)(r)

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -267,7 +267,7 @@ class Initialize(simulate.SimulationOperation):
                                                         rmax=r[-1],
                                                         coeff=dict(r=r,u=u,f=f))
 
-    #helper method for attach_potentials
+    # helper method for attach_potentials
     def _table_eval(self, r_i, rmin, rmax, **coeff):
         r = coeff['r']
         u = coeff['u']

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -180,6 +180,7 @@ class LAMMPSOperation(simulate.SimulationOperation):
         """
         pass
 
+## initializers
 class Initialize(LAMMPSOperation):
     """Initializes a simulation box and pair potentials.
 
@@ -451,6 +452,7 @@ class InitializeRandomly(Initialize):
 
         return cmds
 
+## integrators
 class MinimizeEnergy(LAMMPSOperation):
     """Runs an energy minimization until converged.
 
@@ -775,6 +777,7 @@ class RunUpTo(LAMMPSOperation):
 
         return cmds
 
+## analyzers
 class AddEnsembleAnalyzer(LAMMPSOperation):
     """Analyzes the simulation ensemble and rdf at specified timestep intervals.
 

--- a/relentless/variable.py
+++ b/relentless/variable.py
@@ -581,7 +581,7 @@ class DependentVariable(Variable):
     @property
     def value(self):
         """float: Value of the variable.
-        
+
         The variable will be evaluated using the `VariableGraph` if it needs to
         be recomputed.
 
@@ -619,10 +619,10 @@ class DependentVariable(Variable):
     @abc.abstractmethod
     def compute(self):
         """Implementation of the value.
-        
+
         This method should implement calculation of the variable from the
         parameter keywords. The parameters will be passed as keyword arguments.
-        
+
         """
         pass
 
@@ -974,7 +974,7 @@ class VariableGraph:
 
     def set_dependencies(self, x, depends):
         """Set dependencies of a variable in the graph.
-        
+
         The dependencies of ``x`` should be specified as a dictionary whose
         keys are the names of the parameters and whose values are :class:`Variable`
         objects (or values that can be coerced to variables). Any existing
@@ -986,7 +986,7 @@ class VariableGraph:
         x : :class:`DependentVariable`
             Dependent variable to set dependencies for.
         depends : dict
-            Variable(s) specifying the parameters that ``x`` depends
+            Variable(s) specifying the parameters on which ``x`` depends.
 
         Raises
         ------
@@ -1012,9 +1012,9 @@ class VariableGraph:
 
     def update(self, x):
         """Mark a variable as being updated.
-        
+
         When an :class:`IndependentVariable` is updated, the graph is updated to
-        reflect that on :class:`DependentVariable` objects that depend on it need to
+        reflect that :class:`DependentVariable` objects that depend on it need to
         be recomputed. This is done in a lazy way by marking a private property,
         so the values are only recomputed when they are needed. The update is
         performed using depth-first search of the graph with the dependency
@@ -1030,7 +1030,7 @@ class VariableGraph:
         ----------
         x : :class:`IndependentVariable`
             Independent variable to update.
-        
+
         """
         self._assert_is_variable(x)
         self._assert_in_graph(x)
@@ -1050,8 +1050,8 @@ class VariableGraph:
         of the graph up). The results are stored in private attributes of the
         variables and cached to make subsequent evaluation faster.
 
-        If ``x`` is not a :class:`DependentVariable`, nothing needs to be done and the
-        value is simply returned.
+        If ``x`` is not a :class:`DependentVariable`, nothing needs to be done
+        and the value is simply returned.
 
         Parameters
         ----------
@@ -1158,11 +1158,11 @@ class VariableGraph:
 
     def check_variables_and_types(self, x, types):
         """Coerce variables to a tuple and check types.
-        
+
         Parameters
         ----------
         x : :class:`Variable` or tuple
-            Variable(s) to check
+            Variable(s) to check.
         types : tuple
             Valid types for the variables to have (per `isinstance`).
 
@@ -1201,7 +1201,7 @@ class VariableGraph:
         """Assert object is a node in the graph."""
         self._assert_is_variable(x)
         if x not in self._graph:
-            raise AssertionError('Object has not been added to graph')       
+            raise AssertionError('Object has not been added to graph')
 
     def _ensure_variable(self, x):
         """Coerce an object into a variable.

--- a/tests/optimize/test_criteria.py
+++ b/tests/optimize/test_criteria.py
@@ -19,7 +19,7 @@ class test_Tolerance(unittest.TestCase):
         self.assertAlmostEqual(t.absolute[y], 1.0)
         self.assertAlmostEqual(t.relative[y], 0.5)
 
-        #test changing tolerances by scalar
+        # test changing tolerances by scalar
         t.absolute.default = 1.1
         t.relative.default = 0.6
         self.assertAlmostEqual(t.absolute[x], 1.1)
@@ -27,7 +27,7 @@ class test_Tolerance(unittest.TestCase):
         self.assertAlmostEqual(t.absolute[y], 1.1)
         self.assertAlmostEqual(t.relative[y], 0.6)
 
-        #test changing tolerances by key
+        # test changing tolerances by key
         t.absolute[x] = 1.2
         t.relative[x] = 0.7
         self.assertAlmostEqual(t.absolute[x], 1.2)
@@ -45,7 +45,7 @@ class test_Tolerance(unittest.TestCase):
         self.assertTrue(t.isclose(x.value, 2.7, key=x))
         self.assertTrue(t.isclose(x.value, 2.7))
 
-        #test invalid tolerances
+        # test invalid tolerances
         with self.assertRaises(ValueError):
             t = relentless.optimize.Tolerance(absolute=-0.1, relative=0.1)
             t.isclose(x.value, 2.5)
@@ -67,7 +67,7 @@ class test_GradientTest(unittest.TestCase):
         self.assertAlmostEqual(t.tolerance[x], 1e-8)
         self.assertAlmostEqual(t.tolerance.default, 1e-8)
 
-        #change tolerance
+        # change tolerance
         t.tolerance[x] = 1e-5
         self.assertAlmostEqual(t.tolerance[x], 1e-5)
         self.assertAlmostEqual(t.tolerance.default, 1e-8)
@@ -82,7 +82,7 @@ class test_GradientTest(unittest.TestCase):
         x.value = 0.999999999
         self.assertTrue(t.converged(result=q.compute(x)))
 
-        #test at high
+        # test at high
         x.value = -2.0
         x.high = 2.0
         self.assertFalse(t.converged(result=q.compute(x)))
@@ -90,7 +90,7 @@ class test_GradientTest(unittest.TestCase):
         x.high = 0.0
         self.assertTrue(t.converged(result=q.compute(x)))
 
-        #test at low
+        # test at low
         x.high = None
         x.value = 0.0
         x.low = 0.0
@@ -106,19 +106,19 @@ class test_ValueTest(unittest.TestCase):
         """Test creation with data."""
         x = relentless.variable.DesignVariable(value=3.0)
 
-        #test default values
+        # test default values
         t = relentless.optimize.ValueTest(value=2.5)
         self.assertAlmostEqual(t.absolute, 1e-8)
         self.assertAlmostEqual(t.relative, 1e-5)
         self.assertAlmostEqual(t.value, 2.5)
 
-        #non-default values
+        # non-default values
         t = relentless.optimize.ValueTest(absolute=1e-7, relative=1e-4, value=3.0)
         self.assertAlmostEqual(t.absolute, 1e-7)
         self.assertAlmostEqual(t.relative, 1e-4)
         self.assertAlmostEqual(t.value, 3.0)
 
-        #change parameters
+        # change parameters
         t.absolute = 1e-9
         t.relative = 1e-5
         t.value = 1.5

--- a/tests/optimize/test_method.py
+++ b/tests/optimize/test_method.py
@@ -120,7 +120,7 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertEqual(o.stop, t)
         self.assertEqual(o.max_iter, 1000)
         self.assertAlmostEqual(o.step_size, 0.25)
-        self.assertDictEqual(o.scale, {x:0.3})
+        self.assertEqual(o.scale, {x:0.3})
         self.assertIsNone(o.line_search)
 
         #test using line search
@@ -129,7 +129,7 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertEqual(o.stop, t)
         self.assertEqual(o.max_iter, 1000)
         self.assertAlmostEqual(o.step_size, 0.25)
-        self.assertDictEqual(o.scale, {x:0.3})
+        self.assertEqual(o.scale, {x:0.3})
         self.assertEqual(o.line_search, l)
 
         #test invalid parameters

--- a/tests/optimize/test_method.py
+++ b/tests/optimize/test_method.py
@@ -22,7 +22,7 @@ class test_LineSearch(unittest.TestCase):
         self.assertAlmostEqual(l.tolerance, 1e-8)
         self.assertEqual(l.max_iter, 1000)
 
-        #test invalid parameters
+        # test invalid parameters
         with self.assertRaises(ValueError):
             l.max_iter = 0
         with self.assertRaises(TypeError):
@@ -35,7 +35,7 @@ class test_LineSearch(unittest.TestCase):
         q = QuadraticObjective(x=x)
         res_1 = q.compute(x)
 
-        #bracketing the minimum (find step size that takes function to minimum)
+        # bracketing the minimum (find step size that takes function to minimum)
         x.value = 3.0
         res_2 = q.compute(x)
         x.value = -3.0
@@ -53,7 +53,7 @@ class test_LineSearch(unittest.TestCase):
         self.assertTrue(os.path.isdir(os.path.join(d.path,'0')))
         self.assertTrue(os.path.isfile(os.path.join(d.path,'0','x.log')))
 
-        #not bracketing the minimum (accept "maximum" step size)
+        # not bracketing the minimum (accept "maximum" step size)
         x.value = -1.0
         res_3 = q.compute(x)
         x.value = -3.0
@@ -62,21 +62,21 @@ class test_LineSearch(unittest.TestCase):
         self.assertAlmostEqual(res_new.gradient[x], -4.0)
         self.assertEqual(q.x.value, -3.0)
 
-        #bound does not include current objective value
+        # bound does not include current objective value
         res_new = l.find(objective=q, start=res_3, end=res_2)
         self.assertAlmostEqual(res_new.variables[x], 1.0)
         self.assertAlmostEqual(res_new.gradient[x], 0.0)
         self.assertEqual(q.x.value, -3.0)
 
-        #invalid search interval (not descent direction)
+        # invalid search interval (not descent direction)
         with self.assertRaises(ValueError):
             res_new = l.find(objective=q, start=res_3, end=res_1)
 
-        #invalid search interval (0 distance from start to end)
+        # invalid search interval (0 distance from start to end)
         with self.assertRaises(ValueError):
             res_new = l.find(objective=q, start=res_3, end=res_3)
 
-        #invalid tolerance
+        # invalid tolerance
         with self.assertRaises(ValueError):
             l.tolerance = -1e-9
             l.find(objective=q, start=res_1, end=res_3)
@@ -107,7 +107,7 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertAlmostEqual(o.scale, 1.0)
         self.assertIsNone(o.line_search)
 
-        #test scalar scaling parameter
+        # test scalar scaling parameter
         o.scale = 0.5
         self.assertEqual(o.stop, t)
         self.assertEqual(o.max_iter, 1000)
@@ -115,7 +115,7 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertAlmostEqual(o.scale, 0.5)
         self.assertIsNone(o.line_search)
 
-        #test dictionary of scaling parameters
+        # test dictionary of scaling parameters
         o.scale = {x:0.3}
         self.assertEqual(o.stop, t)
         self.assertEqual(o.max_iter, 1000)
@@ -123,7 +123,7 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertEqual(o.scale, {x:0.3})
         self.assertIsNone(o.line_search)
 
-        #test using line search
+        # test using line search
         l = relentless.optimize.LineSearch(tolerance=1e-9, max_iter=100)
         o.line_search = l
         self.assertEqual(o.stop, t)
@@ -132,7 +132,7 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertEqual(o.scale, {x:0.3})
         self.assertEqual(o.line_search, l)
 
-        #test invalid parameters
+        # test invalid parameters
         with self.assertRaises(TypeError):
             o.stop = 1e-8
         with self.assertRaises(ValueError):
@@ -158,25 +158,25 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-        #test insufficient maximum iterations
+        # test insufficient maximum iterations
         x.value = 1.5
         o.max_iter = 1
         self.assertFalse(o.optimize(objective=q, design_variables=x))
 
-        #test with nontrivial scalar scaling parameter
+        # test with nontrivial scalar scaling parameter
         x.value = 50
         o.scale = 0.85
         o.max_iter = 1000
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-        #test with nontrivial dictionary of scaling parameters
+        # test with nontrivial dictionary of scaling parameters
         x.value = -35
         o.scale = {x:1.5}
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-        #test using line search option
+        # test using line search option
         x.value = 3
         o.line_search = relentless.optimize.LineSearch(tolerance=1e-5, max_iter=100)
         self.assertTrue(o.optimize(objective=q, design_variables=x))
@@ -260,31 +260,31 @@ class test_FixedStepDescent(unittest.TestCase):
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-        #test insufficient maximum iterations
+        # test insufficient maximum iterations
         x.value = 1.5
         o.max_iter = 1
         self.assertFalse(o.optimize(objective=q, design_variables=x))
 
-        #test step size that does not converge
+        # test step size that does not converge
         x.value = 1.5
         o.step_size = 0.42
         o.max_iter = 10000
         self.assertFalse(o.optimize(objective=q, design_variables=x))
 
-        #test with nontrivial scalar scaling parameter
+        # test with nontrivial scalar scaling parameter
         x.value = 50
         o.step_size = 0.25
         o.scale = 4.0
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-        #test with nontrivial dictionary of scaling parameters
+        # test with nontrivial dictionary of scaling parameters
         x.value = -35
         o.scale = {x:1.5}
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-        #test using line search option
+        # test using line search option
         x.value = 3
         o.line_search = relentless.optimize.LineSearch(tolerance=1e-5, max_iter=100)
         self.assertTrue(o.optimize(objective=q, design_variables=x))

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -48,9 +48,9 @@ class test_ObjectiveFunction(unittest.TestCase):
         self.assertAlmostEqual(res.variables[x], 4.0)
 
         x.value = 3.0
-        self.assertAlmostEqual(res.variables[x], 4.0) #maintains the value at time of construction
+        self.assertAlmostEqual(res.variables[x], 4.0) # maintains the value at time of construction
 
-        #test "invalid" variable
+        # test "invalid" variable
         with self.assertRaises(KeyError):
             m = res.gradient[relentless.variable.SameAs(x)]
 
@@ -133,7 +133,7 @@ class test_RelativeEntropy(unittest.TestCase):
         self.assertEqual(relent.potentials, self.potentials)
         self.assertEqual(relent.thermo, self.thermo)
 
-        #test invalid target ensemble
+        # test invalid target ensemble
         with self.assertRaises(ValueError):
             relent.target = relentless.ensemble.Ensemble(T=1.5, P=1, N={'1':50})
 
@@ -159,7 +159,7 @@ class test_RelativeEntropy(unittest.TestCase):
         numpy.testing.assert_allclose(res_grad[self.epsilon], grad_eps, atol=1e-4)
         numpy.testing.assert_allclose(res_grad[self.sigma], grad_sig, atol=1e-4)
 
-        #test extensive option
+        # test extensive option
         relent = relentless.optimize.RelativeEntropy(self.target,
                                                      self.simulation,
                                                      self.potentials,

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -582,6 +582,7 @@ class test_PairSpline(unittest.TestCase):
         s = relentless.potential.PairSpline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
+        dvars = []
         for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
             self.assertAlmostEqual(r.value, r_arr[i])
             self.assertAlmostEqual(k.value, u_arr_diff[i])
@@ -590,11 +591,14 @@ class test_PairSpline(unittest.TestCase):
                 self.assertIsInstance(k, relentless.variable.IndependentVariable)
             else:
                 self.assertIsInstance(k, relentless.variable.DesignVariable)
+                dvars.append(k)
+        self.assertCountEqual(s.design_variables, dvars)
 
         #test value mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
+        dvars = []
         for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
             self.assertAlmostEqual(r.value, r_arr[i])
             self.assertAlmostEqual(k.value, u_arr[i])
@@ -603,6 +607,8 @@ class test_PairSpline(unittest.TestCase):
                 self.assertIsInstance(k, relentless.variable.IndependentVariable)
             else:
                 self.assertIsInstance(k, relentless.variable.DesignVariable)
+                dvars.append(k)
+        self.assertCountEqual(s.design_variables, dvars)
 
         #test invalid r and u shapes
         r_arr = [2,3]

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -16,29 +16,29 @@ class test_PairParameters(unittest.TestCase):
         pairs = (('A','B'), ('B','B'), ('A','A'))
         params = ('energy', 'mass')
 
-        #test construction with tuple input
+        # test construction with tuple input
         m = relentless.potential.PairParameters(types=('A','B'), params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
-        #test construction with list input
+        # test construction with list input
         m = relentless.potential.PairParameters(types=['A','B'], params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
-        #test construction with mixed tuple/list input
+        # test construction with mixed tuple/list input
         m = relentless.potential.PairParameters(types=('A','B'), params=['energy','mass'])
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
-        #test construction with int type parameters
+        # test construction with int type parameters
         with self.assertRaises(TypeError):
             m = relentless.potential.PairParameters(types=('A','B'), params=(1,2))
 
-        #test construction with mixed type parameters
+        # test construction with mixed type parameters
         with self.assertRaises(TypeError):
             m = relentless.potential.PairParameters(types=('A','B'), params=('1',2))
 
@@ -59,7 +59,7 @@ class test_PairParameters(unittest.TestCase):
         self.assertEqual(m['B']['energy'], None)
         self.assertEqual(m['B']['mass'], None)
 
-        #test setting shared params
+        # test setting shared params
         m.shared.update(energy=1.0, mass=2.0)
 
         self.assertEqual(m.shared['energy'], 1.0)
@@ -75,7 +75,7 @@ class test_PairParameters(unittest.TestCase):
         self.assertEqual(m['B']['energy'], None)
         self.assertEqual(m['B']['mass'], None)
 
-        #test setting per-pair params
+        # test setting per-pair params
         m['A','A'].update(energy=1.5, mass=2.5)
         m['A','B'].update(energy=2.0, mass=3.0)
         m['B','B'].update(energy=0.5, mass=0.7)
@@ -93,7 +93,7 @@ class test_PairParameters(unittest.TestCase):
         self.assertEqual(m['B']['energy'], None)
         self.assertEqual(m['B']['mass'], None)
 
-        #test setting per-type params
+        # test setting per-type params
         m['A'].update(energy=0.1, mass=0.2)
         m['B'].update(energy=0.2, mass=0.1)
 
@@ -151,7 +151,7 @@ class TwoVarPot(relentless.potential.PairPotential):
         pass
 
     def _derivative(self, param, r, **params):
-        #not real derivative, just used to test functionality
+        # not real derivative, just used to test functionality
         r,d,s = self._zeros(r)
         if param == 'x':
             d[:] = 2*r
@@ -166,7 +166,7 @@ class test_PairPotential(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data"""
-        #test creation with only m
+        # test creation with only m
         p = LinPot(types=('1',), params=('m',))
         p.coeff['1','1']['m'] = 3.5
 
@@ -180,7 +180,7 @@ class test_PairPotential(unittest.TestCase):
         self.assertCountEqual(p.coeff.params, coeff.params)
         self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
-        #test creation with m and rmin
+        # test creation with m and rmin
         p = LinPot(types=('1',), params=('m','rmin'))
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['rmin'] = 0.0
@@ -195,7 +195,7 @@ class test_PairPotential(unittest.TestCase):
         self.assertCountEqual(p.coeff.params, coeff.params)
         self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
-        #test creation with m and rmax
+        # test creation with m and rmax
         p = LinPot(types=('1',), params=('m','rmax'))
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['rmax'] = 1.0
@@ -210,7 +210,7 @@ class test_PairPotential(unittest.TestCase):
         self.assertCountEqual(p.coeff.params, coeff.params)
         self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
-        #test creation with m and shift
+        # test creation with m and shift
         p = LinPot(types=('1',), params=('m','shift'))
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['shift'] = True
@@ -225,7 +225,7 @@ class test_PairPotential(unittest.TestCase):
         self.assertCountEqual(p.coeff.params, coeff.params)
         self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
-        #test creation with all params
+        # test creation with all params
         p = LinPot(types=('1',), params=('m','rmin','rmax','shift'))
         p.coeff['1','1']['m'] = 3.5
         p.coeff['1','1']['rmin'] = 0.0
@@ -247,41 +247,41 @@ class test_PairPotential(unittest.TestCase):
         p = LinPot(types=('1',), params=('m',))
         p.coeff['1','1']['m'] = 2.0
 
-        #test with no cutoffs
+        # test with no cutoffs
         u = p.energy(pair=('1','1'), r=0.5)
         self.assertAlmostEqual(u, 1.0)
         u = p.energy(pair=('1','1'), r=[0.25,0.75])
         numpy.testing.assert_allclose(u, [0.5,1.5])
 
-        #test with rmin set
+        # test with rmin set
         p.coeff['1','1']['rmin'] = 0.5
         u = p.energy(pair=('1','1'), r=0.6)
         self.assertAlmostEqual(u, 1.2)
         u = p.energy(pair=('1','1'), r=[0.25,0.75])
         numpy.testing.assert_allclose(u, [1.0,1.5])
 
-        #test with rmax set
+        # test with rmax set
         p.coeff['1','1'].update(rmin=False, rmax=1.5)
         u = p.energy(pair=('1','1'), r=1.0)
         self.assertAlmostEqual(u, 2.0)
         u = p.energy(pair=('1','1'), r=[0.25,1.75])
         numpy.testing.assert_allclose(u, [0.5,3.0])
 
-        #test with rmin and rmax set
+        # test with rmin and rmax set
         p.coeff['1','1']['rmin'] = 0.5
         u = p.energy(pair=('1','1'), r=0.75)
         self.assertAlmostEqual(u, 1.5)
         u = p.energy(pair=('1','1'), r=[0.25,0.5,1.5,1.75])
         numpy.testing.assert_allclose(u, [1.0,1.0,3.0,3.0])
 
-        #test with shift set
+        # test with shift set
         p.coeff['1','1'].update(shift=True)
         u = p.energy(pair=('1','1'), r=0.5)
         self.assertAlmostEqual(u, -2.0)
         u = p.energy(pair=('1','1'), r=[0.25,0.75,1.0,1.5])
         numpy.testing.assert_allclose(u, [-2.0,-1.5,-1.0,0.0])
 
-        #test with shift set without rmax
+        # test with shift set without rmax
         p.coeff['1','1'].update(rmax=False)
         with self.assertRaises(ValueError):
             u = p.energy(pair=('1','1'), r=0.5)
@@ -291,34 +291,34 @@ class test_PairPotential(unittest.TestCase):
         p = LinPot(types=('1',), params=('m',))
         p.coeff['1','1']['m'] = 2.0
 
-        #test with no cutoffs
+        # test with no cutoffs
         f = p.force(pair=('1','1'), r=0.5)
         self.assertAlmostEqual(f, -2.0)
         f = p.force(pair=('1','1'), r=[0.25,0.75])
         numpy.testing.assert_allclose(f, [-2.0,-2.0])
 
-        #test with rmin set
+        # test with rmin set
         p.coeff['1','1']['rmin'] = 0.5
         f = p.force(pair=('1','1'), r=0.6)
         self.assertAlmostEqual(f, -2.0)
         f = p.force(pair=('1','1'), r=[0.25,0.75])
         numpy.testing.assert_allclose(f, [0.0,-2.0])
 
-        #test with rmax set
+        # test with rmax set
         p.coeff['1','1'].update(rmin=False, rmax=1.5)
         f = p.force(pair=('1','1'), r=1.0)
         self.assertAlmostEqual(f, -2.0)
         f = p.force(pair=('1','1'), r=[0.25,1.75])
         numpy.testing.assert_allclose(f, [-2.0,0.0])
 
-        #test with rmin and rmax set
+        # test with rmin and rmax set
         p.coeff['1','1']['rmin'] = 0.5
         f = p.force(pair=('1','1'), r=0.75)
         self.assertAlmostEqual(f, -2.0)
         f = p.force(pair=('1','1'), r=[0.25,0.5,1.5,1.75])
         numpy.testing.assert_allclose(f, [0.0,-2.0,-2.0,0.0])
 
-        #test with shift set
+        # test with shift set
         p.coeff['1','1'].update(shift=True)
         f = p.force(pair=('1','1'), r=0.5)
         self.assertAlmostEqual(f, -2.0)
@@ -331,13 +331,13 @@ class test_PairPotential(unittest.TestCase):
         x = relentless.variable.DesignVariable(value=2.0)
         p.coeff['1','1']['m'] = x
 
-        #test with no cutoffs
+        # test with no cutoffs
         d = p.derivative(pair=('1','1'), var=x, r=0.5)
         self.assertAlmostEqual(d, 0.5)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
         numpy.testing.assert_allclose(d, [0.25,0.75])
 
-        #test with rmin set
+        # test with rmin set
         rmin = relentless.variable.DesignVariable(value=0.5)
         p.coeff['1','1']['rmin'] = rmin
         d = p.derivative(pair=('1','1'), var=x, r=0.6)
@@ -345,7 +345,7 @@ class test_PairPotential(unittest.TestCase):
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
         numpy.testing.assert_allclose(d, [0.5,0.75])
 
-        #test with rmax set
+        # test with rmax set
         rmax = relentless.variable.DesignVariable(value=1.5)
         p.coeff['1','1'].update(rmin=False, rmax=rmax)
         d = p.derivative(pair=('1','1'), var=x, r=1.0)
@@ -353,27 +353,27 @@ class test_PairPotential(unittest.TestCase):
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,1.75])
         numpy.testing.assert_allclose(d, [0.25,1.5])
 
-        #test with rmin and rmax set
+        # test with rmin and rmax set
         p.coeff['1','1']['rmin'] = rmin
         d = p.derivative(pair=('1','1'), var=x, r=0.75)
         self.assertAlmostEqual(d, 0.75)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.5,1.5,1.75])
         numpy.testing.assert_allclose(d, [0.5,0.5,1.5,1.5])
 
-        #test w.r.t. rmin and rmax
+        # test w.r.t. rmin and rmax
         d = p.derivative(pair=('1','1'), var=rmin, r=[0.25,1.0,2.0])
         numpy.testing.assert_allclose(d, [2.0,0.0,0.0])
         d = p.derivative(pair=('1','1'), var=rmax, r=[0.25,1.0,2.0])
         numpy.testing.assert_allclose(d, [0.0,0.0,2.0])
 
-        #test parameter derivative with shift set
+        # test parameter derivative with shift set
         p.coeff['1','1'].update(shift=True)
         d = p.derivative(pair=('1','1'), var=x, r=0.5)
         self.assertAlmostEqual(d, -1.0)
         d = p.derivative(pair=('1','1'), var=x, r=[0.25,1.0,1.5,1.75])
         numpy.testing.assert_allclose(d, [-1.0,-0.5,0.0,0.0])
 
-        #test w.r.t. rmin and rmax, shift set
+        # test w.r.t. rmin and rmax, shift set
         d = p.derivative(pair=('1','1'), var=rmin, r=[0.25,1.0,2.0])
         numpy.testing.assert_allclose(d, [2.0,0.0,0.0])
         d = p.derivative(pair=('1','1'), var=rmax, r=[0.25,1.0,2.0])
@@ -387,23 +387,23 @@ class test_PairPotential(unittest.TestCase):
         z = relentless.variable.GeometricMean(x, y)
         q.coeff['1','1']['m'] = z
 
-        #test with respect to dependent variable parameter
+        # test with respect to dependent variable parameter
         d = q.derivative(pair=('1','1'), var=z, r=2.0)
         self.assertAlmostEqual(d, 2.0)
 
-        #test with respect to independent variable on which parameter is dependent
+        # test with respect to independent variable on which parameter is dependent
         d = q.derivative(pair=('1','1'), var=x, r=1.5)
         self.assertAlmostEqual(d, 3.0)
         d = q.derivative(pair=('1','1'), var=y, r=4.0)
         self.assertAlmostEqual(d, 0.5)
 
-        #test invalid derivative w.r.t. scalar
+        # test invalid derivative w.r.t. scalar
         a = 2.5
         q.coeff['1','1']['m'] = a
         with self.assertRaises(TypeError):
             d = q.derivative(pair=('1','1'), var=a, r=2.0)
 
-        #test with respect to independent variable which is related to a SameAs variable
+        # test with respect to independent variable which is related to a SameAs variable
         r = TwoVarPot(types=('1',), params=('x','y'))
 
         r.coeff['1','1']['x'] = x
@@ -467,19 +467,19 @@ class test_LennardJones(unittest.TestCase):
         """Test _energy method"""
         lj = relentless.potential.LennardJones(types=('1',))
 
-        #test scalar r
+        # test scalar r
         r_input = 0.5
         u_actual = 0
         u = lj._energy(r=r_input, epsilon=1.0, sigma=0.5)
         self.assertAlmostEqual(u, u_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         u_actual = numpy.array([numpy.inf,-0.061523438,-0.0054794417])
         u = lj._energy(r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(u, u_actual)
 
-        #test negative sigma
+        # test negative sigma
         with self.assertRaises(ValueError):
             u = lj._energy(r=r_input, epsilon=1.0, sigma=-1.0)
 
@@ -487,19 +487,19 @@ class test_LennardJones(unittest.TestCase):
         """Test _force method"""
         lj = relentless.potential.LennardJones(types=('1',))
 
-        #test scalar r
+        # test scalar r
         r_input = 0.5
         f_actual = 48
         f = lj._force(r=r_input, epsilon=1.0, sigma=0.5)
         self.assertAlmostEqual(f, f_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         f_actual = numpy.array([numpy.inf,-0.36328125,-0.02188766])
         f = lj._force(r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(f, f_actual)
 
-        #test negative sigma
+        # test negative sigma
         with self.assertRaises(ValueError):
             u = lj._force(r=r_input, epsilon=1.0, sigma=-1.0)
 
@@ -507,37 +507,37 @@ class test_LennardJones(unittest.TestCase):
         """Test _derivative method"""
         lj = relentless.potential.LennardJones(types=('1',))
 
-        #w.r.t. epsilon
-        #test scalar r
+        # w.r.t. epsilon
+        # test scalar r
         r_input = 0.5
         d_actual = 0
         d = lj._derivative(param='epsilon', r=r_input, epsilon=1.0, sigma=0.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         d_actual = numpy.array([numpy.inf,-0.061523438,-0.0054794417])
         d = lj._derivative(param='epsilon', r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #w.r.t. sigma
-        #test scalar r
+        # w.r.t. sigma
+        # test scalar r
         r_input = 0.5
         d_actual = 48
         d = lj._derivative(param='sigma', r=r_input, epsilon=1.0, sigma=0.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         d_actual = numpy.array([numpy.inf,-0.7265625,-0.06566298])
         d = lj._derivative(param='sigma', r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #test negative sigma
+        # test negative sigma
         with self.assertRaises(ValueError):
             u = lj._derivative(param='sigma', r=r_input, epsilon=1.0, sigma=-1.0)
 
-        #test invalid param
+        # test invalid param
         with self.assertRaises(ValueError):
             u = lj._derivative(param='simga', r=r_input, epsilon=1.0, sigma=1.0)
 
@@ -546,7 +546,7 @@ class test_PairSpline(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data"""
-        #test diff mode
+        # test diff mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3)
         self.assertEqual(s.num_knots, 3)
         self.assertEqual(s.mode, 'diff')
@@ -555,7 +555,7 @@ class test_PairSpline(unittest.TestCase):
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
 
-        #test value mode
+        # test value mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='value')
         self.assertEqual(s.num_knots, 3)
         self.assertEqual(s.mode, 'value')
@@ -564,11 +564,11 @@ class test_PairSpline(unittest.TestCase):
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
 
-        #test invalid number of knots
+        # test invalid number of knots
         with self.assertRaises(ValueError):
             s = relentless.potential.PairSpline(types=('1',), num_knots=1)
 
-        #test invalid mode
+        # test invalid mode
         with self.assertRaises(ValueError):
             s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='val')
 
@@ -578,7 +578,7 @@ class test_PairSpline(unittest.TestCase):
         u_arr = [9,4,1]
         u_arr_diff = [5,3,1]
 
-        #test diff mode
+        # test diff mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
@@ -594,7 +594,7 @@ class test_PairSpline(unittest.TestCase):
                 dvars.append(k)
         self.assertCountEqual(s.design_variables, dvars)
 
-        #test value mode
+        # test value mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
 
@@ -610,7 +610,7 @@ class test_PairSpline(unittest.TestCase):
                 dvars.append(k)
         self.assertCountEqual(s.design_variables, dvars)
 
-        #test invalid r and u shapes
+        # test invalid r and u shapes
         r_arr = [2,3]
         with self.assertRaises(ValueError):
             s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
@@ -625,21 +625,21 @@ class test_PairSpline(unittest.TestCase):
         r_arr = [1,2,3]
         u_arr = [9,4,1]
 
-        #test diff mode
+        # test diff mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         u_actual = numpy.array([6.25,2.25,1])
         u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
         numpy.testing.assert_allclose(u, u_actual)
 
-        #test value mode
+        # test value mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         u_actual = numpy.array([6.25,2.25,1])
         u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
         numpy.testing.assert_allclose(u, u_actual)
 
-        #test PairSpline with 2 knots
+        # test PairSpline with 2 knots
         s = relentless.potential.PairSpline(types=('1',), num_knots=2, mode='value')
         s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
         u = s.energy(pair=('1','1'), r=1.5)
@@ -650,21 +650,21 @@ class test_PairSpline(unittest.TestCase):
         r_arr = [1,2,3]
         u_arr = [9,4,1]
 
-        #test diff mode
+        # test diff mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         f_actual = numpy.array([5,3,0])
         f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
         numpy.testing.assert_allclose(f, f_actual)
 
-        #test value mode
+        # test value mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         f_actual = numpy.array([5,3,0])
         f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
         numpy.testing.assert_allclose(f, f_actual)
 
-        #test PairSpline with 2 knots
+        # test PairSpline with 2 knots
         s = relentless.potential.PairSpline(types=('1',), num_knots=2, mode='value')
         s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
         f = s.force(pair=('1','1'), r=1.5)
@@ -675,7 +675,7 @@ class test_PairSpline(unittest.TestCase):
         r_arr = [1,2,3]
         u_arr = [9,4,1]
 
-        #test diff mode
+        # test diff mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3)
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = numpy.array([1.125,0.625,0])
@@ -683,7 +683,7 @@ class test_PairSpline(unittest.TestCase):
         d = s.derivative(pair=('1','1'), var=param, r=[1.5,2.5,3.5])
         numpy.testing.assert_allclose(d, d_actual)
 
-        #test value mode
+        # test value mode
         s = relentless.potential.PairSpline(types=('1',), num_knots=3, mode='value')
         s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
         d_actual = numpy.array([0.75,0.75,0])
@@ -709,19 +709,19 @@ class test_Yukawa(unittest.TestCase):
         """Test _energy method"""
         y = relentless.potential.Yukawa(types=('1',))
 
-        #test scalar r
+        # test scalar r
         r_input = 0.5
         u_actual = 1.5576016
         u = y._energy(r=r_input, epsilon=1.0, kappa=0.5)
         self.assertAlmostEqual(u, u_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         u_actual = numpy.array([numpy.inf,0.60653066,0.31491104])
         u = y._energy(r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(u, u_actual)
 
-        #test negative kappa
+        # test negative kappa
         with self.assertRaises(ValueError):
             u = y._energy(r=r_input, epsilon=1.0, kappa=-1.0)
 
@@ -729,19 +729,19 @@ class test_Yukawa(unittest.TestCase):
         """Test _force method"""
         y = relentless.potential.Yukawa(types=('1',))
 
-        #test scalar r
+        # test scalar r
         r_input = 0.5
         f_actual = 3.8940039
         f = y._force(r=r_input, epsilon=1.0, kappa=0.5)
         self.assertAlmostEqual(f, f_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         f_actual = numpy.array([numpy.inf,0.90979599,0.36739621])
         f = y._force(r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(f, f_actual)
 
-        #test negative kappa
+        # test negative kappa
         with self.assertRaises(ValueError):
             u = y._force(r=r_input, epsilon=1.0, kappa=-1.0)
 
@@ -749,37 +749,37 @@ class test_Yukawa(unittest.TestCase):
         """Test _derivative method"""
         y = relentless.potential.Yukawa(types=('1',))
 
-        #w.r.t. epsilon
-        #test scalar r
+        # w.r.t. epsilon
+        # test scalar r
         r_input = 0.5
         d_actual = 1.5576016
         d = y._derivative(param='epsilon', r=r_input, epsilon=1.0, kappa=0.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         d_actual = numpy.array([numpy.inf,0.60653066,0.31491104])
         d = y._derivative(param='epsilon', r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #w.r.t. kappa
-        #test scalar r
+        # w.r.t. kappa
+        # test scalar r
         r_input = 0.5
         d_actual = -0.77880078
         d = y._derivative(param='kappa', r=r_input, epsilon=1.0, kappa=0.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([0,1,1.5])
         d_actual = numpy.array([-1,-0.60653066,-0.47236655])
         d = y._derivative(param='kappa', r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #test negative kappa
+        # test negative kappa
         with self.assertRaises(ValueError):
             u = y._derivative(param='kappa', r=r_input, epsilon=1.0, kappa=-1.0)
 
-        #test invalid param
+        # test invalid param
         with self.assertRaises(ValueError):
             u = y._derivative(param='kapppa', r=r_input, epsilon=1.0, kappa=1.0)
 
@@ -796,7 +796,7 @@ class test_Depletion(unittest.TestCase):
 
     def test_cutoff_init(self):
         """Test creation of Depletion.Cutoff from data"""
-        #create object dependent on scalars
+        # create object dependent on scalars
         w = relentless.potential.Depletion.Cutoff(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertCountEqual(w.params, ('sigma_i','sigma_j','sigma_d'))
 
@@ -808,19 +808,19 @@ class test_Depletion(unittest.TestCase):
         """Test Depletion.Cutoff._derivative method"""
         w = relentless.potential.Depletion.Cutoff(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
 
-        #calculate w.r.t. sigma_i
+        # calculate w.r.t. sigma_i
         dw = w.compute_derivative('sigma_i', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertEqual(dw, 0.5)
 
-        #calculate w.r.t. sigma_j
+        # calculate w.r.t. sigma_j
         dw = w.compute_derivative('sigma_j', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertEqual(dw, 0.5)
 
-        #calculate w.r.t. sigma_d
+        # calculate w.r.t. sigma_d
         dw = w.compute_derivative('sigma_d', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertEqual(dw, 1.0)
 
-        #invalid parameter calculation
+        # invalid parameter calculation
         with self.assertRaises(ValueError):
             dw = w.compute_derivative('sigma', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
 
@@ -828,19 +828,19 @@ class test_Depletion(unittest.TestCase):
         """Test _energy and energy methods"""
         dp = relentless.potential.Depletion(types=('1',))
 
-        #test scalar r
+        # test scalar r
         r_input = 3
         u_actual = -4.6786414
         u = dp._energy(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         self.assertAlmostEqual(u, u_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([1.75,4.25])
         u_actual = numpy.array([-16.59621119,0])
         u = dp._energy(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(u, u_actual)
 
-        #test negative sigma
+        # test negative sigma
         with self.assertRaises(ValueError):
             u = dp._energy(r=r_input, P=1, sigma_i=-1, sigma_j=1, sigma_d=1)
         with self.assertRaises(ValueError):
@@ -848,7 +848,7 @@ class test_Depletion(unittest.TestCase):
         with self.assertRaises(ValueError):
             u = dp._energy(r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
-        #test energy outside of low/high bounds
+        # test energy outside of low/high bounds
         dp.coeff['1','1'].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         r_input = numpy.array([1,5])
         u_actual = numpy.array([-25.7514468,0])
@@ -860,19 +860,19 @@ class test_Depletion(unittest.TestCase):
         """Test _force and force methods"""
         dp = relentless.potential.Depletion(types=('1',))
 
-        #test scalar r
+        # test scalar r
         r_input = 3
         f_actual = -7.0682426
         f = dp._force(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         self.assertAlmostEqual(f, f_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([1.75,4.25])
         f_actual = numpy.array([-11.54054444,0])
         f = dp._force(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(f, f_actual)
 
-        #test negative sigma
+        # test negative sigma
         with self.assertRaises(ValueError):
             f = dp._force(r=r_input, P=1, sigma_i=-1, sigma_j=1, sigma_d=1)
         with self.assertRaises(ValueError):
@@ -880,7 +880,7 @@ class test_Depletion(unittest.TestCase):
         with self.assertRaises(ValueError):
             f = dp._force(r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
-        #test force outside of low/high bounds
+        # test force outside of low/high bounds
         dp.coeff['1','1'].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         r_input = numpy.array([1,5])
         f_actual = numpy.array([-12.5633027,0])
@@ -892,59 +892,59 @@ class test_Depletion(unittest.TestCase):
         """Test _derivative and derivative methods"""
         dp = relentless.potential.Depletion(types=('1',))
 
-        #w.r.t. P
-        #test scalar r
+        # w.r.t. P
+        # test scalar r
         r_input = 3
         d_actual = -4.6786414
         d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([1.75,4.25])
         d_actual = numpy.array([-16.59621119,0])
         d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #w.r.t. sigma_i
-        #test scalar r
+        # w.r.t. sigma_i
+        # test scalar r
         r_input = 3
         d_actual = -4.25424005
         d = dp._derivative(param='sigma_i', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([1.75,4.25])
         d_actual = numpy.array([-8.975979,0])
         d = dp._derivative(param='sigma_i', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #w.r.t. sigma_j
-        #test scalar r
+        # w.r.t. sigma_j
+        # test scalar r
         r_input = 3
         d_actual = -4.04970928
         d = dp._derivative(param='sigma_j', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([1.75,4.25])
         d_actual = numpy.array([-7.573482,0])
         d = dp._derivative(param='sigma_j', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #w.r.t. sigma_d
-        #test scalar r
+        # w.r.t. sigma_d
+        # test scalar r
         r_input = 3
         d_actual = -8.30394933
         d = dp._derivative(param='sigma_d', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         self.assertAlmostEqual(d, d_actual)
 
-        #test array r
+        # test array r
         r_input = numpy.array([1.75,4.25])
         d_actual = numpy.array([-16.549461,0])
         d = dp._derivative(param='sigma_d', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(d, d_actual)
 
-        #test negative sigma
+        # test negative sigma
         with self.assertRaises(ValueError):
             d = dp._derivative(param='P', r=r_input, P=1, sigma_i=-1, sigma_j=1, sigma_d=1)
         with self.assertRaises(ValueError):
@@ -952,11 +952,11 @@ class test_Depletion(unittest.TestCase):
         with self.assertRaises(ValueError):
             d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
-        #test invalid param
+        # test invalid param
         with self.assertRaises(ValueError):
             d = dp._derivative(param='sigmaj', r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=1)
 
-        #test derivative outside of low/high bounds
+        # test derivative outside of low/high bounds
         P_var = relentless.variable.DesignVariable(value=1.0)
         dp.coeff['1','1'].update(P=P_var, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         r_input = numpy.array([1,5])

--- a/tests/potential/test_pair.py
+++ b/tests/potential/test_pair.py
@@ -178,7 +178,7 @@ class test_PairPotential(unittest.TestCase):
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with m and rmin
         p = LinPot(types=('1',), params=('m','rmin'))
@@ -193,7 +193,7 @@ class test_PairPotential(unittest.TestCase):
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with m and rmax
         p = LinPot(types=('1',), params=('m','rmax'))
@@ -208,7 +208,7 @@ class test_PairPotential(unittest.TestCase):
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with m and shift
         p = LinPot(types=('1',), params=('m','shift'))
@@ -223,7 +223,7 @@ class test_PairPotential(unittest.TestCase):
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
         #test creation with all params
         p = LinPot(types=('1',), params=('m','rmin','rmax','shift'))
@@ -240,7 +240,7 @@ class test_PairPotential(unittest.TestCase):
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertDictEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
 
     def test_energy(self):
         """Test energy method"""
@@ -424,9 +424,9 @@ class test_PairPotential(unittest.TestCase):
             p.coeff[pair]['rmin'] = 0.0
             p.coeff[pair]['rmax'] = 1.0
 
-        self.assertDictEqual(dict(p.coeff['1','1']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
-        self.assertDictEqual(dict(p.coeff['1','2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
-        self.assertDictEqual(dict(p.coeff['2','2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
+        self.assertEqual(dict(p.coeff['1','1']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
+        self.assertEqual(dict(p.coeff['1','2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
+        self.assertEqual(dict(p.coeff['2','2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
 
     def test_save(self):
         """Test saving to file"""

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -15,26 +15,26 @@ class test_Parameters(unittest.TestCase):
         types = ('A','B')
         params = ('energy', 'mass')
 
-        #test construction with tuple input
+        # test construction with tuple input
         m = relentless.potential.Parameters(types=('A','B'), params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
 
-        #test construction with list input
+        # test construction with list input
         m = relentless.potential.Parameters(types=['A','B'], params=('energy','mass'))
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
 
-        #test construction with mixed tuple/list input
+        # test construction with mixed tuple/list input
         m = relentless.potential.Parameters(types=('A','B'), params=['energy','mass'])
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
 
-        #test construction with invalid types
+        # test construction with invalid types
         with self.assertRaises(TypeError):
             m = relentless.potential.Parameters(types=(1,'B'), params=(1,2))
 
-        #test construction with invalid parameters
+        # test construction with invalid parameters
         with self.assertRaises(TypeError):
             m = relentless.potential.Parameters(types=('A','B'), params=('1',2))
 
@@ -49,7 +49,7 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m['B']['energy'], None)
         self.assertEqual(m['B']['mass'], None)
 
-        #test setting shared params
+        # test setting shared params
         m.shared.update(energy=1.0, mass=2.0)
 
         self.assertEqual(m.shared['energy'], 1.0)
@@ -59,7 +59,7 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m['B']['energy'], None)
         self.assertEqual(m['B']['mass'], None)
 
-        #test setting per-type params
+        # test setting per-type params
         m['A'].update(energy=0.1, mass=0.2)
         m['B'].update(energy=0.2, mass=0.1)
 
@@ -74,16 +74,16 @@ class test_Parameters(unittest.TestCase):
         """Test various get and set methods on keys"""
         m = relentless.potential.Parameters(types=('A',), params=('energy','mass'))
 
-        #test set and get for each pair type and param
+        # test set and get for each pair type and param
         self.assertEqual(m['A']['energy'], None)
         self.assertEqual(m['A']['mass'], None)
 
-        #test setting all key values at once
+        # test setting all key values at once
         m['A'] = {'energy':1.0, 'mass':2.0}
         self.assertEqual(m['A']['energy'], 1.0)
         self.assertEqual(m['A']['mass'], 2.0)
 
-        #test setting key values partially with = operator
+        # test setting key values partially with = operator
         m['A'] = {'energy':1.5}
         self.assertEqual(m['A']['energy'], 1.5)
         self.assertEqual(m['A']['mass'], None)
@@ -92,16 +92,16 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m['A']['energy'], None)
         self.assertEqual(m['A']['mass'], 2.5)
 
-        #test setting key values partially using update()
-        m['A'].update(energy=2.5)  #using keyword arg
+        # test setting key values partially using update()
+        m['A'].update(energy=2.5) # using keyword arg
         self.assertEqual(m['A']['energy'], 2.5)
         self.assertEqual(m['A']['mass'], 2.5)
 
-        m['A'].update({'mass':0.5})  #using dict
+        m['A'].update({'mass':0.5}) # using dict
         self.assertEqual(m['A']['energy'], 2.5)
         self.assertEqual(m['A']['mass'], 0.5)
 
-        #test accessing key param values individually
+        # test accessing key param values individually
         m['A']['energy'] = 1.0
         self.assertEqual(m['A']['energy'], 1.0)
         self.assertEqual(m['A']['mass'], 0.5)
@@ -110,14 +110,14 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m['A']['energy'], 1.0)
         self.assertEqual(m['A']['mass'], 2.0)
 
-        #test reset and get via iteration
+        # test reset and get via iteration
         params = ('energy', 'mass')
         for j in params:
             m['A'][j] = 1.5
         self.assertEqual(m['A']['energy'], 1.5)
         self.assertEqual(m['A']['mass'], 1.5)
 
-        #test get and set on invalid keys/params
+        # test get and set on invalid keys/params
         with self.assertRaises(KeyError):
             m['C']['energy'] = 2
         with self.assertRaises(KeyError):
@@ -129,14 +129,14 @@ class test_Parameters(unittest.TestCase):
 
     def test_accessor_keys(self):
         """Test get and set methods for various keys"""
-        #test set and get for initialized default
+        # test set and get for initialized default
         m = relentless.potential.Parameters(types=('A','B'), params=('energy','mass'))
         self.assertEqual(m['A']['energy'], None)
         self.assertEqual(m['A']['mass'], None)
         self.assertEqual(m['B']['energy'], None)
         self.assertEqual(m['B']['mass'], None)
 
-        #test reset and get manually
+        # test reset and get manually
         m['A'] = {'energy':1.0, 'mass':2.0}
         self.assertEqual(m['A']['energy'], 1.0)
         self.assertEqual(m['A']['mass'], 2.0)
@@ -161,7 +161,7 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m['B']['energy'], 3.5)
         self.assertEqual(m['B']['mass'], 4.5)
 
-        #test that partial assignment resets other param to default value
+        # test that partial assignment resets other param to default value
         m['A'] = {'energy':2.0}
         self.assertEqual(m['A']['energy'], 2.0)
         self.assertEqual(m['A']['mass'], None)
@@ -170,23 +170,23 @@ class test_Parameters(unittest.TestCase):
 
     def test_evaluate(self):
         """Test evaluation of keyed parameters"""
-        #test evaluation with empty parameter values
+        # test evaluation with empty parameter values
         m = relentless.potential.Parameters(types=('A','B'), params=('energy','mass'))
         with self.assertRaises(ValueError):
             x = m.evaluate('A')
 
-        #test evaluation with invalid key called
+        # test evaluation with invalid key called
         with self.assertRaises(KeyError):
             x = m.evaluate('C')
 
-        #test evaluation with initialized shared parameter values
+        # test evaluation with initialized shared parameter values
         m = relentless.potential.Parameters(types=('A','B'), params=('energy','mass'))
         m.shared['energy'] = 0.0
         m.shared['mass'] = 0.5
         self.assertEqual(m.evaluate('A'), {'energy':0.0, 'mass':0.5})
         self.assertEqual(m.evaluate('B'), {'energy':0.0, 'mass':0.5})
 
-        #test evaluation with initialized shared and individual parameter values
+        # test evaluation with initialized shared and individual parameter values
         m = relentless.potential.Parameters(types=('A','B'), params=('energy','mass'))
         m.shared['energy'] = 0.0
         m.shared['mass'] = 0.5
@@ -194,13 +194,13 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m.evaluate('A'), {'energy':0.0, 'mass':0.5})
         self.assertEqual(m.evaluate('B'), {'energy':1.5, 'mass':0.5})
 
-        #test evaluation with initialized parameter values as DesignVariable types
+        # test evaluation with initialized parameter values as DesignVariable types
         m = relentless.potential.Parameters(types=('A',), params=('energy','mass'))
         m['A']['energy'] = relentless.variable.DesignVariable(value=-1.0,low=0.1)
         m['A']['mass'] = relentless.variable.DesignVariable(value=1.0,high=0.3)
         self.assertEqual(m.evaluate('A'), {'energy':0.1, 'mass':0.3})
 
-        #test evaluation with initialized parameter values as unrecognized types
+        # test evaluation with initialized parameter values as unrecognized types
         m = relentless.potential.Parameters(types=('A','B'), params=('energy','mass'))
         m.shared['energy'] = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
         m.shared['mass'] = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
@@ -211,7 +211,7 @@ class test_Parameters(unittest.TestCase):
         """Test saving to file"""
         temp = tempfile.NamedTemporaryFile()
 
-        #test dumping/re-loading data with scalar parameter values
+        # test dumping/re-loading data with scalar parameter values
         m = relentless.potential.Parameters(types=('A',), params=('energy','mass'))
         m['A']['energy'] = 1.5
         m['A']['mass'] = 2.5
@@ -221,7 +221,7 @@ class test_Parameters(unittest.TestCase):
         self.assertEqual(m['A']['energy'], x['A']['energy'])
         self.assertEqual(m['A']['mass'], x['A']['mass'])
 
-        #test dumping/re-loading data with DesignVariable parameter values
+        # test dumping/re-loading data with DesignVariable parameter values
         m = relentless.potential.Parameters(types=('A',), params=('energy','mass'))
         m['A']['energy'] = relentless.variable.DesignVariable(value=0.5)
         m['A']['mass'] = relentless.variable.DesignVariable(value=2.0)
@@ -260,12 +260,12 @@ class test_Potential(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data"""
-        #test creation with default container
+        # test creation with default container
         p = MockPotential(types=('1',), params=('m',))
         self.assertCountEqual(p.coeff.types, ('1',))
         self.assertCountEqual(p.coeff.params, ('m',))
 
-        #test creation with custom container
+        # test creation with custom container
         p = MockPotential(types=('1',), params=('m',), container=MockContainer)
         self.assertCountEqual(p.coeff.types, ('foo'))
         self.assertCountEqual(p.coeff.params, ('bar'))
@@ -274,7 +274,7 @@ class test_Potential(unittest.TestCase):
         """Test _zeros method"""
         p = MockPotential(types=('1',), params=('m',))
 
-        #test with scalar r
+        # test with scalar r
         r = 0.5
         r_copy, u, s = p._zeros(r)
         numpy.testing.assert_allclose(r_copy, numpy.array([r]))
@@ -282,28 +282,28 @@ class test_Potential(unittest.TestCase):
         self.assertEqual(s, True)
 
         u_copy = numpy.zeros(2)
-        #test with list r
+        # test with list r
         r = [0.2, 0.3]
         r_copy, u, s = p._zeros(r)
         numpy.testing.assert_allclose(r_copy, r)
         numpy.testing.assert_allclose(u, u_copy)
         self.assertEqual(s, False)
 
-        #test with tuple r
+        # test with tuple r
         r = (0.2, 0.3)
         r_copy, u, s = p._zeros(r)
         numpy.testing.assert_allclose(r_copy, r)
         numpy.testing.assert_allclose(u, u_copy)
         self.assertEqual(s, False)
 
-        #test with numpy array r
+        # test with numpy array r
         r = numpy.array([0.2, 0.3])
         r_copy, u, s = p._zeros(r)
         numpy.testing.assert_allclose(r_copy, r)
         numpy.testing.assert_allclose(u, u_copy)
         self.assertEqual(s, False)
 
-        #test with 1-element array
+        # test with 1-element array
         r = [0.2]
         r_copy, u, s = p._zeros(r)
         u_copy = numpy.zeros(1)
@@ -311,7 +311,7 @@ class test_Potential(unittest.TestCase):
         numpy.testing.assert_allclose(u, u_copy)
         self.assertEqual(s, False)
 
-        #test with non 1-d array r
+        # test with non 1-d array r
         r = numpy.array([[1, 2], [0.2, 0.3]])
         with self.assertRaises(TypeError):
             r_copy, u, s = p._zeros(r)

--- a/tests/potential/test_potential.py
+++ b/tests/potential/test_potential.py
@@ -324,8 +324,8 @@ class test_Potential(unittest.TestCase):
             p.coeff[t]['rmin'] = 0.0
             p.coeff[t]['rmax'] = 1.0
 
-        self.assertDictEqual(dict(p.coeff['1']), {'m':2.0, 'rmin':0.0, 'rmax':1.0})
-        self.assertDictEqual(dict(p.coeff['2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0})
+        self.assertEqual(dict(p.coeff['1']), {'m':2.0, 'rmin':0.0, 'rmax':1.0})
+        self.assertEqual(dict(p.coeff['2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0})
 
     def test_save(self):
         """Test saving to file"""

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -20,7 +20,7 @@ class test_Dilute(unittest.TestCase):
         analyzer = relentless.simulate.dilute.AddEnsembleAnalyzer()
         ens = relentless.ensemble.Ensemble(T=1.0, V=relentless.volume.Cube(L=2.0), N={'A':2,'B':3})
 
-        #set up potentials
+        # set up potentials
         pot = LinPot(ens.types,params=('m',))
         for pair in pot.coeff:
             pot.coeff[pair]['m'] = 2.0
@@ -39,7 +39,7 @@ class test_Dilute(unittest.TestCase):
         analyzer = relentless.simulate.dilute.AddEnsembleAnalyzer()
         ens = relentless.ensemble.Ensemble(T=1.0, V=relentless.volume.Cube(L=2.0), N={'A':2,'B':3})
 
-        #test with potential that has infinite potential at low r
+        # test with potential that has infinite potential at low r
         pot = relentless.potential.LennardJones(types=('A','B'))
         for pair in pot.coeff:
             pot.coeff[pair].update({'epsilon':1.0, 'sigma':1.0, 'rmax':3.0, 'shift':True})
@@ -54,7 +54,7 @@ class test_Dilute(unittest.TestCase):
             sim = d.run(ensemble=ens, potentials=pots, directory=self.directory)
         except RuntimeWarning:
             warned = True
-        self.assertFalse(warned)   #no warning should be raised
+        self.assertFalse(warned)   # no warning should be raised
         ens_ = analyzer.extract_ensemble(sim)
         self.assertAlmostEqual(ens_.P, -1.1987890)
 

--- a/tests/simulate/test_generic.py
+++ b/tests/simulate/test_generic.py
@@ -27,7 +27,7 @@ class test_Generic(unittest.TestCase):
                     relentless.simulate.AddLangevinIntegrator(dt=0.1, friction=0.8, seed=2)]
 
     def test_basic(self):
-        #Dilute
+        # Dilute
         dilute = relentless.simulate.dilute.Dilute(self.ops)
         dilute.run(self.ensemble, self.potentials, self.directory)
 
@@ -48,7 +48,7 @@ class test_Generic(unittest.TestCase):
             self.skipTest('LAMMPS not installed')
 
     def test_invalid(self):
-        #Invalid backend
+        # Invalid backend
         with self.assertRaises(TypeError):
             sim = relentless.simulate.Simulation(self.ops)
             sim.run(self.ensemble, self.potentials, self.directory)

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -28,7 +28,7 @@ class test_HOOMD(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self.directory = relentless.data.Directory(self._tmp.name)
 
-    #mock (NVT) ensemble and potential for testing
+    # mock (NVT) ensemble and potential for testing
     def ens_pot(self):
         ens = relentless.ensemble.Ensemble(T=2.0, V=relentless.volume.Cube(L=20.0), N={'A':2,'B':3})
 
@@ -43,7 +43,7 @@ class test_HOOMD(unittest.TestCase):
 
         return (ens,pots)
 
-    #mock gsd file for testing
+    # mock gsd file for testing
     def create_gsd(self):
         with gsd.hoomd.open(name=self.directory.file('test.gsd'), mode='wb') as f:
             s = gsd.hoomd.Snapshot()
@@ -57,7 +57,7 @@ class test_HOOMD(unittest.TestCase):
 
     def test_initialize(self):
         """Test running initialization simulation operations."""
-        #InitializeFromFile
+        # InitializeFromFile
         ens,pot = self.ens_pot()
         f = self.create_gsd()
         op = relentless.simulate.hoomd.InitializeFromFile(filename=f.file.name)
@@ -66,7 +66,7 @@ class test_HOOMD(unittest.TestCase):
         self.assertIsInstance(sim[op].neighbor_list, hoomd.md.nlist.tree)
         self.assertIsInstance(sim[op].pair_potential, hoomd.md.pair.table)
 
-        #InitializeRandomly
+        # InitializeRandomly
         ens,pot = self.ens_pot()
         op = relentless.simulate.hoomd.InitializeRandomly(seed=1)
         h = relentless.simulate.hoomd.HOOMD(operations=op)
@@ -76,7 +76,7 @@ class test_HOOMD(unittest.TestCase):
 
     def test_minimization(self):
         """Test running energy minimization simulation operation."""
-        #MinimizeEnergy
+        # MinimizeEnergy
         ens,pot = self.ens_pot()
         op = [relentless.simulate.hoomd.InitializeRandomly(seed=1),
               relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
@@ -88,14 +88,14 @@ class test_HOOMD(unittest.TestCase):
         h = relentless.simulate.hoomd.HOOMD(operations=op)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #error check for missing max_displacement
+        # error check for missing max_displacement
         with self.assertRaises(KeyError):
             emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                             force_tolerance=1e-7,
                                                             max_iterations=1000,
                                                             options={})
 
-        #check default value for max_evaluations
+        # check default value for max_evaluations
         emin = relentless.simulate.hoomd.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
                                                         max_iterations=1000,
@@ -107,7 +107,7 @@ class test_HOOMD(unittest.TestCase):
         init = relentless.simulate.hoomd.InitializeRandomly(seed=1)
         h = relentless.simulate.hoomd.HOOMD(operations=init)
 
-        #BrownianIntegrator
+        # BrownianIntegrator
         ens,pot = self.ens_pot()
         brn = relentless.simulate.hoomd.AddBrownianIntegrator(dt=0.5,
                                                               friction=1.0,
@@ -119,7 +119,7 @@ class test_HOOMD(unittest.TestCase):
         brn_r(sim)
         self.assertIsNone(sim[brn].integrator)
 
-        #LangevinIntegrator
+        # LangevinIntegrator
         ens,pot = self.ens_pot()
         lgv = relentless.simulate.hoomd.AddLangevinIntegrator(dt=0.5,
                                                               friction=1.0,
@@ -142,7 +142,7 @@ class test_HOOMD(unittest.TestCase):
         lgv_r(sim)
         self.assertIsNone(sim[lgv].integrator)
 
-        #VerletIntegrator - NVE
+        # VerletIntegrator - NVE
         ens,pot = self.ens_pot()
         vrl = relentless.simulate.hoomd.AddVerletIntegrator(dt=0.5)
         vrl_r = relentless.simulate.hoomd.RemoveVerletIntegrator(add_op=vrl)
@@ -152,7 +152,7 @@ class test_HOOMD(unittest.TestCase):
         vrl_r(sim)
         self.assertIsNone(sim[vrl].integrator)
 
-        #VerletIntegrator - NVE (Berendsen)
+        # VerletIntegrator - NVE (Berendsen)
         tb = relentless.simulate.BerendsenThermostat(T=1, tau=0.5)
         vrl = relentless.simulate.hoomd.AddVerletIntegrator(dt=0.5, thermostat=tb)
         vrl_r = relentless.simulate.hoomd.RemoveVerletIntegrator(add_op=vrl)
@@ -162,7 +162,7 @@ class test_HOOMD(unittest.TestCase):
         vrl_r(sim)
         self.assertIsNone(sim[vrl].integrator)
 
-        #VerletIntegrator - NVT
+        # VerletIntegrator - NVT
         tn = relentless.simulate.NoseHooverThermostat(T=1, tau=0.5)
         vrl = relentless.simulate.hoomd.AddVerletIntegrator(dt=0.5, thermostat=tn)
         vrl_r = relentless.simulate.hoomd.RemoveVerletIntegrator(add_op=vrl)
@@ -172,7 +172,7 @@ class test_HOOMD(unittest.TestCase):
         vrl_r(sim)
         self.assertIsNone(sim[vrl].integrator)
 
-        #VerletIntegrator - NPH
+        # VerletIntegrator - NPH
         bm = relentless.simulate.MTKBarostat(P=1, tau=0.5)
         vrl = relentless.simulate.hoomd.AddVerletIntegrator(dt=0.5, barostat=bm)
         vrl_r = relentless.simulate.hoomd.RemoveVerletIntegrator(add_op=vrl)
@@ -182,7 +182,7 @@ class test_HOOMD(unittest.TestCase):
         vrl_r(sim)
         self.assertIsNone(sim[vrl].integrator)
 
-        #VerletIntegrator - NPT
+        # VerletIntegrator - NPT
         vrl = relentless.simulate.hoomd.AddVerletIntegrator(dt=0.5, thermostat=tn, barostat=bm)
         vrl_r = relentless.simulate.hoomd.RemoveVerletIntegrator(add_op=vrl)
         h.operations = [init, vrl]
@@ -191,7 +191,7 @@ class test_HOOMD(unittest.TestCase):
         vrl_r(sim)
         self.assertIsNone(sim[vrl].integrator)
 
-        #VerletIntegrator - incorrect
+        # VerletIntegrator - incorrect
         with self.assertRaises(TypeError):
             vrl = relentless.simulate.hoomd.AddVerletIntegrator(dt=0.5, thermostat=tb, barostat=bm)
             h.operations = [init, vrl]
@@ -202,13 +202,13 @@ class test_HOOMD(unittest.TestCase):
         init = relentless.simulate.hoomd.InitializeRandomly(seed=1)
         h = relentless.simulate.hoomd.HOOMD(operations=init)
 
-        #Run
+        # Run
         ens,pot = self.ens_pot()
         run = relentless.simulate.hoomd.Run(steps=1000)
         h.operations = [init,run]
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #RunUpTo
+        # RunUpTo
         ens,pot = self.ens_pot()
         run = relentless.simulate.hoomd.RunUpTo(step=999)
         h.operations = [init,run]
@@ -230,7 +230,7 @@ class test_HOOMD(unittest.TestCase):
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
         thermo = sim[analyzer].thermo_callback
 
-        #extract ensemble
+        # extract ensemble
         ens_ = analyzer.extract_ensemble(sim)
         self.assertIsNotNone(ens_.T)
         self.assertNotEqual(ens_.T, 0)
@@ -242,7 +242,7 @@ class test_HOOMD(unittest.TestCase):
             self.assertEqual(ens_.rdf[i,j].table.shape, (len(pot.pair.r)-1,2))
         self.assertEqual(thermo.num_samples, 100)
 
-        #reset callback
+        # reset callback
         thermo.reset()
         self.assertEqual(thermo.num_samples, 0)
         self.assertIsNone(thermo.T)

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -21,7 +21,7 @@ class test_LAMMPS(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self.directory = relentless.data.Directory(self._tmp.name)
 
-    #mock (NVT) ensemble and potential for testing
+    # mock (NVT) ensemble and potential for testing
     def ens_pot(self):
         ens = relentless.ensemble.Ensemble(T=2.0, V=relentless.volume.Cube(L=10.0), N={'1':2,'2':3})
         ens.P = 2.5
@@ -65,7 +65,7 @@ class test_LAMMPS(unittest.TestCase):
 
     def test_initialize(self):
         """Test running initialization simulation operations."""
-        #InitializeFromFile
+        # InitializeFromFile
         ens,pot = self.ens_pot()
         file_ = self.create_file()
         op = relentless.simulate.lammps.InitializeFromFile(filename=file_)
@@ -74,7 +74,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertIsInstance(sim.lammps, lammps.lammps)
         self.assertEqual(sim.lammps.get_natoms(), 5)
 
-        #InitializeRandomly
+        # InitializeRandomly
         op = relentless.simulate.lammps.InitializeRandomly(seed=1)
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
@@ -87,7 +87,7 @@ class test_LAMMPS(unittest.TestCase):
         file_ = self.create_file()
         init = relentless.simulate.lammps.InitializeFromFile(filename=file_)
 
-        #MinimizeEnergy
+        # MinimizeEnergy
         op = [init,
               relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                         force_tolerance=1e-7,
@@ -97,7 +97,7 @@ class test_LAMMPS(unittest.TestCase):
         l = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #check default value of max_evaluations
+        # check default value of max_evaluations
         emin = relentless.simulate.lammps.MinimizeEnergy(energy_tolerance=1e-7,
                                                          force_tolerance=1e-7,
                                                          max_iterations=1000,
@@ -112,8 +112,8 @@ class test_LAMMPS(unittest.TestCase):
         init = relentless.simulate.lammps.InitializeRandomly(seed=1)
         l = relentless.simulate.lammps.LAMMPS(operations=init, quiet=False)
 
-        #LangevinIntegrator
-        #float friction
+        # LangevinIntegrator
+        # float friction
         ens,pot = self.ens_pot()
         lgv = relentless.simulate.lammps.AddLangevinIntegrator(dt=0.5,
                                                                friction=1.5,
@@ -127,7 +127,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_nve)))
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_langevin)))
 
-        #dictionary friction
+        # dictionary friction
         lgv = relentless.simulate.lammps.AddLangevinIntegrator(dt=0.5,
                                                                friction={'1':2.0,'2':5.0},
                                                                seed=2)
@@ -140,7 +140,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_nve)))
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_langevin)))
 
-        #single-type friction
+        # single-type friction
         ens_1 = relentless.ensemble.Ensemble(T=2.0, V=relentless.volume.Cube(L=10.0), N={'1':2})
         lgv = relentless.simulate.lammps.AddLangevinIntegrator(dt=0.5,
                                                                friction={'1':3.0},
@@ -154,7 +154,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_nve)))
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_langevin)))
 
-        #invalid-type friction
+        # invalid-type friction
         lgv = relentless.simulate.lammps.AddLangevinIntegrator(dt=0.5,
                                                                friction={'2':5.0,'3':2.0},
                                                                seed=2)
@@ -162,7 +162,7 @@ class test_LAMMPS(unittest.TestCase):
         with self.assertRaises(KeyError):
             sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #VerletIntegrator - NVE
+        # VerletIntegrator - NVE
         ens,pot = self.ens_pot()
         vrl = relentless.simulate.lammps.AddVerletIntegrator(dt=0.5)
         vrl_r = relentless.simulate.lammps.RemoveVerletIntegrator(add_op=vrl)
@@ -198,7 +198,7 @@ class test_LAMMPS(unittest.TestCase):
         vrl_r(sim)
         self.assertFalse(sim.lammps.has_id('fix',str(vrl._fix)))
 
-        #VerletIntegrator - NVT
+        # VerletIntegrator - NVT
         tn = relentless.simulate.NoseHooverThermostat(T=1, tau=0.5)
         vrl = relentless.simulate.lammps.AddVerletIntegrator(dt=0.5, thermostat=tn)
         vrl_r = relentless.simulate.lammps.RemoveVerletIntegrator(add_op=vrl)
@@ -216,7 +216,7 @@ class test_LAMMPS(unittest.TestCase):
         vrl_r(sim)
         self.assertFalse(sim.lammps.has_id('fix',str(vrl._fix)))
 
-        #VerletIntegrator - NPH
+        # VerletIntegrator - NPH
         bm = relentless.simulate.MTKBarostat(P=1, tau=0.5)
         vrl = relentless.simulate.lammps.AddVerletIntegrator(dt=0.5, barostat=bm)
         vrl_r = relentless.simulate.lammps.RemoveVerletIntegrator(add_op=vrl)
@@ -234,7 +234,7 @@ class test_LAMMPS(unittest.TestCase):
         vrl_r(sim)
         self.assertFalse(sim.lammps.has_id('fix',str(vrl._fix)))
 
-        #VerletIntegrator - NPT
+        # VerletIntegrator - NPT
         vrl = relentless.simulate.lammps.AddVerletIntegrator(dt=0.5, thermostat=tn, barostat=bm)
         vrl_r = relentless.simulate.lammps.RemoveVerletIntegrator(add_op=vrl)
         l.operations = [init, vrl]
@@ -243,7 +243,7 @@ class test_LAMMPS(unittest.TestCase):
         vrl_r(sim)
         self.assertFalse(sim.lammps.has_id('fix',str(vrl._fix)))
 
-        #VerletIntegrator - incorrect
+        # VerletIntegrator - incorrect
         with self.assertRaises(TypeError):
             vrl = relentless.simulate.lammps.AddVerletIntegrator(dt=0.5, thermostat=bb, barostat=tb)
             l.operations = [init, vrl]
@@ -254,13 +254,13 @@ class test_LAMMPS(unittest.TestCase):
         init = relentless.simulate.lammps.InitializeRandomly(seed=1)
         l = relentless.simulate.lammps.LAMMPS(operations=init, quiet=False)
 
-        #Run
+        # Run
         ens,pot = self.ens_pot()
         run = relentless.simulate.lammps.Run(steps=1000)
         l.operations = [init,run]
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #RunUpTo
+        # RunUpTo
         run = relentless.simulate.lammps.RunUpTo(step=999)
         l.operations = [init,run]
         sim = l.run(ensemble=ens, potentials=pot, directory=self.directory)
@@ -280,7 +280,7 @@ class test_LAMMPS(unittest.TestCase):
         h = relentless.simulate.lammps.LAMMPS(operations=op, quiet=False)
         sim = h.run(ensemble=ens, potentials=pot, directory=self.directory)
 
-        #extract ensemble
+        # extract ensemble
         ens_ = analyzer.extract_ensemble(sim)
         self.assertIsNotNone(ens_.T)
         self.assertNotEqual(ens_.T, 0)

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -9,7 +9,7 @@ import relentless
 class test_Simulation(unittest.TestCase):
     """Unit tests for relentless.Simulation"""
 
-    #mock functions for use as operations
+    # mock functions for use as operations
     class CheckEnsemble(relentless.simulate.SimulationOperation):
         def __call__(self, sim):
             try:
@@ -29,22 +29,22 @@ class test_Simulation(unittest.TestCase):
         operations = [self.CheckEnsemble(), self.CheckPotential()]
         options = {'constant_ens':True, 'constant_pot':True}
 
-        #no operations, no options
+        # no operations, no options
         d = relentless.simulate.Simulation()
         self.assertEqual(d.operations, [])
         self.assertEqual(d.options, {})
 
-        #with operations, no options
+        # with operations, no options
         d = relentless.simulate.Simulation(operations)
         self.assertEqual(d.operations, operations)
         self.assertEqual(d.options, {})
 
-        #no operations, with options
+        # no operations, with options
         d = relentless.simulate.Simulation(**options)
         self.assertEqual(d.operations, [])
         self.assertEqual(d.options, options)
 
-        #with operations, with options
+        # with operations, with options
         d = relentless.simulate.Simulation(operations, **options)
         self.assertCountEqual(d.operations, operations)
         self.assertEqual(d.options, options)
@@ -61,7 +61,7 @@ class test_Simulation(unittest.TestCase):
         operations = [self.CheckEnsemble(), self.CheckPotential()]
         options = {'constant_ens':True, 'constant_pot':True}
 
-        #no operations, no options
+        # no operations, no options
         sim = relentless.simulate.Simulation()
         sim_ = sim.run(ensemble=ens, potentials=pot, directory=dirc)
         with self.assertRaises(AttributeError):
@@ -69,19 +69,19 @@ class test_Simulation(unittest.TestCase):
         with self.assertRaises(AttributeError):
             sim_[operations[1]].value
 
-        #with operations, no options
+        # with operations, no options
         sim = relentless.simulate.Simulation(operations=operations)
         sim_ = sim.run(ensemble=ens, potentials=pot, directory=dirc)
         self.assertFalse(sim_[operations[0]].value)
         self.assertFalse(sim_[operations[1]].value)
 
-        #with operations, options
+        # with operations, options
         sim = relentless.simulate.Simulation(operations=operations, **options)
         sim_ = sim.run(ensemble=ens, potentials=pot, directory=dirc)
         self.assertTrue(sim_[operations[0]].value)
         self.assertTrue(sim_[operations[1]].value)
 
-        #invalid operation type
+        # invalid operation type
         sim = relentless.simulate.Simulation(operations='a')
         with self.assertRaises(TypeError):
             sim.run(ensemble=ens, potential=pot, directory=dirc)
@@ -99,14 +99,14 @@ class test_SimulationInstance(unittest.TestCase):
         ens = relentless.ensemble.Ensemble(T=1.0, V=relentless.volume.Cube(L=2.0), N={'A':2,'B':3})
         pots = relentless.simulate.Potentials()
 
-        #no options
+        # no options
         sim = relentless.simulate.SimulationInstance(None, ens, pots, self.directory)
         self.assertEqual(sim.ensemble, ens)
         self.assertEqual(sim.potentials, pots)
         with self.assertRaises(AttributeError):
             sim.constant_ens
 
-        #with options
+        # with options
         sim = relentless.simulate.SimulationInstance(None, ens, pots, self.directory, **options)
         self.assertEqual(sim.ensemble, ens)
         self.assertEqual(sim.potentials, pots)
@@ -159,7 +159,7 @@ class test_PotentialTabulator(unittest.TestCase):
         xs = numpy.array([0.0,0.5,1,1.5])
         p1 = QuadPot(types=('1',), params=('m',))
 
-        #test creation with no potential
+        # test creation with no potential
         t = relentless.simulate.PotentialTabulator(start=0.0,stop=1.5,num=4)
         numpy.testing.assert_allclose(t.x,xs)
         self.assertAlmostEqual(t.start, 0.0)
@@ -167,7 +167,7 @@ class test_PotentialTabulator(unittest.TestCase):
         self.assertEqual(t.num, 4)
         self.assertEqual(t.potentials, [])
 
-        #test creation with defined potential
+        # test creation with defined potential
         t = relentless.simulate.PotentialTabulator(start=0.0,stop=1.5,num=4,potentials=p1)
         numpy.testing.assert_allclose(t.x,xs)
         self.assertAlmostEqual(t.start, 0.0)
@@ -241,7 +241,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         """Test creation with data."""
         rs = numpy.array([0.0,0.5,1,1.5])
 
-        #test creation with only required parameters
+        # test creation with only required parameters
         t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=1.5,num=4,neighbor_buffer=0.4)
         numpy.testing.assert_allclose(t.r,rs)
         self.assertAlmostEqual(t.rmin, 0.0)
@@ -250,7 +250,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         self.assertEqual(t.neighbor_buffer, 0.4)
         self.assertEqual(t.fmax, None)
 
-        #test creation with required parameters and fmax
+        # test creation with required parameters and fmax
         t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=1.5,num=4,neighbor_buffer=0.4,fmax=1.5)
         numpy.testing.assert_allclose(t.r, rs)
         self.assertAlmostEqual(t.rmin, 0.0)

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -31,17 +31,17 @@ class test_Simulation(unittest.TestCase):
 
         #no operations, no options
         d = relentless.simulate.Simulation()
-        self.assertCountEqual(d.operations, [])
+        self.assertEqual(d.operations, [])
         self.assertDictEqual(d.options, {})
 
         #with operations, no options
         d = relentless.simulate.Simulation(operations)
-        self.assertCountEqual(d.operations, operations)
+        self.assertEqual(d.operations, operations)
         self.assertDictEqual(d.options, {})
 
         #no operations, with options
         d = relentless.simulate.Simulation(**options)
-        self.assertCountEqual(d.operations, [])
+        self.assertEqual(d.operations, [])
         self.assertDictEqual(d.options, options)
 
         #with operations, with options
@@ -165,7 +165,7 @@ class test_PotentialTabulator(unittest.TestCase):
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
-        self.assertCountEqual(t.potentials, [])
+        self.assertEqual(t.potentials, [])
 
         #test creation with defined potential
         t = relentless.simulate.PotentialTabulator(start=0.0,stop=1.5,num=4,potentials=p1)
@@ -173,7 +173,7 @@ class test_PotentialTabulator(unittest.TestCase):
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
-        self.assertCountEqual(t.potentials, [p1])
+        self.assertEqual(t.potentials, [p1])
 
     def test_potential(self):
         """Test energy, force, and derivative methods"""

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -32,22 +32,22 @@ class test_Simulation(unittest.TestCase):
         #no operations, no options
         d = relentless.simulate.Simulation()
         self.assertEqual(d.operations, [])
-        self.assertDictEqual(d.options, {})
+        self.assertEqual(d.options, {})
 
         #with operations, no options
         d = relentless.simulate.Simulation(operations)
         self.assertEqual(d.operations, operations)
-        self.assertDictEqual(d.options, {})
+        self.assertEqual(d.options, {})
 
         #no operations, with options
         d = relentless.simulate.Simulation(**options)
         self.assertEqual(d.operations, [])
-        self.assertDictEqual(d.options, options)
+        self.assertEqual(d.options, options)
 
         #with operations, with options
         d = relentless.simulate.Simulation(operations, **options)
         self.assertCountEqual(d.operations, operations)
-        self.assertDictEqual(d.options, options)
+        self.assertEqual(d.options, options)
 
     def test_run(self):
         """Test run method."""

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -16,23 +16,23 @@ class test_FixedKeyDict(unittest.TestCase):
         #test construction with tuple input
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
         self.assertCountEqual(d.keys(), keys)
-        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
+        self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         #test construction with list input
         d = relentless.collections.FixedKeyDict(keys=['A','B'])
         self.assertCountEqual(d.keys(), keys)
-        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
+        self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         #test construction with defined default input
         d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertCountEqual(d.keys(), keys)
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         #test construction with single-key tuple input
         keys = ('A',)
         d = relentless.collections.FixedKeyDict(keys=('A',))
         self.assertCountEqual(d.keys(), keys)
-        self.assertCountEqual([d[k] for k in d.keys()], [None])
+        self.assertEqual([d[k] for k in d.keys()], [None])
 
     def test_accessors(self):
         """Test get and set methods on keys."""
@@ -40,15 +40,15 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test setting and getting values
         d['A'] = 1.0
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, None])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, None])
         d['B'] = 1.0
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         #test re-setting and getting values
         d['A'] = 2.0
-        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
         d['B'] = 1.5
-        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.5])
+        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
         #test getting invalid key
         with self.assertRaises(KeyError):
@@ -58,21 +58,21 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test update method to get and set keys."""
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
 
-        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
+        self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         #test updating both keys
         d.update({'A':1.0, 'B':2.0})  #using dict
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 2.0])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, 2.0])
 
         d.update(A=1.5, B=2.5)  #using kwargs
-        self.assertCountEqual([d[k] for k in d.keys()], [1.5, 2.5])
+        self.assertEqual([d[k] for k in d.keys()], [1.5, 2.5])
 
         #test updating only one key at a time
         d.update({'A':1.1})   #using dict
-        self.assertCountEqual([d[k] for k in d.keys()], [1.1, 2.5])
+        self.assertEqual([d[k] for k in d.keys()], [1.1, 2.5])
 
         d.update(B=2.2)   #using kwargs
-        self.assertCountEqual([d[k] for k in d.keys()], [1.1, 2.2])
+        self.assertEqual([d[k] for k in d.keys()], [1.1, 2.2])
 
         #test using *args length > 1
         with self.assertRaises(TypeError):
@@ -80,7 +80,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test using both *args and **kwargs
         d.update({'A':3.0, 'B':2.0}, B=2.2)
-        self.assertCountEqual([d[k] for k in d.keys()], [3.0, 2.2])
+        self.assertEqual([d[k] for k in d.keys()], [3.0, 2.2])
 
         #test using invalid kwarg
         with self.assertRaises(KeyError):
@@ -90,19 +90,19 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test clear method to reset keys to default."""
         #test clear with no default set
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
-        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
+        self.assertEqual([d[k] for k in d.keys()], [None, None])
         d.update(A=2, B=3)
-        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 3.0])
+        self.assertEqual([d[k] for k in d.keys()], [2.0, 3.0])
         d.clear()
-        self.assertCountEqual([d[k] for k in d.keys()], [None, None])
+        self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         #test clear with set default
         d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
         d.update(A=2, B=3)
-        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 3.0])
+        self.assertEqual([d[k] for k in d.keys()], [2.0, 3.0])
         d.clear()
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
     def test_iteration(self):
         """Test iteration on the dictionary."""
@@ -111,18 +111,18 @@ class test_FixedKeyDict(unittest.TestCase):
         #test iteration for setting values
         for k in d:
             d[k] = 1.0
-        self.assertCountEqual([d[k] for k in d.keys()], [1.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         #test manual re-setting of values
         d['A'] = 2.0
-        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.0])
+        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
         d['B'] = 1.5
-        self.assertCountEqual([d[k] for k in d.keys()], [2.0, 1.5])
+        self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
         #test iteration for re-setting values
         for k in d:
             d[k] = 3.0
-        self.assertCountEqual([d[k] for k in d.keys()], [3.0, 3.0])
+        self.assertEqual([d[k] for k in d.keys()], [3.0, 3.0])
 
     def test_copy(self):
         """Test copying custom dict to standard dict."""

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -13,22 +13,22 @@ class test_FixedKeyDict(unittest.TestCase):
         keys = ('A','B')
         default = {'A':1.0, 'B':1.0}
 
-        #test construction with tuple input
+        # test construction with tuple input
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
-        #test construction with list input
+        # test construction with list input
         d = relentless.collections.FixedKeyDict(keys=['A','B'])
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
-        #test construction with defined default input
+        # test construction with defined default input
         d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
-        #test construction with single-key tuple input
+        # test construction with single-key tuple input
         keys = ('A',)
         d = relentless.collections.FixedKeyDict(keys=('A',))
         self.assertCountEqual(d.keys(), keys)
@@ -38,19 +38,19 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test get and set methods on keys."""
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
 
-        #test setting and getting values
+        # test setting and getting values
         d['A'] = 1.0
         self.assertEqual([d[k] for k in d.keys()], [1.0, None])
         d['B'] = 1.0
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
-        #test re-setting and getting values
+        # test re-setting and getting values
         d['A'] = 2.0
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
         d['B'] = 1.5
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
-        #test getting invalid key
+        # test getting invalid key
         with self.assertRaises(KeyError):
             x = d['C']
 
@@ -60,35 +60,35 @@ class test_FixedKeyDict(unittest.TestCase):
 
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
-        #test updating both keys
-        d.update({'A':1.0, 'B':2.0})  #using dict
+        # test updating both keys
+        d.update({'A':1.0, 'B':2.0}) # using dict
         self.assertEqual([d[k] for k in d.keys()], [1.0, 2.0])
 
-        d.update(A=1.5, B=2.5)  #using kwargs
+        d.update(A=1.5, B=2.5) # using kwargs
         self.assertEqual([d[k] for k in d.keys()], [1.5, 2.5])
 
-        #test updating only one key at a time
-        d.update({'A':1.1})   #using dict
+        # test updating only one key at a time
+        d.update({'A':1.1}) # using dict
         self.assertEqual([d[k] for k in d.keys()], [1.1, 2.5])
 
-        d.update(B=2.2)   #using kwargs
+        d.update(B=2.2) # using kwargs
         self.assertEqual([d[k] for k in d.keys()], [1.1, 2.2])
 
-        #test using *args length > 1
+        # test using *args length > 1
         with self.assertRaises(TypeError):
             d.update({'A':3.0}, {'B':4.0})
 
-        #test using both *args and **kwargs
+        # test using both *args and **kwargs
         d.update({'A':3.0, 'B':2.0}, B=2.2)
         self.assertEqual([d[k] for k in d.keys()], [3.0, 2.2])
 
-        #test using invalid kwarg
+        # test using invalid kwarg
         with self.assertRaises(KeyError):
             d.update(C=2.5)
 
     def test_clear(self):
         """Test clear method to reset keys to default."""
-        #test clear with no default set
+        # test clear with no default set
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
         self.assertEqual([d[k] for k in d.keys()], [None, None])
         d.update(A=2, B=3)
@@ -96,7 +96,7 @@ class test_FixedKeyDict(unittest.TestCase):
         d.clear()
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
-        #test clear with set default
+        # test clear with set default
         d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
         d.update(A=2, B=3)
@@ -108,18 +108,18 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test iteration on the dictionary."""
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
 
-        #test iteration for setting values
+        # test iteration for setting values
         for k in d:
             d[k] = 1.0
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
-        #test manual re-setting of values
+        # test manual re-setting of values
         d['A'] = 2.0
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
         d['B'] = 1.5
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
-        #test iteration for re-setting values
+        # test iteration for re-setting values
         for k in d:
             d[k] = 3.0
         self.assertEqual([d[k] for k in d.keys()], [3.0, 3.0])
@@ -128,16 +128,16 @@ class test_FixedKeyDict(unittest.TestCase):
         """Test copying custom dict to standard dict."""
         d = relentless.collections.FixedKeyDict(keys=('A','B'))
 
-        #test copying for empty dict
+        # test copying for empty dict
         dict_var = {'A':None, 'B':None}
         self.assertEqual(dict(d), dict_var)
 
-        #test copying for partially filled dict
+        # test copying for partially filled dict
         dict_var = {'A':None, 'B':1.0}
         d['B'] = 1.0
         self.assertEqual(dict(d), dict_var)
 
-        #test copying for full dict
+        # test copying for full dict
         dict_var = {'A':1.0, 'B':1.0}
         d['A'] = 1.0
         self.assertEqual(dict(d), dict_var)
@@ -150,12 +150,12 @@ class test_PairMatrix(unittest.TestCase):
         types = ('A','B')
         pairs  = (('A','B'), ('B','B'), ('A','A'))
 
-        #test construction with tuple input
+        # test construction with tuple input
         m = relentless.collections.PairMatrix(types=('A','B'))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
-        #test construction with list input
+        # test construction with list input
         m = relentless.collections.PairMatrix(types=['A','B'])
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
@@ -163,16 +163,16 @@ class test_PairMatrix(unittest.TestCase):
         types = ('A',)
         pairs = (('A','A'),)
 
-        #test construction with single type tuple
+        # test construction with single type tuple
         m = relentless.collections.PairMatrix(types=('A',))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
-        #test construction with int type input
+        # test construction with int type input
         with self.assertRaises(TypeError):
             m = relentless.collections.PairMatrix(types=(1,2))
 
-        #test construction with mixed type input
+        # test construction with mixed type input
         with self.assertRaises(TypeError):
             m = relentless.collections.PairMatrix(types=('1',2))
 
@@ -180,7 +180,7 @@ class test_PairMatrix(unittest.TestCase):
         """Test get and set methods on pairs."""
         m = relentless.collections.PairMatrix(types=('A','B'))
 
-        #test set and get for each pair type
+        # test set and get for each pair type
         m['A','A']['energy'] = 1.0
         self.assertEqual(m['A','A']['energy'], 1.0)
         self.assertEqual(m['A','B'], {})
@@ -196,10 +196,10 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['A','B']['energy'], -1.0)
         self.assertEqual(m['B','B']['energy'], 1.0)
 
-        #test key order equality
+        # test key order equality
         self.assertEqual(m['A','B'], m['B','A'])
 
-        #test re-set and get
+        # test re-set and get
         m['A','A']['energy'] = 2.0
         self.assertEqual(m['A','A']['energy'], 2.0)
         self.assertEqual(m['A','B']['energy'], -1.0)
@@ -215,7 +215,7 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['A','B']['energy'], -1.5)
         self.assertEqual(m['B','B']['energy'], 0.0)
 
-        #test setting multiple parameters and get
+        # test setting multiple parameters and get
         m['A','A']['mass'] = 1.0
         self.assertEqual(m['A','A']['mass'], 1.0)
         self.assertEqual(m['A','A']['energy'], 2.0)
@@ -231,7 +231,7 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['B','B']['energy'], 0.0)
         self.assertEqual(m['B','B'], {'energy':0.0, 'mass':5.0})
 
-        #test setting paramters for invalid keys
+        # test setting paramters for invalid keys
         with self.assertRaises(KeyError):
             x = m['C','C']
         with self.assertRaises(KeyError):
@@ -241,7 +241,7 @@ class test_PairMatrix(unittest.TestCase):
         """Test iteration on the matrix."""
         m = relentless.collections.PairMatrix(types=('A','B'))
 
-        #test iteration for initialization
+        # test iteration for initialization
         for pair in m:
             m[pair]['mass'] = 2.0
             m[pair]['energy'] = 1.0
@@ -249,14 +249,14 @@ class test_PairMatrix(unittest.TestCase):
         self.assertEqual(m['A','A'], {'energy':1.0, 'mass':2.0})
         self.assertEqual(m['B','B'], {'energy':1.0, 'mass':2.0})
 
-        #test resetting values manually
+        # test resetting values manually
         m['A','B']['mass'] = 2.5
         m['A','A']['energy'] = 1.5
         self.assertEqual(m['A','B'], {'energy':1.0, 'mass':2.5})
         self.assertEqual(m['A','A'], {'energy':1.5, 'mass':2.0})
         self.assertEqual(m['B','B'], {'energy':1.0, 'mass':2.0})
 
-        #test re-iteration for setting values
+        # test re-iteration for setting values
         for pair in m:
             m[pair]['energy'] = 3.0
         self.assertEqual(m['A','B'], {'energy':3.0, 'mass':2.5})
@@ -268,28 +268,28 @@ class test_DefaultDict(unittest.TestCase):
 
     def test_funcs(self):
         """Test functionalities."""
-        #instantiation
+        # instantiation
         d = relentless.collections.DefaultDict(default=1.0)
         self.assertAlmostEqual(d.default, 1.0)
         self.assertAlmostEqual(d['A'], 1.0)
         self.assertAlmostEqual(d['B'], 1.0)
         self.assertEqual(len(d), 0)
 
-        #set individually
+        # set individually
         d['A'] = 2.0
         self.assertAlmostEqual(d.default, 1.0)
         self.assertAlmostEqual(d['A'], 2.0)
         self.assertAlmostEqual(d['B'], 1.0)
         self.assertEqual(len(d), 1)
 
-        #delete
+        # delete
         del d['A']
         self.assertAlmostEqual(d.default, 1.0)
         self.assertAlmostEqual(d['A'], 1.0)
         self.assertAlmostEqual(d['B'], 1.0)
         self.assertEqual(len(d), 0)
 
-        #iterate
+        # iterate
         for key in ('A','B'):
             d[key] = 2.5
         self.assertAlmostEqual(d.default, 1.0)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -130,17 +130,17 @@ class test_FixedKeyDict(unittest.TestCase):
 
         #test copying for empty dict
         dict_var = {'A':None, 'B':None}
-        self.assertDictEqual(dict(d), dict_var)
+        self.assertEqual(dict(d), dict_var)
 
         #test copying for partially filled dict
         dict_var = {'A':None, 'B':1.0}
         d['B'] = 1.0
-        self.assertDictEqual(dict(d), dict_var)
+        self.assertEqual(dict(d), dict_var)
 
         #test copying for full dict
         dict_var = {'A':1.0, 'B':1.0}
         d['A'] = 1.0
-        self.assertDictEqual(dict(d), dict_var)
+        self.assertEqual(dict(d), dict_var)
 
 class test_PairMatrix(unittest.TestCase):
     """Unit tests for relentless.collections.PairMatrix."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -16,47 +16,47 @@ class test_Directory(unittest.TestCase):
         """Test basic creation and methods of Directory."""
         cwd = os.getcwd()
 
-        #test creation with existing path
+        # test creation with existing path
         d = relentless.data.Directory(self.f.name)
         self.assertEqual(d.path, self.real_f)
         self.assertEqual(d._start, [])
-        #enter and exit
+        # enter and exit
         with d:
             self.assertEqual(d._start, [cwd])
             self.assertEqual(os.getcwd(), self.real_f)
         self.assertEqual(d._start, [])
 
-        #test creation with non-existent path (absolute)
+        # test creation with non-existent path (absolute)
         foo = os.path.join(self.f.name,'foo')
         real_foo = os.path.realpath(foo)
         d1 = relentless.data.Directory(foo)
         self.assertEqual(d1.path, real_foo)
         self.assertEqual(d1._start, [])
-        #enter and exit
+        # enter and exit
         with d1:
             self.assertEqual(d1._start, [cwd])
             self.assertEqual(os.getcwd(), real_foo)
         self.assertEqual(d1._start, [])
 
-        #test creation with non-existent path (recursive)
+        # test creation with non-existent path (recursive)
         foobar = os.path.join(self.f.name,'bar','foobar')
         real_foobar = os.path.realpath(foobar)
         d2 = relentless.data.Directory(foobar)
         self.assertEqual(d2.path, real_foobar)
         self.assertEqual(d2._start, [])
-        #enter and exit
+        # enter and exit
         with d2:
             self.assertEqual(d2._start, [cwd])
             self.assertEqual(os.getcwd(), real_foobar)
         self.assertEqual(d2._start, [])
 
-        #test creation with invalid directory path
+        # test creation with invalid directory path
         x = tempfile.NamedTemporaryFile(dir=self.f.name)
         with self.assertRaises(OSError):
             d3 = relentless.data.Directory(x.name)
         x.close()
 
-        #test unsuccessfully changing directories (by redundancy)
+        # test unsuccessfully changing directories (by redundancy)
         with d:
             self.assertEqual(d._start, [cwd])
             with d1:
@@ -73,18 +73,18 @@ class test_Directory(unittest.TestCase):
             self.assertEqual(d1._start, [])
         self.assertEqual(d._start, [])
 
-        #test unsuccessful exit after successful enter
+        # test unsuccessful exit after successful enter
         with d2:
             self.assertEqual(d2._start, [cwd])
             with d1:
                 self.assertEqual(d1._start, [d2.path])
                 shutil.rmtree(foobar)
             self.assertEqual(d1._start, [])
-            self.assertEqual(os.getcwd(), d1.path) #no exit
+            self.assertEqual(os.getcwd(), d1.path) # no exit
 
     def test_context(self):
         """Test context methods for Directory."""
-        #create nested directory structure
+        # create nested directory structure
         d = relentless.data.Directory(self.f.name)
         d1 = d.directory('foo')
         d2 = d.directory('bar')
@@ -94,7 +94,7 @@ class test_Directory(unittest.TestCase):
         self.assertEqual(d2.path, os.path.join(self.real_f,'bar'))
         self.assertEqual(d3.path, os.path.join(self.real_f,'foo','bar','foobar'))
 
-        #test creating files
+        # test creating files
         x = d.file('spam.txt')
         x1 = d1.file('ham.txt')
         x2 = d1.file('eggs.txt')
@@ -108,14 +108,14 @@ class test_Directory(unittest.TestCase):
         self.assertEqual(os.path.abspath(x2), os.path.join(d1.path,'eggs.txt'))
         self.assertEqual(os.path.abspath(x3), os.path.join(d3.path,'baz.txt'))
 
-        #test clearing directory structure
-        #delete sub-directory
+        # test clearing directory structure
+        # delete sub-directory
         self.assertCountEqual(os.listdir(d1.path), ['bar','ham.txt','eggs.txt'])
         self.assertCountEqual(os.listdir(d3.path), ['baz.txt'])
         d3.clear_contents()
         self.assertCountEqual(os.listdir(d1.path), ['bar','ham.txt','eggs.txt'])
         self.assertCountEqual(os.listdir(d3.path), [])
-        #delete parent directory
+        # delete parent directory
         self.assertCountEqual(os.listdir(d.path), ['foo','bar','spam.txt'])
         d.clear_contents()
         self.assertCountEqual(os.listdir(d.path), [])

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -11,7 +11,7 @@ class test_RDF(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data"""
-        #test valid construction
+        # test valid construction
         r = [1,2,3]
         g = [2,9,5]
         rdf = relentless.ensemble.RDF(r=r, g=g)
@@ -19,15 +19,15 @@ class test_RDF(unittest.TestCase):
                                                               [2,9],
                                                               [3,5]]))
 
-        #test interpolation
+        # test interpolation
         numpy.testing.assert_allclose(rdf([2.5,3.5]), [8.375,5.0])
 
-        #test invalid construction with r and g having different lengths
+        # test invalid construction with r and g having different lengths
         r = [1,2,3,4]
         with self.assertRaises(ValueError):
             rdf = relentless.ensemble.RDF(r=r, g=g)
 
-        #test invalid construction with non-strictly-increasing r
+        # test invalid construction with non-strictly-increasing r
         r = [1,3,2]
         with self.assertRaises(ValueError):
             rdf = relentless.ensemble.RDF(r=r, g=g)
@@ -37,7 +37,7 @@ class test_Ensemble(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #P and N set
+        # P and N set
         ens = relentless.ensemble.Ensemble(T=10, P=2.0, N={'A':1,'B':2})
         self.assertCountEqual(ens.types, ('A','B'))
         self.assertCountEqual(ens.rdf.pairs, (('A','B'),('A','A'),('B','B')))
@@ -48,7 +48,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(dict(ens.N), {'A':1,'B':2})
         self.assertAlmostEqual(ens.beta, 0.1)
 
-        #V and N set, non-default value of kB
+        # V and N set, non-default value of kB
         v_obj = relentless.volume.Cube(L=3.0)
         ens = relentless.ensemble.Ensemble(T=20, V=v_obj, N={'A':1,'B':2}, kB=2.0)
         self.assertCountEqual(ens.types, ('A','B'))
@@ -73,7 +73,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(dict(ens.N), {'A':None,'B':2})
         self.assertAlmostEqual(ens.beta, 0.01)
 
-        #test creation with single type
+        # test creation with single type
         ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':10})
         self.assertCountEqual(ens.types, ('A',))
         self.assertCountEqual(ens.rdf.pairs, (('A','A'),))
@@ -85,7 +85,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(dict(ens.N), {'A':10})
         self.assertAlmostEqual(ens.beta, 0.01)
 
-        #test setting rdf
+        # test setting rdf
         ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
         r = [1,2,3]
         ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])
@@ -101,10 +101,10 @@ class test_Ensemble(unittest.TestCase):
                                                                            [2,9],
                                                                            [3,3]]))
 
-        #test setting N as a float
+        # test setting N as a float
         with self.assertRaises(TypeError):
             ens = relentless.ensemble.Ensemble(T=10, P=1.0, N={'A':1.0})
-        #test setting N with non-string type
+        # test setting N with non-string type
         with self.assertRaises(TypeError):
             ens = relentless.ensemble.Ensemble(T=10, P=1.0, N={1:2})
 
@@ -113,14 +113,14 @@ class test_Ensemble(unittest.TestCase):
         v_obj = relentless.volume.Cube(L=3.0)
         v_obj1 = relentless.volume.Cube(L=4.0)
 
-        #NVT ensemble
+        # NVT ensemble
         ens = relentless.ensemble.Ensemble(T=10, V=v_obj, N={'A':1,'B':2})
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
         self.assertEqual(dict(ens.N), {'A':1,'B':2})
 
-        #set values
+        # set values
         ens.V = v_obj1
         self.assertIs(ens.V,v_obj1)
         self.assertAlmostEqual(ens.V.volume, 64.0)
@@ -128,11 +128,11 @@ class test_Ensemble(unittest.TestCase):
         ens.N['B'] = 3
         self.assertEqual(dict(ens.N), {'A':2,'B':3})
 
-        #set other values
+        # set other values
         ens.P = 2.0
         self.assertAlmostEqual(ens.P, 2.0)
 
-        #test invalid setting of N directly
+        # test invalid setting of N directly
         with self.assertRaises(AttributeError):
             ens.N = {'A':3,'B':4}
 
@@ -140,7 +140,7 @@ class test_Ensemble(unittest.TestCase):
         """Test copy method"""
         v_obj = relentless.volume.Cube(L=1.0)
 
-        #P and mu set
+        # P and mu set
         ens = relentless.ensemble.Ensemble(T=10, P=2.0, V=v_obj, N={'A':1,'B':2})
         ens_ = ens.copy()
         self.assertIsNot(ens, ens_)
@@ -152,7 +152,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
         self.assertEqual(dict(ens_.N), dict(ens.N))
 
-        #test copying rdf
+        # test copying rdf
         ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
         r = [1,2,3]
         ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])
@@ -182,7 +182,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
         self.assertEqual(dict(ens_.N), dict(ens.N))
 
-        #test saving/constructing rdf
+        # test saving/constructing rdf
         ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
         r = [1,2,3]
         ens.rdf['A','B'] = relentless.ensemble.RDF(r=r, g=[2,9,5])

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -45,7 +45,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.T, 10)
         self.assertAlmostEqual(ens.P, 2.0)
         self.assertEqual(ens.V, None)
-        self.assertDictEqual(dict(ens.N), {'A':1,'B':2})
+        self.assertEqual(dict(ens.N), {'A':1,'B':2})
         self.assertAlmostEqual(ens.beta, 0.1)
 
         #V and N set, non-default value of kB
@@ -58,7 +58,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(dict(ens.N), {'A':1,'B':2})
+        self.assertEqual(dict(ens.N), {'A':1,'B':2})
         self.assertAlmostEqual(ens.beta, 0.025)
 
         # one N is None
@@ -70,7 +70,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(dict(ens.N), {'A':None,'B':2})
+        self.assertEqual(dict(ens.N), {'A':None,'B':2})
         self.assertAlmostEqual(ens.beta, 0.01)
 
         #test creation with single type
@@ -82,7 +82,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(dict(ens.N), {'A':10})
+        self.assertEqual(dict(ens.N), {'A':10})
         self.assertAlmostEqual(ens.beta, 0.01)
 
         #test setting rdf
@@ -118,7 +118,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V,v_obj)
         self.assertAlmostEqual(ens.V.volume, 27.0)
-        self.assertDictEqual(dict(ens.N), {'A':1,'B':2})
+        self.assertEqual(dict(ens.N), {'A':1,'B':2})
 
         #set values
         ens.V = v_obj1
@@ -126,7 +126,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.V.volume, 64.0)
         ens.N['A'] = 2
         ens.N['B'] = 3
-        self.assertDictEqual(dict(ens.N), {'A':2,'B':3})
+        self.assertEqual(dict(ens.N), {'A':2,'B':3})
 
         #set other values
         ens.P = 2.0
@@ -150,7 +150,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.P, ens_.P)
         self.assertIsInstance(ens_.V, relentless.volume.Cube)
         self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+        self.assertEqual(dict(ens_.N), dict(ens.N))
 
         #test copying rdf
         ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
@@ -180,7 +180,7 @@ class test_Ensemble(unittest.TestCase):
         self.assertAlmostEqual(ens.P, ens_.P)
         self.assertIsInstance(ens_.V, relentless.volume.Cube)
         self.assertAlmostEqual(ens.V.volume, ens_.V.volume)
-        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+        self.assertEqual(dict(ens_.N), dict(ens.N))
 
         #test saving/constructing rdf
         ens = relentless.ensemble.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -89,10 +89,10 @@ class test_KeyedArray(unittest.TestCase):
     def test_init(self):
         """Test construction with data."""
         k = relentless.math.KeyedArray(keys=('A','B'))
-        self.assertDictEqual(dict(k), {'A':None, 'B':None})
+        self.assertEqual(dict(k), {'A':None, 'B':None})
 
         k = relentless.math.KeyedArray(keys=('A','B'), default=2.0)
-        self.assertDictEqual(dict(k), {'A':2.0, 'B':2.0})
+        self.assertEqual(dict(k), {'A':2.0, 'B':2.0})
 
         #invalid key
         with self.assertRaises(KeyError):
@@ -109,15 +109,15 @@ class test_KeyedArray(unittest.TestCase):
 
         #addition
         k4 = k1 + k2
-        self.assertDictEqual(dict(k4), {'A':3.0, 'B':5.0})
+        self.assertEqual(dict(k4), {'A':3.0, 'B':5.0})
         k4 += k2
-        self.assertDictEqual(dict(k4), {'A':5.0, 'B':8.0})
+        self.assertEqual(dict(k4), {'A':5.0, 'B':8.0})
         k4 = k1 + 1
-        self.assertDictEqual(dict(k4), {'A':2.0, 'B':3.0})
+        self.assertEqual(dict(k4), {'A':2.0, 'B':3.0})
         k4 = 2 + k1
-        self.assertDictEqual(dict(k4), {'A':3.0, 'B':4.0})
+        self.assertEqual(dict(k4), {'A':3.0, 'B':4.0})
         k4 += 1
-        self.assertDictEqual(dict(k4), {'A':4.0, 'B':5.0})
+        self.assertEqual(dict(k4), {'A':4.0, 'B':5.0})
         with self.assertRaises(KeyError):
             k4 = k1 + k3
         with self.assertRaises(KeyError):
@@ -125,15 +125,15 @@ class test_KeyedArray(unittest.TestCase):
 
         #subtraction
         k4 = k1 - k2
-        self.assertDictEqual(dict(k4), {'A':-1.0, 'B':-1.0})
+        self.assertEqual(dict(k4), {'A':-1.0, 'B':-1.0})
         k4 -= k2
-        self.assertDictEqual(dict(k4), {'A':-3.0, 'B':-4.0})
+        self.assertEqual(dict(k4), {'A':-3.0, 'B':-4.0})
         k4 = k1 - 1
-        self.assertDictEqual(dict(k4), {'A':0.0, 'B':1.0})
+        self.assertEqual(dict(k4), {'A':0.0, 'B':1.0})
         k4 = 2 - k1
-        self.assertDictEqual(dict(k4), {'A':1.0, 'B':0.0})
+        self.assertEqual(dict(k4), {'A':1.0, 'B':0.0})
         k4 -= 1
-        self.assertDictEqual(dict(k4), {'A':0.0, 'B':-1.0})
+        self.assertEqual(dict(k4), {'A':0.0, 'B':-1.0})
         with self.assertRaises(KeyError):
             k4 = k1 - k3
         with self.assertRaises(KeyError):
@@ -141,41 +141,41 @@ class test_KeyedArray(unittest.TestCase):
 
         #multiplication
         k4 = k1*k2
-        self.assertDictEqual(dict(k4), {'A':2.0, 'B':6.0})
+        self.assertEqual(dict(k4), {'A':2.0, 'B':6.0})
         k4 *= k2
-        self.assertDictEqual(dict(k4), {'A':4.0, 'B':18.0})
+        self.assertEqual(dict(k4), {'A':4.0, 'B':18.0})
         k4 = 3*k1
-        self.assertDictEqual(dict(k4), {'A':3.0, 'B':6.0})
+        self.assertEqual(dict(k4), {'A':3.0, 'B':6.0})
         k4 = k2*3
-        self.assertDictEqual(dict(k4), {'A':6.0, 'B':9.0})
+        self.assertEqual(dict(k4), {'A':6.0, 'B':9.0})
         k4 *= 3
-        self.assertDictEqual(dict(k4), {'A':18.0, 'B':27.0})
+        self.assertEqual(dict(k4), {'A':18.0, 'B':27.0})
         with self.assertRaises(KeyError):
             k4 = k1*k3
 
         #division
         k4 = k1/k2
-        self.assertDictEqual(dict(k4), {'A':0.5, 'B':0.6666666666666666})
+        self.assertEqual(dict(k4), {'A':0.5, 'B':0.6666666666666666})
         k4 /= k2
-        self.assertDictEqual(dict(k4), {'A':0.25, 'B':0.2222222222222222})
+        self.assertEqual(dict(k4), {'A':0.25, 'B':0.2222222222222222})
         k4 = 2/k2
-        self.assertDictEqual(dict(k4), {'A':1.0, 'B':0.6666666666666666})
+        self.assertEqual(dict(k4), {'A':1.0, 'B':0.6666666666666666})
         k4 = k2/2
-        self.assertDictEqual(dict(k4), {'A':1.0, 'B':1.5})
+        self.assertEqual(dict(k4), {'A':1.0, 'B':1.5})
         k4 /= 2
-        self.assertDictEqual(dict(k4), {'A':0.5, 'B':0.75})
+        self.assertEqual(dict(k4), {'A':0.5, 'B':0.75})
         with self.assertRaises(KeyError):
             k4 = k1/k3
 
         #exponentiation
         k4 = k1**k2
-        self.assertDictEqual(dict(k4), {'A':1.0, 'B':8.0})
+        self.assertEqual(dict(k4), {'A':1.0, 'B':8.0})
         k4 = k2**2
-        self.assertDictEqual(dict(k4), {'A':4.0, 'B':9.0})
+        self.assertEqual(dict(k4), {'A':4.0, 'B':9.0})
 
         #negation
         k4 = -k1
-        self.assertDictEqual(dict(k4), {'A':-1.0, 'B':-2.0})
+        self.assertEqual(dict(k4), {'A':-1.0, 'B':-2.0})
 
     def test_vector_ops(self):
         """Test vector operations."""

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -10,37 +10,37 @@ class test_Interpolator(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #test construction with tuple input
+        # test construction with tuple input
         f = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
         self.assertEqual(f.domain, (-1,1))
 
-        #test construction with list input
+        # test construction with list input
         f = relentless.math.Interpolator(x=[-1,0,1], y=[-2,0,2])
         self.assertEqual(f.domain, (-1,1))
 
-        #test construction with numpy array input
+        # test construction with numpy array input
         f = relentless.math.Interpolator(x=numpy.array([-1,0,1]),
                                          y=numpy.array([-2,0,2]))
         self.assertEqual(f.domain, (-1,1))
 
-        #test construction with mixed input
+        # test construction with mixed input
         f = relentless.math.Interpolator(x=[-1,0,1], y=(-2,0,2))
         self.assertEqual(f.domain, (-1,1))
 
-        #test construction with scalar input
+        # test construction with scalar input
         with self.assertRaises(ValueError):
             f = relentless.math.Interpolator(x=1, y=2)
 
-        #test construction with 2d-array input
+        # test construction with 2d-array input
         with self.assertRaises(ValueError):
             f = relentless.math.Interpolator(x=numpy.array([[-1,0,1], [-2,2,4]]),
                                              y=numpy.array([[-1,0,1], [-2,2,4]]))
 
-        #test construction with x and y having different lengths
+        # test construction with x and y having different lengths
         with self.assertRaises(ValueError):
             f = relentless.math.Interpolator(x=[-1,0], y=[-2,0,2])
 
-        #test construction with non-strictly-increasing domain
+        # test construction with non-strictly-increasing domain
         with self.assertRaises(ValueError):
             f = relentless.math.Interpolator(x=(0,1,-1), y=(0,2,-2))
 
@@ -48,22 +48,22 @@ class test_Interpolator(unittest.TestCase):
         """Test calls, both scalar and array."""
         f = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
 
-        #test scalar call
+        # test scalar call
         self.assertAlmostEqual(f(-0.5), -1.0)
         self.assertAlmostEqual(f(0.5), 1.0)
 
-        #test array call
+        # test array call
         numpy.testing.assert_allclose(f([-0.5,0.5]), [-1.0,1.0])
 
     def test_derivative(self):
         """Test derivative function, both scalar and array."""
         f = relentless.math.Interpolator(x=(-2,-1,0,1,2), y=(4,1,0,1,4))
 
-        #test scalar call
+        # test scalar call
         d = f.derivative(x=1.5, n=1)
         self.assertAlmostEqual(d, 3.0)
 
-        #test array call
+        # test array call
         d = f.derivative(x=numpy.array([-3.0,-0.5,0.5,3.0]), n=1)
         numpy.testing.assert_allclose(d, numpy.array([0.0,-1.0,1.0,0.0]))
 
@@ -71,16 +71,16 @@ class test_Interpolator(unittest.TestCase):
         """Test extrapolation calls."""
         f = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
 
-        #test extrap below lo
+        # test extrap below lo
         self.assertAlmostEqual(f(-2), -2.0)
 
-        #test extrap above hi
+        # test extrap above hi
         self.assertAlmostEqual(f(2), 2.0)
 
-        #test extrap below low and above hi
+        # test extrap below low and above hi
         numpy.testing.assert_allclose(f([-2,2]), [-2.0,2.0])
 
-        #test combined extrapolation and interpolation
+        # test combined extrapolation and interpolation
         numpy.testing.assert_allclose(f([-2,0.5,2]), [-2.0,1.0,2.0])
 
 class test_KeyedArray(unittest.TestCase):
@@ -94,7 +94,7 @@ class test_KeyedArray(unittest.TestCase):
         k = relentless.math.KeyedArray(keys=('A','B'), default=2.0)
         self.assertEqual(dict(k), {'A':2.0, 'B':2.0})
 
-        #invalid key
+        # invalid key
         with self.assertRaises(KeyError):
             x = k['C']
 
@@ -107,7 +107,7 @@ class test_KeyedArray(unittest.TestCase):
         k3 = relentless.math.KeyedArray(keys=('A','B','C'))
         k3.update({'A':3.0, 'B':4.0, 'C':5.0})
 
-        #addition
+        # addition
         k4 = k1 + k2
         self.assertEqual(dict(k4), {'A':3.0, 'B':5.0})
         k4 += k2
@@ -123,7 +123,7 @@ class test_KeyedArray(unittest.TestCase):
         with self.assertRaises(KeyError):
             k3 += k2
 
-        #subtraction
+        # subtraction
         k4 = k1 - k2
         self.assertEqual(dict(k4), {'A':-1.0, 'B':-1.0})
         k4 -= k2
@@ -139,7 +139,7 @@ class test_KeyedArray(unittest.TestCase):
         with self.assertRaises(KeyError):
             k3 -= k2
 
-        #multiplication
+        # multiplication
         k4 = k1*k2
         self.assertEqual(dict(k4), {'A':2.0, 'B':6.0})
         k4 *= k2
@@ -153,7 +153,7 @@ class test_KeyedArray(unittest.TestCase):
         with self.assertRaises(KeyError):
             k4 = k1*k3
 
-        #division
+        # division
         k4 = k1/k2
         self.assertEqual(dict(k4), {'A':0.5, 'B':0.6666666666666666})
         k4 /= k2
@@ -167,13 +167,13 @@ class test_KeyedArray(unittest.TestCase):
         with self.assertRaises(KeyError):
             k4 = k1/k3
 
-        #exponentiation
+        # exponentiation
         k4 = k1**k2
         self.assertEqual(dict(k4), {'A':1.0, 'B':8.0})
         k4 = k2**2
         self.assertEqual(dict(k4), {'A':4.0, 'B':9.0})
 
-        #negation
+        # negation
         k4 = -k1
         self.assertEqual(dict(k4), {'A':-1.0, 'B':-2.0})
 
@@ -186,11 +186,11 @@ class test_KeyedArray(unittest.TestCase):
         k3 = relentless.math.KeyedArray(keys=('A','B','C'))
         k3.update({'A':3.0, 'B':4.0, 'C':5.0})
 
-        #norm
+        # norm
         self.assertAlmostEqual(k1.norm(), numpy.sqrt(5))
         self.assertAlmostEqual(k3.norm(), numpy.sqrt(50))
 
-        #dot product
+        # dot product
         self.assertAlmostEqual(k1.dot(k2), 8.0)
         self.assertAlmostEqual(k1.dot(k2), k2.dot(k1))
         with self.assertRaises(KeyError):

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -28,11 +28,11 @@ class test_Variable(unittest.TestCase):
 
     def test_operations(self):
         """Test arithmetic operations on variables."""
-        #create dependent variables
+        # create dependent variables
         v = relentless.variable.IndependentVariable(value=2.0)
         w = relentless.variable.IndependentVariable(value=4.0)
 
-        #addition
+        # addition
         x = v+w
         self.assertAlmostEqual(x.value, 6.0)
         x = v+2.0
@@ -40,7 +40,7 @@ class test_Variable(unittest.TestCase):
         x = 2.0+w
         self.assertAlmostEqual(x.value, 6.0)
 
-        #subtraction
+        # subtraction
         x = v-w
         self.assertAlmostEqual(x.value, -2.0)
         x = v-1.0
@@ -48,7 +48,7 @@ class test_Variable(unittest.TestCase):
         x = 1.0-w
         self.assertAlmostEqual(x.value, -3.0)
 
-        #multiplication
+        # multiplication
         x = v*w
         self.assertAlmostEqual(x.value, 8.0)
         x = v*1.5
@@ -56,7 +56,7 @@ class test_Variable(unittest.TestCase):
         x = 1.5*w
         self.assertAlmostEqual(x.value, 6.0)
 
-        #division
+        # division
         x = w/v
         self.assertAlmostEqual(x.value, 2.0)
         x = v/2.0
@@ -64,17 +64,17 @@ class test_Variable(unittest.TestCase):
         x = 3.0/w
         self.assertAlmostEqual(x.value, 0.75)
 
-        #exponentiation
+        # exponentiation
         x = w**v
         self.assertAlmostEqual(x.value, 16.0)
         x = v**3.0
         self.assertAlmostEqual(x.value, 8.0)
 
-        #negation
+        # negation
         x = -w
         self.assertAlmostEqual(x.value, -4.0)
 
-        #string conversion
+        # string conversion
         self.assertEqual(str(x), '-4.0')
 
 class test_IndependentVariable(unittest.TestCase):
@@ -82,7 +82,7 @@ class test_IndependentVariable(unittest.TestCase):
 
     def test_init(self):
         """Test construction with data."""
-        #test scalar values
+        # test scalar values
         v = relentless.variable.IndependentVariable(1.0)
         self.assertEqual(v.value, 1.0)
 
@@ -102,29 +102,29 @@ class test_IndependentVariable(unittest.TestCase):
 
     def test_ioperations(self):
         """Test in-place arithmetic operations on variables."""
-        #create dependent variables
+        # create dependent variables
         v = relentless.variable.IndependentVariable(value=2.0)
         w = relentless.variable.IndependentVariable(value=4.0)
 
-        #addition
+        # addition
         v += 2.0
         self.assertAlmostEqual(v.value, 4.0)
         with self.assertRaises(TypeError):
             v += w
 
-        #subtraction
+        # subtraction
         w -= 2.0
         self.assertAlmostEqual(w.value, 2.0)
         with self.assertRaises(TypeError):
             v -= w
 
-        #multiplication
+        # multiplication
         w *= 3.0
         self.assertAlmostEqual(w.value, 6.0)
         with self.assertRaises(TypeError):
             v *= w
 
-        #division
+        # division
         v /= 4.0
         self.assertAlmostEqual(v.value, 1.0)
         with self.assertRaises(TypeError):
@@ -135,7 +135,7 @@ class test_DesignVariable(unittest.TestCase):
 
     def test_init(self):
         """Test construction with different bounds."""
-        #test with no bounds
+        # test with no bounds
         v = relentless.variable.DesignVariable(value=1.0)
         self.assertAlmostEqual(v.value, 1.0)
         self.assertEqual(v.low, None)
@@ -144,7 +144,7 @@ class test_DesignVariable(unittest.TestCase):
         self.assertEqual(v.atlow(), False)
         self.assertEqual(v.athigh(), False)
 
-        #test in between low and high bounds
+        # test in between low and high bounds
         v = relentless.variable.DesignVariable(value=1.2, low=0.0, high=2.0)
         self.assertAlmostEqual(v.value, 1.2)
         self.assertAlmostEqual(v.low, 0.0)
@@ -153,7 +153,7 @@ class test_DesignVariable(unittest.TestCase):
         self.assertEqual(v.atlow(), False)
         self.assertEqual(v.athigh(), False)
 
-        #test below low bound
+        # test below low bound
         v = relentless.variable.DesignVariable(value=-1, low=0.5)
         self.assertAlmostEqual(v.value, 0.5)
         self.assertAlmostEqual(v.low, 0.5)
@@ -162,7 +162,7 @@ class test_DesignVariable(unittest.TestCase):
         self.assertEqual(v.atlow(), True)
         self.assertEqual(v.athigh(), False)
 
-        #test above high bound
+        # test above high bound
         v = relentless.variable.DesignVariable(value=2.2, high=2.0)
         self.assertAlmostEqual(v.value, 2.0)
         self.assertEqual(v.high, 2.0)
@@ -171,23 +171,23 @@ class test_DesignVariable(unittest.TestCase):
         self.assertEqual(v.atlow(), False)
         self.assertEqual(v.athigh(), True)
 
-        #test setting bounds after construction
+        # test setting bounds after construction
         v = relentless.variable.DesignVariable(value=-1.0)
         self.assertAlmostEqual(v.value, -1.0)
         self.assertEqual(v.high, None)
         self.assertEqual(v.low, None)
-        #only low
+        # only low
         v.low = -1.5
         self.assertAlmostEqual(v.value, -1.0)
         self.assertEqual(v.high, None)
         self.assertEqual(v.low, -1.5)
-        #only high
+        # only high
         v.low = None
         v.high = 1.5
         self.assertAlmostEqual(v.value, -1.0)
         self.assertEqual(v.high, 1.5)
         self.assertEqual(v.low, None)
-        #both
+        # both
         v.low = -1.5
         self.assertAlmostEqual(v.value, -1.0)
         self.assertEqual(v.high, 1.5)
@@ -195,88 +195,88 @@ class test_DesignVariable(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             v.value = '4'
-        #test invalid low initialization
+        # test invalid low initialization
         with self.assertRaises(TypeError):
             v.low = '4'
-        #test invalid high initialization
+        # test invalid high initialization
         with self.assertRaises(TypeError):
             v.high = '4'
 
     def test_clamp(self):
         """Test methods for clamping values with bounds."""
-        #construction with only low bound
+        # construction with only low bound
         v = relentless.variable.DesignVariable(value=0.0, low=2.0)
-        #test below low
+        # test below low
         val,state = v.clamp(1.0)
         self.assertAlmostEqual(val, 2.0)
         self.assertEqual(state, v.State.LOW)
-        #test at low
+        # test at low
         val,state = v.clamp(2.0)
         self.assertAlmostEqual(val, 2.0)
         self.assertEqual(state, v.State.LOW)
-        #test above low
+        # test above low
         val,state = v.clamp(3.0)
         self.assertAlmostEqual(val, 3.0)
         self.assertEqual(state, v.State.FREE)
 
-        #construction with low and high bounds
+        # construction with low and high bounds
         v = relentless.variable.DesignVariable(value=0.0, low=0.0, high=2.0)
-        #test below low
+        # test below low
         val,state = v.clamp(-1.0)
         self.assertAlmostEqual(val, 0.0)
         self.assertEqual(state, v.State.LOW)
-        #test between bounds
+        # test between bounds
         val,state = v.clamp(1.0)
         self.assertAlmostEqual(val, 1.0)
         self.assertEqual(state, v.State.FREE)
-        #test above high
+        # test above high
         val,state = v.clamp(2.5)
         self.assertAlmostEqual(val, 2.0)
         self.assertEqual(state, v.State.HIGH)
 
-        #construction with no bounds
+        # construction with no bounds
         v = relentless.variable.DesignVariable(value=0.0)
-        #test free variable
+        # test free variable
         val,state = v.clamp(1.0)
         self.assertAlmostEqual(val, 1.0)
         self.assertEqual(state, v.State.FREE)
 
     def test_value(self):
         """Test methods for setting values and checking bounds."""
-        #test construction with value between bounds
+        # test construction with value between bounds
         v = relentless.variable.DesignVariable(value=0.0, low=-1.0, high=1.0)
         self.assertAlmostEqual(v.value, 0.0)
         self.assertEqual(v.state, v.State.FREE)
 
-        #test below low
+        # test below low
         v.value = -1.5
         self.assertAlmostEqual(v.value, -1.0)
         self.assertEqual(v.state, v.State.LOW)
 
-        #test above high
+        # test above high
         v.value = 3
         self.assertAlmostEqual(v.value, 1.0)
         self.assertEqual(v.state, v.State.HIGH)
 
-        #test invalid value
+        # test invalid value
         with self.assertRaises(TypeError):
             v.value = '0'
 
     def test_bounds(self):
         """Test methods for setting bounds and checking value clamping."""
-        #test construction with value between bounds
+        # test construction with value between bounds
         v = relentless.variable.DesignVariable(value=0.0, low=-1.0, high=1.0)
         self.assertAlmostEqual(v.value, 0.0)
         self.assertEqual(v.state, v.State.FREE)
 
-        #test changing low bound to above value
+        # test changing low bound to above value
         v.low = 0.2
         self.assertAlmostEqual(v.value, 0.2)
         self.assertAlmostEqual(v.low, 0.2)
         self.assertAlmostEqual(v.high, 1.0)
         self.assertEqual(v.state, v.State.LOW)
 
-        #test changing high bound to below value
+        # test changing high bound to below value
         v.low = -1.0
         v.high = -0.2
         self.assertAlmostEqual(v.value, -0.2)
@@ -284,7 +284,7 @@ class test_DesignVariable(unittest.TestCase):
         self.assertAlmostEqual(v.high, -0.2)
         self.assertEqual(v.state, v.State.HIGH)
 
-        #test changing bounds incorrectly
+        # test changing bounds incorrectly
         with self.assertRaises(ValueError):
             v.low = 0.2
         with self.assertRaises(ValueError):
@@ -299,9 +299,9 @@ class DepVar(relentless.variable.DependentVariable):
         return numpy.sum([v for v in kwargs.values()])
 
     def compute_derivative(self, param, **kwargs):
-        #Note: this method doesn't calculate the actual derivatives;
-        #it is merely used for testing the chain rule calculations
-        #with various variable dependencies
+        # Note: this method doesn't calculate the actual derivatives;
+        # it is merely used for testing the chain rule calculations
+        # with various variable dependencies
         if param in self.params:
             if kwargs[param] > 5.0:
                 return 0.5
@@ -319,31 +319,31 @@ class test_DependentVariable(unittest.TestCase):
         u = relentless.variable.DesignVariable(value=2.0)
         v = relentless.variable.DesignVariable(value=3.0)
 
-        #test creation with only vardicts
+        # test creation with only vardicts
         w = DepVar({'t':t, 'u':u, 'v':v})
         self.assertAlmostEqual(w.value, 6.0)
 
-        #test creation with only kwvars
+        # test creation with only kwvars
         w = DepVar(t=t, u=u, v=v)
         self.assertAlmostEqual(w.value, 6.0)
 
-        #test creation with vardicts and kwvars
+        # test creation with vardicts and kwvars
         w = DepVar({'t':t, 'u':u}, v=v)
         self.assertAlmostEqual(w.value, 6.0)
 
-        #test creation with repeated attributes
+        # test creation with repeated attributes
         w = DepVar({'t':t, 'u':u}, u=v)
         self.assertAlmostEqual(w.value, 4.0)
 
-        #test creation with multiple vardicts
+        # test creation with multiple vardicts
         w = DepVar({'t':t, 'u':u}, {'v':v})
         self.assertAlmostEqual(w.value, 6.0)
 
-        #test creation with scalar attributes
+        # test creation with scalar attributes
         w = DepVar(t=1.0, u=2.0, v=3.0)
         self.assertAlmostEqual(w.value, 6.0)
 
-        #test invalid creation with no attributes
+        # test invalid creation with no attributes
         with self.assertRaises(AssertionError):
             w = DepVar()
 
@@ -353,23 +353,23 @@ class test_DependentVariable(unittest.TestCase):
         u = relentless.variable.DesignVariable(value=2.0)
         v = relentless.variable.DesignVariable(value=3.0)
 
-        #test derivative with 1 level of dependency
+        # test derivative with 1 level of dependency
         w = DepVar(t=t, u=u, v=v)
         dw = w.derivative(t)
         self.assertAlmostEqual(dw, -0.5)
         dw = w.derivative(v)
         self.assertAlmostEqual(dw, -0.5)
 
-        #test derivative with respect to self
+        # test derivative with respect to self
         dw = w.derivative(w)
         self.assertAlmostEqual(dw, 1.0)
 
-        #test derivative of variable not in the graph
+        # test derivative of variable not in the graph
         x = DepVar(t=t, v=v)
         dx = x.derivative(u)
         self.assertAlmostEqual(dx, 0.0)
 
-        #test derivative with 2 levels of dependency
+        # test derivative with 2 levels of dependency
         y = DepVar(w=w, x=x)
         dy = y.derivative(t)
         self.assertAlmostEqual(dy, 0.0)
@@ -378,7 +378,7 @@ class test_DependentVariable(unittest.TestCase):
         dy = y.derivative(v)
         self.assertAlmostEqual(dy, 0.0)
 
-        #test derivative with more complex dependency
+        # test derivative with more complex dependency
         z = DepVar(t=t, w=w, y=y)
         dz = z.derivative(u)
         self.assertAlmostEqual(dz, -0.375)
@@ -387,7 +387,7 @@ class test_DependentVariable(unittest.TestCase):
         dz = z.derivative(w)
         self.assertAlmostEqual(dz, 0.75)
 
-        #test derivative with 'multiple' dependency on same object
+        # test derivative with 'multiple' dependency on same object
         q = DepVar(t=t, u=t, v=t)
         dq = q.derivative(t)
         self.assertAlmostEqual(dq, -1.5)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -10,14 +10,14 @@ class test_Parallelepiped(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #test valid construction
+        # test valid construction
         p = relentless.volume.Parallelepiped(a=(1,2,1),b=(3,4,5),c=(9,9,0))
         numpy.testing.assert_allclose(p.a, numpy.array([1,2,1]))
         numpy.testing.assert_allclose(p.b, numpy.array([3,4,5]))
         numpy.testing.assert_allclose(p.c, numpy.array([9,9,0]))
         self.assertAlmostEqual(p.volume, 36)
 
-        #test invalid construction
+        # test invalid construction
         with self.assertRaises(TypeError):
             p = relentless.volume.Parallelepiped(a=(1,2,1),b=(3,4,5),c=(9,9))
         with self.assertRaises(ValueError):
@@ -39,7 +39,7 @@ class test_TriclinicBox(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #test valid construction, LAMMPS convention
+        # test valid construction, LAMMPS convention
         t = relentless.volume.TriclinicBox(Lx=1,Ly=2,Lz=3,xy=1,xz=0.75,yz=2.25,
                                            convention=relentless.volume.TriclinicBox.Convention.LAMMPS)
         numpy.testing.assert_allclose(t.a, numpy.array([1,0,0]))
@@ -47,7 +47,7 @@ class test_TriclinicBox(unittest.TestCase):
         numpy.testing.assert_allclose(t.c, numpy.array([0.75,2.25,3]))
         self.assertAlmostEqual(t.volume, 6)
 
-        #test valid construction, HOOMD convention
+        # test valid construction, HOOMD convention
         t = relentless.volume.TriclinicBox(Lx=1,Ly=2,Lz=3,xy=0.5,xz=0.25,yz=0.75,
                                            convention=relentless.volume.TriclinicBox.Convention.HOOMD)
         numpy.testing.assert_allclose(t.a, numpy.array([1,0,0]))
@@ -55,7 +55,7 @@ class test_TriclinicBox(unittest.TestCase):
         numpy.testing.assert_allclose(t.c, numpy.array([0.75,2.25,3]))
         self.assertAlmostEqual(t.volume, 6)
 
-        #test invalid constructions
+        # test invalid constructions
         with self.assertRaises(ValueError):
             t = relentless.volume.TriclinicBox(Lx=1,Ly=2,Lz=3,xy=1,xz=0.75,yz=2.25,convention='LAMMPS')
         with self.assertRaises(ValueError):
@@ -64,7 +64,7 @@ class test_TriclinicBox(unittest.TestCase):
 
     def test_to_from_json(self):
         """Test to_json and from_json methods."""
-        #test LAMMPS convention
+        # test LAMMPS convention
         c = relentless.volume.TriclinicBox(Lx=3,Ly=4,Lz=5,xy=2,xz=3,yz=4,
                                            convention=relentless.volume.TriclinicBox.Convention.LAMMPS)
         data = c.to_json()
@@ -75,7 +75,7 @@ class test_TriclinicBox(unittest.TestCase):
         numpy.testing.assert_allclose(c.c, c_.c)
         self.assertAlmostEqual(c.volume, c_.volume)
 
-        #test HOOMD convention
+        # test HOOMD convention
         c = relentless.volume.TriclinicBox(Lx=3,Ly=4,Lz=5,xy=2,xz=3,yz=4,
                                            convention=relentless.volume.TriclinicBox.Convention.HOOMD)
         data = c.to_json()
@@ -91,14 +91,14 @@ class test_Cuboid(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #test valid construction
+        # test valid construction
         c = relentless.volume.Cuboid(Lx=3,Ly=4,Lz=5)
         numpy.testing.assert_allclose(c.a, numpy.array([3,0,0]))
         numpy.testing.assert_allclose(c.b, numpy.array([0,4,0]))
         numpy.testing.assert_allclose(c.c, numpy.array([0,0,5]))
         self.assertAlmostEqual(c.volume, 60)
 
-        #test invalid construction
+        # test invalid construction
         with self.assertRaises(ValueError):
             c = relentless.volume.Cuboid(Lx=-3,Ly=4,Lz=5)
 
@@ -118,14 +118,14 @@ class test_Cube(unittest.TestCase):
 
     def test_init(self):
         """Test creation from data."""
-        #test valid construction
+        # test valid construction
         c = relentless.volume.Cube(L=3)
         numpy.testing.assert_allclose(c.a, numpy.array([3,0,0]))
         numpy.testing.assert_allclose(c.b, numpy.array([0,3,0]))
         numpy.testing.assert_allclose(c.c, numpy.array([0,0,3]))
         self.assertAlmostEqual(c.volume, 27)
 
-        #test invalid construction
+        # test invalid construction
         with self.assertRaises(ValueError):
             c = relentless.volume.Cube(L=-1)
 


### PR DESCRIPTION
- Fix bug in `design_variables` property of `PairSpline`
- Modify `FixedKeyDict` `__iter__` method
- Remove unnecessary uses of `assertCountEqual` and `assertDictEqual` from some unit tests
- Fix documentation, stylistic errors

Resolves #101