### PR TITLE
Improve random initialization procedure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,20 +23,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: test
 
       - name: Install dependencies
         run: |
-          conda install -y -c conda-forge --file tests/requirements.txt
+          mamba install --file tests/requirements.txt
 
       - name: Build
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: requirements.txt
     - requirements: doc/requirements.txt

--- a/relentless/extent.py
+++ b/relentless/extent.py
@@ -9,7 +9,6 @@ The following three-dimensional box types have been implemented:
 .. autosummary::
     :nosignatures:
 
-    Parallelepiped
     TriclinicBox
     Cuboid
     Cube
@@ -19,7 +18,6 @@ The following two-dimensional box types have been implemented:
 .. autosummary::
     :nosignatures:
 
-    Parallelogram
     ObliqueArea
     Rectangle
     Square
@@ -56,15 +54,11 @@ and define the required methods.
     :members:
 .. autoclass:: Area
     :members:
-.. autoclass:: Parallelepiped
-    :members:
 .. autoclass:: TriclinicBox
     :members:
 .. autoclass:: Cuboid
     :members:
 .. autoclass:: Cube
-    :members:
-.. autoclass:: Parallelogram
     :members:
 .. autoclass:: ObliqueArea
     :members:
@@ -88,12 +82,25 @@ class Extent(abc.ABC):
     Extent must be specified so that the object can be saved to disk.
 
     """
+    @classmethod
+    @abc.abstractmethod
+    def from_json(cls, data):
+        r"""Deserialize from a dictionary.
+
+        Returns
+        -------
+        :class:`Extent`
+            The object reconstructed from the ``data``.
+
+        """
+        pass
+
     @property
     @abc.abstractmethod
     def extent(self):
         r"""float: Extent of the region."""
         pass
-    
+
     @abc.abstractmethod
     def to_json(self):
         r"""Serialize as a dictionary.
@@ -108,19 +115,6 @@ class Extent(abc.ABC):
         """
         pass
 
-    @classmethod
-    @abc.abstractmethod
-    def from_json(cls, data):
-        r"""Deserialize from a dictionary.
-
-        Returns
-        -------
-        :class:`Extent`
-            The object reconstructed from the ``data``.
-
-        """
-        pass
-
 class Volume(Extent):
     r"""Three-dimensional region of space.
 
@@ -130,113 +124,24 @@ class Volume(Extent):
     Volume must be specified so that the object can be saved to disk.
 
     """
-    @property
-    def volume(self):
-        r"""float: Volume of the region."""
-        pass
+    pass
 
-class Area(Extent):
-    r"""Two-dimensional region of space.
-
-    An Area can be any 2d region of space; typically, it is a simulation "box."
-    Any deriving class must implement the volume method that computes the scalar
-    area of the region. Additionally, methods to serialize and deserialize a
-    Area must be specified so that the object can be saved to disk.
-
-    """
-    @property
-    def area(self):
-        r"""float: Area of the region."""
-        pass
-
-class Parallelepiped(Volume):
-    r"""Parallelepiped box defined by three vectors.
-
-    The three vectors :math:`\mathbf{a}`, :math:`\mathbf{b}`, and :math:`\mathbf{c}`
-    must form a right-hand basis so that the box volume :math:`V` is positive:
-
-    .. math::
-
-        V = (\mathbf{a} \times \mathbf{b}) \cdot \mathbf{c} > 0
-
-    Parameters
-    ----------
-    a : array_like
-        First vector defining the parallelepiped.
-    b : array_like
-        Second vector defining the parallelepiped.
-    c : array_like
-        Third vector defining the parallelepiped.
-
-    Raises
-    ------
-    TypeError
-        If ``a``, ``b``, and ``c`` are not all 3-element vectors.
-    ValueError
-        If the volume is not positive.
-
-    """
-    def __init__(self, a, b, c):
-        self.a = numpy.asarray(a,dtype=numpy.float64)
-        self.b = numpy.asarray(b,dtype=numpy.float64)
-        self.c = numpy.asarray(c,dtype=numpy.float64)
-        if not (self.a.shape==(3,) and self.b.shape==(3,) and self.c.shape==(3,)):
-            raise TypeError('a, b, and c must be 3-element vectors.')
-        if self.extent <= 0:
-            raise ValueError('The volume must be positive.')
-
-    @property
-    def extent(self):
-        return numpy.dot(numpy.cross(self.a,self.b),self.c)
-
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the three box vectors ``a``, ``b``, and ``c`` as tuples.
-
-        Returns
-        -------
-        dict
-            The serialized Parallelepiped.
-
-        """
-        return {'a': tuple(self.a),
-                'b': tuple(self.b),
-                'c': tuple(self.c)
-               }
-
-    @classmethod
-    def from_json(cls, data):
-        r"""Deserialize from a dictionary.
-
-        Parameters
-        ----------
-        data : dict
-            The serialized equivalent of the Parallelepiped object. The keys
-            of ``data`` should be ``('a','b','c')``, and the data for each
-            is the 3-element box vector.
-
-        Returns
-        -------
-        :class:`Parallelepiped`
-            A new Parallelepiped object constructed from the data.
-
-        """
-        return Parallelepiped(**data)
-
-class TriclinicBox(Parallelepiped):
+class TriclinicBox(Volume):
     r"""Triclinic box.
 
-    A TriclinicBox is a special type of :class:`Parallelepiped`. The box is
-    defined by an orthorhombic box oriented along the Cartesian axes and having
-    three vectors of length :math:`L_x`, :math:`L_y`, and :math:`L_z`, respectively.
-    The box is then tilted by factors :math:`xy`, :math:`xz`, and :math:`yz`, which
+    A TriclinicBox is defined by three edge vectors **a**, **b**, and **c** that form
+    a right-hand basis. These vectors are defined by deformation of an orthorhombic
+    box oriented along the Cartesian axes and having three vectors of length
+    :math:`L_x`, :math:`L_y`, and :math:`L_z`, respectively. The box is then
+    tilted by factors :math:`xy`, :math:`xz`, and :math:`yz`, which
     are upper off-diagonal elements of the matrix of box vectors. As a result,
-    the :math:`\mathbf{a}` vector is always aligned along the :math:`x` axis, while
+    the **a** vector is always aligned along the :math:`x` axis, while
     the other two vectors may be tilted.
 
     The tilt factors can be defined using one of two :class:`TriclinicBox.Convention`\s.
     By default, the LAMMPS convention is applied to calculate the basis vectors.
+
+    The box is centered at the origin :math:`(0,0,0)`.
 
     Parameters
     ----------
@@ -252,6 +157,8 @@ class TriclinicBox(Parallelepiped):
         Second tilt factor.
     yz : float
         Third tilt factor.
+    convention : :class:`TriclinicBox.Convention`
+        Convention for defining the tilt factors.
 
     Raises
     ------
@@ -298,55 +205,29 @@ class TriclinicBox(Parallelepiped):
         HOOMD = 2
 
     def __init__(self, Lx, Ly, Lz, xy, xz, yz, convention=Convention.LAMMPS):
-        if Lx<=0 or Ly<=0 or Lz<= 0:
+        if Lx <= 0 or Ly <= 0 or Lz <= 0:
             raise ValueError('All side lengths must be positive.')
-        self._convention = convention
-        if self.convention is TriclinicBox.Convention.LAMMPS:
+
+        if convention is TriclinicBox.Convention.LAMMPS:
             a = (Lx,0,0)
             b = (xy,Ly,0)
             c = (xz,yz,Lz)
-        elif self.convention is TriclinicBox.Convention.HOOMD:
+        elif convention is TriclinicBox.Convention.HOOMD:
             a = (Lx,0,0)
             b = (xy*Ly,Ly,0)
             c = (xz*Lz,yz*Lz,Lz)
         else:
-            raise ValueError('Triclinic convention must be TriclinicBox.Convention.LAMMPS or TriclinicBox.Convention.HOOMD')
-        super().__init__(a,b,c)
+            raise ValueError('Triclinic convention must be LAMMPS or HOOMD')
 
-    @property
-    def convention(self):
-        r""":class:`TriclinicBox.Convention`: Convention for tilt factors."""
-        return self._convention
+        self.a = numpy.array(a, dtype=numpy.float64)
+        self.b = numpy.array(b, dtype=numpy.float64)
+        self.c = numpy.array(c, dtype=numpy.float64)
 
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the three box lengths ``Lx``, ``Ly``, and ``Lz``,
-        the three tilt factors ``xy``, ``xz``, and ``yz``, and the ``convention``
-        for the tilt factors.
-
-        Returns
-        -------
-        dict
-            The serialized TriclinicBox.
-
-        """
-        if self._convention is TriclinicBox.Convention.LAMMPS:
-            xy = self.b[0]
-            xz = self.c[0]
-            yz = self.c[1]
-        elif self._convention is TriclinicBox.Convention.HOOMD:
-            xy = self.b[0]/self.b[1]
-            xz = self.c[0]/self.c[2]
-            yz = self.c[1]/self.c[2]
-        return {'Lx': self.a[0],
-                'Ly': self.b[1],
-                'Lz': self.c[2],
-                'xy': xy,
-                'xz': xz,
-                'yz': yz,
-                'convention': self._convention.name
-               }
+        box_vec = self.a + self.b + self.c
+        self._low = -0.5*box_vec
+        self._high = 0.5*box_vec
+        self._extent = numpy.dot(numpy.cross(self.a, self.b), self.c)
+        self._convention = convention
 
     @classmethod
     def from_json(cls, data):
@@ -380,6 +261,183 @@ class TriclinicBox(Parallelepiped):
             return ValueError('Only LAMMPS and HOOMD conventions are supported.')
         return TriclinicBox(**data_)
 
+    @property
+    def convention(self):
+        r""":class:`TriclinicBox.Convention`: Convention for tilt factors."""
+        return self._convention
+
+    @property
+    def extent(self):
+        return self._extent
+
+    @property
+    def low(self):
+        return self._low
+
+    @property
+    def high(self):
+        return self._high
+
+    def as_array(self, convention=None):
+        """Convert to array of lengths and tilt factors.
+
+        Parameters
+        ----------
+        convention : :class:`TriclinicBox.Convention`
+            Convention to use for the tilt factors. Default of ``None``
+            will use the convention for the box.
+
+        Returns
+        -------
+        numpy.ndarray
+            An array containing ``(Lx,Ly,Lz,xy,xz,yz)`` according to the
+            ``convention``.
+
+        """
+        if convention is None:
+            convention = self._convention
+
+        Lx = self.a[0]
+        Ly = self.b[1]
+        Lz = self.c[2]
+        if convention is TriclinicBox.Convention.LAMMPS:
+            xy = self.b[0]
+            xz = self.c[0]
+            yz = self.c[1]
+        elif convention is TriclinicBox.Convention.HOOMD:
+            xy = self.b[0]/self.b[1]
+            xz = self.c[0]/self.c[2]
+            yz = self.c[1]/self.c[2]
+        else:
+            raise TypeError('Convention must be LAMMPS or HOOMD')
+
+        return numpy.array([Lx,Ly,Lz,xy,xz,yz])
+
+    def coordinate_to_fraction(self, r):
+        r"""Make fractional coordinates from Cartesian coordinates.
+
+        The Cartesian coordinates **r** are projected onto the three
+        (potentially nonorthogonal) basis vectors defining the box to yield
+        fractional coordinates **x** such that:
+
+        .. math::
+
+            \mathbf{r} = \mathbf{r}_{\rm low} + (\mathbf{a}\quad\mathbf{b}\quad\mathbf{c}) \cdot \mathbf{x}
+
+        where :math:`\mathbf{r}_{\rm low}` is the lower bound of the box, i.e., :attr:`low`.
+
+        Parameters
+        ----------
+        r : array_like
+            Cartesian coordinates (or array of).
+
+        Returns
+        -------
+        numpy.ndarray
+            Fractional coordinates **x** corresponding to **r**.
+
+        """
+        Lx,Ly,Lz,xy,xz,yz = self.as_array(TriclinicBox.Convention.LAMMPS)
+
+        # get difference from lower bound
+        dx = -self.low + r
+        is_1d = False
+        if len(dx.shape) == 1:
+            dx = dx[numpy.newaxis,...]
+            is_1d = True
+
+        # make fractional coordinate
+        x = numpy.zeros_like(dx)
+        x[:,0] = (1.0/Lx)*dx[...,0] + (-xy/(Lx*Ly))*dx[...,1] + ((yz*xy-Ly*xz)/(Lx*Ly*Lz))*dx[...,2]
+        x[:,1] = (1.0/Ly)*dx[...,1] + (-yz/(Ly*Lz))*dx[...,2]
+        x[:,2] = (1.0/Lz)*dx[...,2]
+        if is_1d:
+            x = x[0]
+
+        return x
+
+    def fraction_to_coordinate(self, x):
+        r"""Make Cartesian coordinates from fractional coordinates.
+
+        The fractional coordinates **x** are converted to Cartesian coordinates **r**
+        using the basis vectors of the box. See :meth:`coordinate_to_fraction`
+        for the definition of these coordinates.
+
+        Parameters
+        ----------
+        r : array_like
+            Fractional coordinates (or array of).
+
+        Returns
+        -------
+        numpy.ndarray
+            Cartesian coordinates **r** corresponding to **x**.
+
+        """
+        Lx,Ly,Lz,xy,xz,yz = self.as_array(TriclinicBox.Convention.LAMMPS)
+
+        # make real coordinate
+        r = numpy.array(x)
+        is_1d = False
+        if len(r.shape) == 1:
+            r = r[numpy.newaxis,...]
+            is_1d = True
+        r[:,0] = Lx*r[...,0] + xy*r[...,1] + xz*r[...,2]
+        r[:,1] = Ly*r[...,1] + yz*r[...,2]
+        r[:,2] = Lz*r[...,2]
+        r += self.low
+        if is_1d:
+            r = r[0]
+
+        return r
+
+    def to_json(self):
+        r"""Serialize as a dictionary.
+
+        The dictionary contains the three box lengths ``Lx``, ``Ly``, and ``Lz``,
+        the three tilt factors ``xy``, ``xz``, and ``yz``, and the ``convention``
+        for the tilt factors.
+
+        Returns
+        -------
+        dict
+            The serialized TriclinicBox.
+
+        """
+        Lx,Ly,Lz,xy,xz,yz = self.as_array()
+        return {'Lx': Lx,
+                'Ly': Ly,
+                'Lz': Lz,
+                'xy': xy,
+                'xz': xz,
+                'yz': yz,
+                'convention': self._convention.name
+               }
+
+    def wrap(self, positions):
+        """Wrap positions subject to periodic boundary conditions.
+
+        Three-dimensional periodic boundary conditions are applied to ensure
+        the ``positions`` lie within the box. This is achieved by converting
+        to fractional coordinates, bounding the fractional coordinates within
+        :math:`[0,1)`, then converting back to Cartesian coordinates.
+
+        Parameters
+        ----------
+        positions : array_like
+            Position vector(s).
+
+        Returns
+        -------
+        numpy.ndarray
+            Wrapped position(s).
+
+        """
+        x = self.coordinate_to_fraction(positions)
+        x -= numpy.round(x-0.5)
+        r = self.fraction_to_coordinate(x)
+        return r
+
 class Cuboid(TriclinicBox):
     r"""Orthorhombic box.
 
@@ -401,22 +459,6 @@ class Cuboid(TriclinicBox):
     def __init__(self, Lx, Ly, Lz):
         super().__init__(Lx,Ly,Lz,0,0,0)
 
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the three box lengths ``Lx``, ``Ly``, and ``Lz``.
-
-        Returns
-        -------
-        dict
-            The serialized Cuboid.
-
-        """
-        return {'Lx': self.a[0],
-                'Ly': self.b[1],
-                'Lz': self.c[2],
-               }
-
     @classmethod
     def from_json(cls, data):
         r"""Deserialize from a dictionary.
@@ -436,6 +478,22 @@ class Cuboid(TriclinicBox):
         """
         return Cuboid(**data)
 
+    def to_json(self):
+        r"""Serialize as a dictionary.
+
+        The dictionary contains the three box lengths ``Lx``, ``Ly``, and ``Lz``.
+
+        Returns
+        -------
+        dict
+            The serialized Cuboid.
+
+        """
+        return {'Lx': self.a[0],
+                'Ly': self.b[1],
+                'Lz': self.c[2],
+               }
+
 class Cube(Cuboid):
     r"""Cubic box.
 
@@ -450,19 +508,6 @@ class Cube(Cuboid):
     """
     def __init__(self, L):
         super().__init__(L,L,L)
-
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the box length ``L``.
-
-        Returns
-        -------
-        dict
-            The serialized Cube.
-
-        """
-        return {'L': self.a[0]}
 
     @classmethod
     def from_json(cls, data):
@@ -482,86 +527,40 @@ class Cube(Cuboid):
         """
         return Cube(**data)
 
-class Parallelogram(Area):
-    r"""Parallelogram box defined by two vectors.
-
-    The two vectors :math:`\mathbf{a}` and :math:`\mathbf{b}`
-    must form a right-hand basis so that the box volume :math:`A` is positive:
-
-    .. math::
-
-        A = |(\mathbf{a} \times \mathbf{b})| > 0
-
-    Parameters
-    ----------
-    a : array_like
-        First vector defining the parallelogram.
-    b : array_like
-        Second vector defining the parallelogram.
-
-    Raises
-    ------
-    TypeError
-        If ``a`` and ``b`` are not both 2-element vectors.
-    ValueError
-        If the area is not positive.
-
-    """
-    def __init__(self, a, b):
-        self.a = numpy.asarray(a,dtype=numpy.float64)
-        self.b = numpy.asarray(b,dtype=numpy.float64)
-        if not (self.a.shape==(2,) and self.b.shape==(2,)):
-            raise TypeError('a and b must be 2-element vectors.')
-        if self.extent <= 0:
-            raise ValueError('The area must be positive.')
-
-    @property
-    def extent(self):
-        return numpy.linalg.norm(numpy.cross(self.a,self.b))
-
     def to_json(self):
         r"""Serialize as a dictionary.
 
-        The dictionary contains the two box vectors ``a`` and ``b`` as tuples.
+        The dictionary contains the box length ``L``.
 
         Returns
         -------
         dict
-            The serialized Parallelogram.
+            The serialized Cube.
 
         """
-        return {'a': tuple(self.a),
-                'b': tuple(self.b)
-               }
+        return {'L': self.a[0]}
 
-    @classmethod
-    def from_json(cls, data):
-        r"""Deserialize from a dictionary.
+class Area(Extent):
+    r"""Two-dimensional region of space.
 
-        Parameters
-        ----------
-        data : dict
-            The serialized equivalent of the Parallelogram object. The keys
-            of ``data`` should be ``('a','b')``, and the data for each
-            is the 2-element box vector.
+    An Area can be any 2d region of space; typically, it is a simulation "box."
+    Any deriving class must implement the volume method that computes the scalar
+    area of the region. Additionally, methods to serialize and deserialize a
+    Area must be specified so that the object can be saved to disk.
 
-        Returns
-        -------
-        :class:`Parallelogram`
-            A new Parallelogram object constructed from the data.
+    """
+    pass
 
-        """
-        return Parallelogram(**data)
 
-class ObliqueArea(Parallelogram):
+class ObliqueArea(Area):
     r"""Oblique area.
 
-    A ObliqueArea is a special type of :class:`Parallelogram`. The box is
-    defined by an area oriented along the Cartesian axes and having
-    two vectors of length :math:`L_x` and :math:`L_y`, respectively.
-    The box is then tilted by factor :math:`xy`, which
-    is upper off-diagonal elements of the matrix of box vectors. As a result,
-    the :math:`\mathbf{a}` vector is always aligned along the :math:`x` axis, while
+    An ObliqueArea is defined by two edge vectors **a** and **b** that form
+    a right-hand basis. These vectors are defined by deformation of a rectangle
+    oriented along the Cartesian axes and having two edge lengths :math:`L_x`
+    and :math:`L_y`, respectively. The box is then tilted by a factor :math:`xy`,
+    which is the upper off-diagonal element of the matrix of box vectors. As a result,
+    the **a** vector is always aligned along the :math:`x` axis, while
     the other vector may be tilted.
 
     The tilt factors can be defined using one of two :class:`ObliqueArea.Convention`\s.
@@ -575,7 +574,8 @@ class ObliqueArea(Parallelogram):
         Length along the :math:`y` axis.
     xy : float
         Tilt factor.
-
+    convention : :class:`ObliqueArea.Convention`
+        Convention for the tilt factor.
 
     Raises
     ------
@@ -586,7 +586,7 @@ class ObliqueArea(Parallelogram):
         ``ObliqueArea.Convention.HOOMD``.
 
     """
-    
+
     class Convention(Enum):
         r"""Convention by which the tilt factors are applied to the basis vectors.
 
@@ -620,46 +620,26 @@ class ObliqueArea(Parallelogram):
         HOOMD = 2
 
     def __init__(self, Lx, Ly, xy, convention=Convention.LAMMPS):
-        if Lx<=0 or Ly<=0:
+        if Lx <= 0 or Ly <= 0:
             raise ValueError('All side lengths must be positive.')
-        self._convention = convention
-        if self.convention is ObliqueArea.Convention.LAMMPS:
+        if convention is ObliqueArea.Convention.LAMMPS:
             a = (Lx,0)
             b = (xy,Ly)
-        elif self.convention is ObliqueArea.Convention.HOOMD:
+        elif convention is ObliqueArea.Convention.HOOMD:
             a = (Lx,0)
             b = (xy*Ly,Ly)
         else:
             raise ValueError('Triclinic convention must be ObliqueArea.Convention.LAMMPS or ObliqueArea.Convention.HOOMD')
-        super().__init__(a,b)
+        self._convention = convention
 
-    @property
-    def convention(self):
-        r""":class:`ObliqueArea.Convention`: Convention for tilt factors."""
-        return self._convention
+        self.a = numpy.asarray(a, dtype=numpy.float64)
+        self.b = numpy.asarray(b, dtype=numpy.float64)
 
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the two box lengths ``Lx`` and ``Ly``,
-        the tilt factor ``xy``, and the ``convention``
-        for the tilt factors.
-
-        Returns
-        -------
-        dict
-            The serialized ObliqueArea.
-
-        """
-        if self._convention is ObliqueArea.Convention.LAMMPS:
-            xy = self.b[0]
-        elif self._convention is ObliqueArea.Convention.HOOMD:
-            xy = self.b[0]/self.b[1]
-        return {'Lx': self.a[0],
-                'Ly': self.b[1],
-                'xy': xy,
-                'convention': self._convention.name
-               }
+        box_vec = self.a + self.b
+        self._low = -0.5*box_vec
+        self._high = 0.5*box_vec
+        self._extent = numpy.linalg.norm(numpy.cross(self.a,self.b))
+        self._convention = convention
 
     @classmethod
     def from_json(cls, data):
@@ -693,6 +673,172 @@ class ObliqueArea(Parallelogram):
             return ValueError('Only LAMMPS and HOOMD conventions are supported.')
         return ObliqueArea(**data_)
 
+    @property
+    def convention(self):
+        r""":class:`ObliqueArea.Convention`: Convention for tilt factors."""
+        return self._convention
+
+    @property
+    def extent(self):
+        return self._extent
+
+    @property
+    def low(self):
+        return self._low
+
+    @property
+    def high(self):
+        return self._high
+
+    def as_array(self, convention=None):
+        """Convert to array of lengths and tilt factor.
+
+        Parameters
+        ----------
+        convention : :class:`ObliqueArea.Convention`
+            Convention to use for the tilt factor. Default of ``None``
+            will use the convention for the box.
+
+        Returns
+        -------
+        numpy.ndarray
+            An array containing ``(Lx,Ly,xy)`` according to the
+            ``convention``.
+
+        """
+        if convention is None:
+            convention = self._convention
+
+        Lx = self.a[0]
+        Ly = self.b[1]
+        if convention is ObliqueArea.Convention.LAMMPS:
+            xy = self.b[0]
+        elif convention is ObliqueArea.Convention.HOOMD:
+            xy = self.b[0]/self.b[1]
+        else:
+            raise TypeError('Convention must be HOOMD or LAMMPS')
+        return numpy.array([Lx,Ly,xy])
+
+    def coordinate_to_fraction(self, r):
+        r"""Make fractional coordinates from Cartesian coordinates.
+
+        The Cartesian coordinates **r** are projected onto the two
+        (potentially nonorthogonal) basis vectors defining the box to yield
+        fractional coordinates **x** such that:
+
+        .. math::
+
+            \mathbf{r} = \mathbf{r}_{\rm low} + (\mathbf{a}\quad\mathbf{b}) \cdot \mathbf{x}
+
+        where :math:`\mathbf{r}_{\rm low}` is the lower bound of the box, i.e., :attr:`low`.
+
+        Parameters
+        ----------
+        r : array_like
+            Cartesian coordinates (or array of).
+
+        Returns
+        -------
+        numpy.ndarray
+            Fractional coordinates **x** corresponding to **r**.
+
+        """
+        Lx,Ly,xy = self.as_array(ObliqueArea.Convention.LAMMPS)
+
+        # get difference from lower bound
+        dx = -self.low + r
+        is_1d = False
+        if len(dx.shape) == 1:
+            dx = dx[numpy.newaxis,...]
+            is_1d = True
+
+        # make fractional coordinate
+        x = numpy.zeros_like(dx)
+        x[:,0] = (1.0/Lx)*dx[...,0] + (-xy/(Lx*Ly))*dx[...,1]
+        x[:,1] = (1.0/Ly)*dx[...,1]
+        if is_1d:
+            x = x[0]
+
+        return x
+
+    def fraction_to_coordinate(self, x):
+        r"""Make Cartesian coordinates from fractional coordinates.
+
+        The fractional coordinates **x** are converted to Cartesian coordinates **r**
+        using the basis vectors of the box. See :meth:`coordinate_to_fraction`
+        for the definition of these coordinates.
+
+        Parameters
+        ----------
+        r : array_like
+            Fractional coordinates (or array of).
+
+        Returns
+        -------
+        numpy.ndarray
+            Cartesian coordinates **r** corresponding to **x**.
+
+        """
+        Lx,Ly,xy = self.as_array(ObliqueArea.Convention.LAMMPS)
+
+        # make real coordinate
+        r = numpy.array(x)
+        is_1d = False
+        if len(r.shape) == 1:
+            r = r[numpy.newaxis,...]
+            is_1d = True
+        r[:,0] = Lx*r[...,0] + xy*r[...,1]
+        r[:,1] = Ly*r[...,1]
+        r += self.low
+        if is_1d:
+            r = r[0]
+
+        return r
+
+    def to_json(self):
+        r"""Serialize as a dictionary.
+
+        The dictionary contains the two box lengths ``Lx`` and ``Ly``,
+        the tilt factor ``xy``, and the ``convention``
+        for the tilt factors.
+
+        Returns
+        -------
+        dict
+            The serialized ObliqueArea.
+
+        """
+        Lx,Ly,xy = self.as_array()
+        return {'Lx': Lx,
+                'Ly': Ly,
+                'xy': xy,
+                'convention': self._convention.name
+               }
+
+    def wrap(self, positions):
+        """Wrap positions subject to periodic boundary conditions.
+
+        Two-dimensional periodic boundary conditions are applied to ensure
+        the ``positions`` lie within the box. This is achieved by converting
+        to fractional coordinates, bounding the fractional coordinates within
+        :math:`[0,1)`, then converting back to Cartesian coordinates.
+
+        Parameters
+        ----------
+        positions : array_like
+            Position vector(s).
+
+        Returns
+        -------
+        numpy.ndarray
+            Wrapped position(s).
+
+        """
+        x = self.coordinate_to_fraction(positions)
+        x -= numpy.round(x-0.5)
+        r = self.fraction_to_coordinate(x)
+        return r
+
 class Rectangle(ObliqueArea):
     r"""Rectangle box.
 
@@ -711,21 +857,6 @@ class Rectangle(ObliqueArea):
     """
     def __init__(self, Lx, Ly):
         super().__init__(Lx,Ly,0)
-
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the two box lengths ``Lx`` and ``Ly``.
-
-        Returns
-        -------
-        dict
-            The serialized Rectangle.
-
-        """
-        return {'Lx': self.a[0],
-                'Ly': self.b[1],
-               }
 
     @classmethod
     def from_json(cls, data):
@@ -746,6 +877,21 @@ class Rectangle(ObliqueArea):
         """
         return Rectangle(**data)
 
+    def to_json(self):
+        r"""Serialize as a dictionary.
+
+        The dictionary contains the two box lengths ``Lx`` and ``Ly``.
+
+        Returns
+        -------
+        dict
+            The serialized Rectangle.
+
+        """
+        return {'Lx': self.a[0],
+                'Ly': self.b[1],
+               }
+
 class Square(Rectangle):
     r"""Square box.
 
@@ -760,19 +906,6 @@ class Square(Rectangle):
     """
     def __init__(self, L):
         super().__init__(L,L)
-
-    def to_json(self):
-        r"""Serialize as a dictionary.
-
-        The dictionary contains the box length ``L``.
-
-        Returns
-        -------
-        dict
-            The serialized Square.
-
-        """
-        return {'L': self.a[0]}
 
     @classmethod
     def from_json(cls, data):
@@ -791,3 +924,16 @@ class Square(Rectangle):
 
         """
         return Square(**data)
+
+    def to_json(self):
+        r"""Serialize as a dictionary.
+
+        The dictionary contains the box length ``L``.
+
+        Returns
+        -------
+        dict
+            The serialized Square.
+
+        """
+        return {'L': self.a[0]}

--- a/relentless/extent.py
+++ b/relentless/extent.py
@@ -434,7 +434,7 @@ class TriclinicBox(Volume):
 
         """
         x = self.coordinate_to_fraction(positions)
-        x -= numpy.round(x-0.5)
+        x -= numpy.floor(x)
         r = self.fraction_to_coordinate(x)
         return r
 

--- a/relentless/simulate/dilute.py
+++ b/relentless/simulate/dilute.py
@@ -42,10 +42,13 @@ class InitializeRandomly(simulate.SimulationOperation):
         Temperature.
     masses : dict
         Masses of each particle type. These are not actually used by this
-        operation, so default of ``None`` is the same as specifying something.
+        operation, so None is the same as specifying something.
+    diameters : dict
+        Diameter of each particle type. These are not actually used by this
+        operation, so None is the same as specifying something.
 
     """
-    def __init__(self, seed, N, V, T, masses=None):
+    def __init__(self, seed, N, V, T, masses, diameters):
         self.N = N
         self.V = V
         self.T = T

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -90,9 +90,19 @@ class InitializeFromFile(Initialize):
 class InitializeRandomly(Initialize):
     """Initialize a randomly generated simulation box.
 
-    Particles are randomly placed in the box according to the specification.
-    No checks are performed for overlaps, so this can produce very poor starting
-    states for denser systems.
+    If ``diameters`` is ``None``, the particles are randomly placed in the box.
+    This can work pretty well for low densities, particularly if
+    :class:`MinimizeEnergy` is used to remove overlaps before starting to run a
+    simulation. However, it will typically fail for higher densities, where
+    there are many overlaps that are hard to resolve.
+
+    If ``diameters`` is specified for each particle type, the particles will
+    be randomly packed into sites of a close-packed lattice. The insertion
+    order is from big to small. No particles are allowed to overlap based on
+    the diameters, which typically means the initially state will be more
+    favorable than using random initialization. However, the packing procedure
+    can fail if there is not enough room in the box to fit particles using
+    lattice sites.
 
     Parameters
     ----------
@@ -100,101 +110,84 @@ class InitializeRandomly(Initialize):
         The seed to randomly initialize the particle locations.
     N : dict
         Number of particles of each type.
-    V : :class:`~relentless.extent.TriclinicBox` or :class:`~relentless.extent.ObliqueArea`
+    V : :class:`~relentless.extent.Extent`
         Simulation extent.
     T : float
-        Temperature.
+        Temperature. Defaults to None, which means system is not thermalized.
     masses : dict
-        Mass of each particle type.
+        Masses of each particle type. Defaults to None, which means particles
+        have unit mass.
+    diameters : dict
+        Diameter of each particle type. Defaults to None, which means particles
+        are randomly inserted without checking their sizes.
 
     """
-    def __init__(self, seed, N, V, T=None, masses=None):
+    def __init__(self, seed, N, V, T=None, masses=None, diameters=None):
         super().__init__()
         self.seed = seed
         self.N = N
         self.V = V
         self.T = T
         self.masses = masses
+        self.diameters = diameters
 
     def initialize(self, sim):
-        if not isinstance(self.V, (extent.TriclinicBox, extent.ObliqueArea)):
-            raise TypeError('HOOMD boxes must be derived from TriclinicBox or ObliqueArea')
+        with sim.hoomd:
+            # make the box and snapshot
+            if isinstance(self.V, extent.TriclinicBox):
+                box_array = self.V.as_array(extent.TriclinicBox.Convention.HOOMD)
+                box = hoomd.data.boxdim(*box_array, dimensions=3)
+            elif isinstance(self.V, extent.ObliqueArea):
+                Lx,Ly,xy = self.V.as_array(extent.ObliqueArea.Convention.HOOMD)
+                box = hoomd.data.boxdim(Lx=Lx, Ly=Ly, Lz=1, xy=xy, xz=0, yz=0, dimensions=2)
+            else:
+                raise ValueError('HOOMD supports 2d and 3d simulations')
 
-        # if setting seed, preserve the current RNG state
-        if self.seed is not None:
-            old_state = numpy.random.get_state()
-            numpy.random.seed(self.seed)
-        else:
-            old_state = None
+            types = tuple(self.N.keys())
+            typeids = {i: typeid for typeid,i in enumerate(types)}
+            snap = hoomd.data.make_snapshot(N=sum(self.N.values()),
+                                            box=box,
+                                            particle_types=list(types))
 
-        try:
-            # randomly place the particles
-            with sim.hoomd:
-                # make the box and snapshot
-                if isinstance(self.V, extent.TriclinicBox):
-                    box_ = hoomd.data.boxdim(Lx=self.V.a[0],
-                                             Ly=self.V.b[1],
-                                             Lz=self.V.c[2],
-                                             xy=self.V.b[0]/self.V.b[1],
-                                             xz=self.V.c[0]/self.V.c[2],
-                                             yz=self.V.c[1]/self.V.c[2],
-                                             dimensions=3)
-                    box = freud.Box.from_box([box_.Lx, box_.Ly, box_.Lz, box_.xy, box_.xz, box_.yz], dimensions=3)
-                elif isinstance(self.V, extent.ObliqueArea):
-                    box_ = hoomd.data.boxdim(Lx=self.V.a[0],
-                                             Ly=self.V.b[1],
-                                             Lz=1,
-                                             xy=self.V.b[0]/self.V.b[1],
-                                             xz=0,
-                                             yz=0,
-                                             dimensions=2)
-                    box = freud.Box.from_box([box_.Lx, box_.Ly, 0, box_.xy, 0, 0], dimensions=2)
+            # randomly place particles in fractional coordinates
+            if mpi.world.rank == 0:
+                # generate the positions and types
+                if self.diameters is not None:
+                    positions, all_types = simulate.InitializeRandomly._pack_particles(self.seed, self.N, self.V)
                 else:
-                    raise ValueError('HOOMD supports 2d and 3d simulations')
+                    positions, all_types = simulate.InitializeRandomly._random_particles(self.seed, self.N, self.V)
 
-                types = tuple(self.N.keys())
-                snap = hoomd.data.make_snapshot(N=sum(self.N.values()),
-                                                box=box_,
-                                                particle_types=list(types))
+                # set the positions
+                snap.particles.position[:,:box.dimensions] = positions
 
-                # randomly place particles in fractional coordinates
-                if mpi.world.rank == 0:
-                    # draw positions
-                    rs = numpy.zeros((snap.particles.N, 3))
-                    rs[:,:box.dimensions] = numpy.random.uniform(size=(snap.particles.N, box.dimensions))
-                    snap.particles.position[:] = box.make_absolute(rs)
+                # set the typeids
+                snap.particles.typeid[:] = [typeids[i] for i in all_types]
 
-                    # set types of each
-                    snap.particles.typeid[:] = numpy.repeat(numpy.arange(len(types)), tuple(self.N.values()))
+                # set masses, defaulting to unit mass
+                if self.masses is not None:
+                    snap.particles.mass[:] = [self.masses[i] for i in all_types]
+                else:
+                    snap.particles.mass[:] = 1.0
 
-                    # set masses, defaulting to unit mass
-                    if self.masses is not None:
-                        snap.particles.mass[:] = numpy.repeat([self.masses[t] for t in types], tuple(self.N.values()))
-                    else:
-                        snap.particles.mass[:] = 1.0
+                # set velocities, defaulting to zeros
+                vel = numpy.zeros((snap.particles.N, 3))
+                if self.T is not None:
+                    rng = numpy.random.default_rng(self.seed+1)
+                    # Maxwell-Boltzmann = normal with variance kT/m per component
+                    v_mb = rng.normal(scale=numpy.sqrt(sim.potentials.kB*self.T),
+                                      size=(snap.particles.N,box.dimensions))
+                    v_mb /= numpy.sqrt(snap.particles.mass[:,None])
 
-                    # set velocities, defaulting to zeros
-                    vel = numpy.zeros((snap.particles.N, 3))
-                    if self.T is not None:
-                        # Maxwell-Boltzmann = normal with variance kT/m per component
-                        v_mb = numpy.random.normal(scale=numpy.sqrt(sim.potentials.kB*self.T),
-                                                    size=(snap.particles.N,box.dimensions))
-                        v_mb /= numpy.sqrt(snap.particles.mass[:,None])
+                    # zero the linear momentum
+                    p_mb = numpy.sum(snap.particles.mass[:,None]*v_mb, axis=0)
+                    v_cm = p_mb/numpy.sum(snap.particles.mass)
+                    v_mb -= v_cm
 
-                        # zero the linear momentum
-                        p_mb = numpy.sum(snap.particles.mass[:,None]*v_mb, axis=0)
-                        v_cm = p_mb/numpy.sum(snap.particles.mass)
-                        v_mb -= v_cm
+                    vel[:,:box.dimensions] = v_mb
+                snap.particles.velocity[:] = vel
 
-                        vel[:,:box.dimensions] = v_mb
-                    snap.particles.velocity[:] = vel
-
-                # read snapshot
-                return hoomd.init.read_snapshot(snap)
-        finally:
-            # always restore old state if it exists
-            if old_state is not None:
-                numpy.random.set_state(old_state)
+            # read snapshot
+            return hoomd.init.read_snapshot(snap)
 
 ## integrators
 class MinimizeEnergy(simulate.SimulationOperation):

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -113,16 +113,16 @@ class InitializeRandomly(Initialize):
     V : :class:`~relentless.extent.Extent`
         Simulation extent.
     T : float
-        Temperature. Defaults to None, which means system is not thermalized.
+        Temperature. None means system is not thermalized.
     masses : dict
-        Masses of each particle type. Defaults to None, which means particles
+        Masses of each particle type. None means particles
         have unit mass.
     diameters : dict
-        Diameter of each particle type. Defaults to None, which means particles
+        Diameter of each particle type. None means particles
         are randomly inserted without checking their sizes.
 
     """
-    def __init__(self, seed, N, V, T=None, masses=None, diameters=None):
+    def __init__(self, seed, N, V, T, masses, diameters):
         super().__init__()
         self.seed = seed
         self.N = N
@@ -153,7 +153,7 @@ class InitializeRandomly(Initialize):
             if mpi.world.rank == 0:
                 # generate the positions and types
                 if self.diameters is not None:
-                    positions, all_types = simulate.InitializeRandomly._pack_particles(self.seed, self.N, self.V)
+                    positions, all_types = simulate.InitializeRandomly._pack_particles(self.seed, self.N, self.V, self.diameters)
                 else:
                     positions, all_types = simulate.InitializeRandomly._random_particles(self.seed, self.N, self.V)
 
@@ -414,9 +414,9 @@ class AddVerletIntegrator(AddMDIntegrator):
     dt : float
         Time step.
     thermostat : :class:`~relentless.simulate.simulate.Thermostat`
-        Thermostat for temperature control (defaults to ``None``).
+        Thermostat for temperature control. None means no thermostat.
     barostat : :class:`~relentless.simulate.simulate.Barostat`
-        Barostat for pressure control (defaults to ``None``).
+        Barostat for pressure control. None means no barostat.
 
     Raises
     ------
@@ -424,7 +424,7 @@ class AddVerletIntegrator(AddMDIntegrator):
         If an appropriate combination of thermostat and barostat is not set.
 
     """
-    def __init__(self, dt, thermostat=None, barostat=None):
+    def __init__(self, dt, thermostat, barostat):
         super().__init__(dt)
         self.thermostat = thermostat
         self.barostat = barostat

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -19,9 +19,12 @@ To implement your own LAMMPS operation, create an operation that derives from
 
 """
 import abc
+import tempfile
 
+import lammpsio
 import numpy
 
+from relentless import data
 from relentless import ensemble
 from relentless import mpi
 from relentless import extent
@@ -144,8 +147,19 @@ class InitializeFromFile(Initialize):
 class InitializeRandomly(Initialize):
     """Initialize a randomly generated simulation box.
 
-    The initialization is done using LAMMPS's ``create_atoms`` method, which
-    may produce poor initial structures at high densities.
+    If ``diameters`` is ``None``, the particles are randomly placed in the box.
+    This can work pretty well for low densities, particularly if
+    :class:`MinimizeEnergy` is used to remove overlaps before starting to run a
+    simulation. However, it will typically fail for higher densities, where
+    there are many overlaps that are hard to resolve.
+
+    If ``diameters`` is specified for each particle type, the particles will
+    be randomly packed into sites of a close-packed lattice. The insertion
+    order is from big to small. No particles are allowed to overlap based on
+    the diameters, which typically means the initially state will be more
+    favorable than using random initialization. However, the packing procedure
+    can fail if there is not enough room in the box to fit particles using
+    lattice sites.
 
     Parameters
     ----------
@@ -153,65 +167,92 @@ class InitializeRandomly(Initialize):
         The seed to randomly initialize the particle locations.
     N : dict
         Number of particles of each type.
-    V : :class:`~relentless.extent.TriclinicBox` or :class:`~relentless.extent.ObliqueArea`
+    V : :class:`~relentless.extent.Extent`
         Simulation extent.
     T : float
-        Temperature.
+        Temperature. Defaults to None, which means system is not thermalized.
     masses : dict
-        Mass of each particle type.
+        Masses of each particle type. Defaults to None, which means particles
+        have unit mass.
+    diameters : dict
+        Diameter of each particle type. Defaults to None, which means particles
+        are randomly inserted without checking their sizes.
 
     """
-    def __init__(self, seed, N, V, T=None, masses=None):
+    def __init__(self, seed, N, V, T=None, masses=None, diameters=None):
         super().__init__({i: idx+1 for idx,i in enumerate(N.keys())})
         self.seed = seed
         self.N = N
         self.V = V
         self.T = T
         self.masses = masses
+        self.diameters = diameters
 
     def initialize(self, sim):
-        if not isinstance(self.V, (extent.TriclinicBox, extent.ObliqueArea)):
+        if not isinstance(self.V, (extent.TriclinicBox,extent.ObliqueArea)):
             raise TypeError('LAMMPS boxes must be derived from TriclinicBox or ObliqueArea')
+        elif ((sim.dimension == 3 and not isinstance(self.V, extent.TriclinicBox)) or
+            (sim.dimension == 2 and not isinstance(self.V, extent.ObliqueArea))):
+            raise TypeError('Mismatch between extent type and dimension')
 
         # make box
         if sim.dimension == 3:
-            Lx = self.V.a[0]
-            Ly = self.V.b[1]
-            Lz = self.V.c[2]
-            xy = self.V.b[0]
-            xz = self.V.c[0]
-            yz = self.V.c[1]
-            dL = self.V.a + self.V.b + self.V.c
+            Lx,Ly,Lz,xy,xz,yz = self.V.as_array(extent.TriclinicBox.Convention.LAMMPS)
+            lo = self.V.low
         elif sim.dimension == 2:
-            Lx = self.V.a[0]
-            Ly = self.V.b[1]
-            Lz = 0.2 # LAMMPS wants Lz to be a tiny number
-            xy = self.V.b[0]
+            Lx,Ly,xy = self.V.as_array(extent.ObliqueArea.Convention.LAMMPS)
+            Lz = 1.0
             xz = 0.0
             yz = 0.0
-            dL = numpy.array((self.V.a[0]+self.V.b[0],self.V.a[1]+self.V.b[1],Lz))
+            lo = numpy.array([self.V.low[0],self.V.low[1],-0.5*Lz])
         else:
             raise ValueError('LAMMPS only supports 2d and 3d simulations')
-        lo = -0.5*dL
         hi = lo + [Lx,Ly,Lz]
-        box_size = numpy.array([lo[0],hi[0],lo[1],hi[1],lo[2],hi[2],xy,xz,yz])
-        if not numpy.all(numpy.isclose(box_size[-3:],0)):
-            cmds = ['region box prism {} {} {} {} {} {} {} {} {}'.format(*box_size)]
+        tilt = numpy.array([xy,xz,yz])
+        if not numpy.all(numpy.isclose(tilt,0)):
+            box = lammpsio.Box(lo,hi,tilt)
         else:
-            cmds = ['region box block {} {} {} {} {} {}'.format(*box_size[:-3])]
-        types = tuple(self.N.keys())
-        cmds += ['create_box {N} box'.format(N=len(types))]
+            box = lammpsio.Box(lo,hi)
+        snap = lammpsio.Snapshot(N=sum(self.N.values()), box=box)
 
-        # use lammps random initialization routines
-        for i in types:
-            cmds += ['create_atoms {typeid} random {N} {seed} box'.format(typeid=self.lammps_types[i],
-                                                                          N=self.N[i],
-                                                                          seed=self.seed+self.lammps_types[i]-1),
-                     'mass {typeid} {mass}'.format(typeid=self.lammps_types[i],
-                                                   mass=self.masses[i] if self.masses is not None else 1.0)]
+        # generate the positions and types
+        if self.diameters is not None:
+            positions, all_types = simulate.InitializeRandomly._pack_particles(self.seed, self.N, self.V)
+        else:
+            positions, all_types = simulate.InitializeRandomly._random_particles(self.seed, self.N, self.V)
 
+        # set the positions
+        snap.position[:,:sim.dimension] = positions
+
+        # set the typeids
+        snap.typeid = [self.lammps_types[i] for i in all_types]
+
+        # set masses, defaulting to unit mass
+        if self.masses is not None:
+            snap.mass = [self.masses[i] for i in all_types]
+        else:
+            snap.mass[:] = 1.0
+
+        # set velocities, defaulting to zeros
         if self.T is not None:
-            cmds += ['velocity all create {temp} {seed}'.format(temp=self.T, seed=self.seed)]
+            rng = numpy.random.default_rng(self.seed+1)
+            # Maxwell-Boltzmann = normal with variance kT/m per component
+            vel = rng.normal(scale=numpy.sqrt(sim.potentials.kB*self.T),
+                             size=(snap.N,sim.dimension))
+            vel /= numpy.sqrt(snap.mass[:,None])
+
+            # zero the linear momentum
+            v_cm = numpy.sum(snap.mass[:,None]*vel, axis=0)/numpy.sum(snap.mass)
+            vel -= v_cm
+        else:
+            vel = numpy.zeros((snap.N, sim.dimension))
+        snap.velocity[:,:sim.dimension] = vel
+
+        init_file = sim.directory.file('init.data')
+        lammpsio.DataFile.create(init_file,
+                                 snap,
+                                 self.atom_style)
+        cmds = ['read_data {}'.format(init_file)]
 
         return cmds
 
@@ -701,6 +742,16 @@ class LAMMPS(simulate.Simulation):
         super().__init__(initializer, operations)
         self.dimension = dimension
         self.quiet = quiet
+
+    def run(self, potentials, directory):
+        # lammps always needs a directory, so use a temp one if we don't have it
+        if directory is None:
+            with tempfile.TemporaryDirectory() as directory_:
+                sim = super().run(potentials, directory_)
+        else:
+            sim = super().run(potentials, directory)
+
+        return sim
 
     def _new_instance(self, initializer, potentials, directory):
         sim = super()._new_instance(initializer, potentials, directory)

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -96,15 +96,14 @@ class Initialize(LAMMPSOperation):
     Parameters
     ----------
     lammps_types : dict
-        Mapping of type names (`str`) to LAMMPS type integers.
-    units : str
-        The LAMMPS style of units used in the simulation (defaults to ``lj``).
+        Mapping of type names (`str`) to LAMMPS type integers. None
+        means mapping is not specified.
 
     """
-    def __init__(self, lammps_types=None, units='lj', atom_style='atomic'):
+    def __init__(self, lammps_types):
         self.lammps_types = lammps_types
-        self.units = units
-        self.atom_style = atom_style
+        self.units = 'lj'
+        self.atom_style = 'atomic'
 
     def __call__(self, sim):
         super().__call__(sim)
@@ -136,7 +135,7 @@ class InitializeFromFile(Initialize):
 
     """
     def __init__(self, filename):
-        super().__init__()
+        super().__init__(None)
         self.filename = filename
 
     def initialize(self, sim):
@@ -170,16 +169,16 @@ class InitializeRandomly(Initialize):
     V : :class:`~relentless.extent.Extent`
         Simulation extent.
     T : float
-        Temperature. Defaults to None, which means system is not thermalized.
+        Temperature. None means system is not thermalized.
     masses : dict
-        Masses of each particle type. Defaults to None, which means particles
+        Masses of each particle type. None means particles
         have unit mass.
     diameters : dict
-        Diameter of each particle type. Defaults to None, which means particles
+        Diameter of each particle type. None means particles
         are randomly inserted without checking their sizes.
 
     """
-    def __init__(self, seed, N, V, T=None, masses=None, diameters=None):
+    def __init__(self, seed, N, V, T, masses, diameters):
         super().__init__({i: idx+1 for idx,i in enumerate(N.keys())})
         self.seed = seed
         self.N = N
@@ -217,7 +216,7 @@ class InitializeRandomly(Initialize):
 
         # generate the positions and types
         if self.diameters is not None:
-            positions, all_types = simulate.InitializeRandomly._pack_particles(self.seed, self.N, self.V)
+            positions, all_types = simulate.InitializeRandomly._pack_particles(self.seed, self.N, self.V, self.diameters)
         else:
             positions, all_types = simulate.InitializeRandomly._random_particles(self.seed, self.N, self.V)
 
@@ -426,9 +425,9 @@ class AddVerletIntegrator(AddMDIntegrator):
     dt : float
         Time step size for each simulation iteration.
     thermostat : :class:`~relentless.simulate.simulate.Thermostat`
-        Thermostat used for integration (defaults to ``None``).
+        Thermostat used for integration. None means no thermostat.
     barostat : :class:`~relentless.simulate.simulate.Barostat`
-        Barostat used for integration (defaults to ``None``).
+        Barostat used for integration. None means no barostat.
 
     Raises
     ------
@@ -436,7 +435,7 @@ class AddVerletIntegrator(AddMDIntegrator):
         If an appropriate combination of thermostat and barostat is not set.
 
     """
-    def __init__(self, dt, thermostat=None, barostat=None):
+    def __init__(self, dt, thermostat, barostat):
         super().__init__(dt)
         self.thermostat = thermostat
         self.barostat = barostat

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -13,6 +13,7 @@ import scipy.spatial
 
 from relentless import data
 from relentless import extent
+from relentless import variable
 
 class SimulationOperation(abc.ABC):
     """Operation to be performed by a :class:`Simulation`."""
@@ -756,7 +757,9 @@ class InitializeRandomly(GenericOperation):
         have unit mass.
     diameters : dict
         Diameter of each particle type. Defaults to None, which means particles
-        are randomly inserted without checking their sizes.
+        are randomly inserted without checking their sizes. The value of a
+        diameter can be a :class:`~variable.Variable`, which will be
+        evaluated at the time the operation is called.
 
     """
     def __init__(self, seed, N, V, T=None, masses=None, diameters=None):
@@ -803,6 +806,8 @@ class InitializeRandomly(GenericOperation):
         for i,Ni in sorted_N:
             # generate site coordinates, on orthorhombic lattices
             di = diameters[i]
+            if isinstance(di, variable.Variable):
+                di = di.value
             if dimension == 3:
                 # fcc lattice
                 a = numpy.sqrt(2.)*di

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -760,7 +760,7 @@ class InitializeRandomly(GenericOperation):
 
     """
     def __init__(self, seed, N, V, T=None, masses=None, diameters=None):
-        super().__init__(seed, N, V, T, masses)
+        super().__init__(seed, N, V, T, masses, diameters)
 
     @classmethod
     def _make_orthorhombic(cls, V):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+lammpsio>=0.2.0
 networkx>=2.5
 numpy
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,13 @@ classifiers =
     License :: OSI Approved :: BSD License
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     lammpsio>=0.2.0
     networkx>=2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
 packages = find:
 python_requires = >=3.7
 install_requires =
+    lammpsio>=0.2.0
     networkx>=2.4
     numpy
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     lammpsio>=0.2.0
-    networkx>=2.4
+    networkx>=2.5
     numpy
     packaging
     scipy

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -42,11 +42,11 @@ class test_HOOMD(unittest.TestCase):
         # setup potentials
         pot = LinPot(ens.types,params=('m',))
         for pair in pot.coeff:
-            pot.coeff[pair]['m'] = -2.0
+            pot.coeff[pair].update({'m': -2.0, 'rmax': 1.0})
         pots = relentless.simulate.Potentials()
         pots.pair.potentials.append(pot)
-        pots.pair.rmax = 3.0
-        pots.pair.num = 4
+        pots.pair.rmax = 2.0
+        pots.pair.num = 3
 
         return (ens,pots)
 
@@ -88,6 +88,11 @@ class test_HOOMD(unittest.TestCase):
         # no T
         ens,pot = self.ens_pot()
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V)
+        h = relentless.simulate.HOOMD(op)
+        h.run(potentials=pot, directory=self.directory)
+
+        # T + diameters
+        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, diameters={'A': 1., 'B': 2.})
         h = relentless.simulate.HOOMD(op)
         h.run(potentials=pot, directory=self.directory)
 
@@ -253,7 +258,7 @@ class test_HOOMD(unittest.TestCase):
     def test_analyzer(self):
         """Test ensemble analyzer simulation operation."""
         ens,pot = self.ens_pot()
-        init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
+        init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={'A': 1, 'B': 1})
         lgv = relentless.simulate.AddLangevinIntegrator(dt=0.1,
                                                         T=ens.T,
                                                         friction=0.9,

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -268,10 +268,10 @@ class test_HOOMD(unittest.TestCase):
         """Test ensemble analyzer simulation operation."""
         ens,pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={'A': 1, 'B': 1})
-        lgv = relentless.simulate.AddLangevinIntegrator(dt=0.1,
+        lgv = relentless.simulate.AddLangevinIntegrator(dt=0.001,
                                                         T=ens.T,
-                                                        friction=0.9,
-                                                        seed=2)
+                                                        friction=1.0,
+                                                        seed=1)
         analyzer = relentless.simulate.AddEnsembleAnalyzer(check_thermo_every=5,
                                                            check_rdf_every=5,
                                                            rdf_dr=1.0)

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -308,7 +308,7 @@ class test_LAMMPS(unittest.TestCase):
                                                            check_rdf_every=5,
                                                            rdf_dr=1.0)
         run = relentless.simulate.Run(steps=500)
-        lgv = relentless.simulate.AddLangevinIntegrator(dt=0.005,
+        lgv = relentless.simulate.AddLangevinIntegrator(dt=0.001,
                                                         T=ens.T,
                                                         friction=1.0,
                                                         seed=1)

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -38,11 +38,12 @@ class test_LAMMPS(unittest.TestCase):
         # setup potentials
         pot = LinPot(ens.types,params=('m',))
         for pair in pot.coeff:
-            pot.coeff[pair]['m'] = -2.0
+            pot.coeff[pair].update({'m': -2.0, 'rmax': 1.0})
         pots = relentless.simulate.Potentials()
         pots.pair.potentials.append(pot)
-        pots.pair.rmax = 10.0
-        pots.pair.num = 11
+        pots.pair.rmin = 1e-6
+        pots.pair.rmax = 2.0
+        pots.pair.num = 3
 
         return (ens,pots)
 
@@ -118,6 +119,11 @@ class test_LAMMPS(unittest.TestCase):
         h = relentless.simulate.LAMMPS(op, dimension=self.dim)
         h.run(potentials=pot, directory=self.directory)
 
+        # T + diameters
+        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, diameters={'A': 1., 'B': 2.})
+        h = relentless.simulate.LAMMPS(op, dimension=self.dim)
+        h.run(potentials=pot, directory=self.directory)
+
         # no T + mass
         m = {i: idx+1 for idx,i in enumerate(ens.N)}
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, masses=m)
@@ -190,7 +196,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertFalse(sim.lammps.has_id('fix',str(lgv._fix_langevin)))
 
         # single-type friction
-        init_1 = relentless.simulate.InitializeRandomly(seed=1, N={'1':2}, V=relentless.extent.Cube(L=10.0), T=2.0)
+        init_1 = relentless.simulate.InitializeRandomly(seed=1, N={'1':2}, V=ens.V, T=ens.T)
         lgv = relentless.simulate.AddLangevinIntegrator(dt=0.5,
                                                         T=ens.T,
                                                         friction={'1':3.0},
@@ -320,7 +326,7 @@ class test_LAMMPS(unittest.TestCase):
     def test_analyzer(self):
         """Test ensemble analyzer simulation operation."""
         ens,pot = self.ens_pot()
-        init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
+        init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={'1': 1, '2': 1})
         analyzer = relentless.simulate.AddEnsembleAnalyzer(check_thermo_every=5,
                                                            check_rdf_every=5,
                                                            rdf_dr=1.0)

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -97,7 +97,7 @@ class test_LAMMPS(unittest.TestCase):
         h.run(potentials=pot, directory=self.directory)
 
         # T + diameters
-        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, diameters={'A': 1., 'B': 2.})
+        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, diameters={'1': 1., '2': 2.})
         h = relentless.simulate.LAMMPS(op, dimension=self.dim)
         h.run(potentials=pot, directory=self.directory)
 

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -339,7 +339,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertIsNotNone(ens_.P)
         self.assertNotEqual(ens_.P, 0)
         self.assertIsNotNone(ens_.V)
-        self.assertNotEqual(ens_.V.volume, 0)
+        self.assertNotEqual(ens_.V.extent, 0)
         for i,j in ens_.rdf:
             self.assertEqual(ens_.rdf[i,j].table.shape, (len(pot.pair.r)-1,2))
 

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -241,7 +241,7 @@ class test_InitializeRandomly(unittest.TestCase):
             N = {'A': 100, 'B': 25}
         else:
             N = {'A': 20, 'B': 5}
-        d = {'A': 1.0, 'B': 3.0}
+        d = {'A': 1.0, 'B': relentless.variable.DesignVariable(3.0)}
         rs, types = relentless.simulate.InitializeRandomly._pack_particles(42, N, self.V, d)
 
         mask = numpy.array([typei == 'A' for typei in types])
@@ -256,7 +256,7 @@ class test_InitializeRandomly(unittest.TestCase):
         rBs = rs[~mask]
         for i,rB in enumerate(rBs):
             dr = numpy.linalg.norm(rBs[i+1:]-rB, axis=1)
-            self.assertTrue(numpy.all(dr > d['B']-self.tol))
+            self.assertTrue(numpy.all(dr > d['B'].value-self.tol))
 
         for i,rA in enumerate(rAs):
             dr = numpy.linalg.norm(rAs[i+1:]-rA, axis=1)
@@ -264,7 +264,7 @@ class test_InitializeRandomly(unittest.TestCase):
 
         for i,rA in enumerate(rAs):
             dr = numpy.linalg.norm(rBs-rA,axis=1)
-            dAB = 0.5*(d['A']+d['B'])
+            dAB = 0.5*(d['A']+d['B'].value)
             if numpy.any(dr < dAB):
                 print(dr[dr<dAB])
             self.assertTrue(numpy.all(dr > dAB-self.tol))


### PR DESCRIPTION
This PR enables smarter random initialization (i.e., without hard-sphere overlaps). I decided to write a method that fills the box by random sampling of a close-packed lattice. The particles are placed from biggest to smallest into random lattice sites that do not overlap any previously inserted particles. This should cover a lot of common use cases, but if dense enough packings are still not achieved, we could also write a separate method that uses packmol to do this.

This PR drops support for arbitrarily oriented Parallelepipeds and Parallelograms because we were essentially never using them, and I'm unaware of any packages that do. We could add support for initializing from files with rotation, if needed, at a later time.

This PR adds support for setting particle masses during random initialization, with thermalization handled correctly. Before, it only gave unit mass.

`lammpsio` is now a dependency for writing the Data File to initialize the LAMMPS simulation. This opens up the possibility of (1) getting the particle masses out of a file and (2) configuring the Langevin integrator using these masses, rather than extracting from a running simulation. This would allow us to use 100% LAMMPS script commands to do the simulation, and hence run from the command line (see #81).

This PR should be rebased and merged after PR #114 .