### PR TITLE
Make unit tests robust under MPI

### DIFF
--- a/relentless/data.py
+++ b/relentless/data.py
@@ -65,7 +65,7 @@ class Directory:
             dir_error = not os.path.isdir(path)
         else:
             dir_error = None
-        mpi.world.bcast(dir_error)
+        dir_error = mpi.world.bcast(dir_error)
         if dir_error:
             raise OSError('The specified path is not a valid directory')
         self._path = path

--- a/relentless/ensemble.py
+++ b/relentless/ensemble.py
@@ -30,6 +30,7 @@ import numpy
 from .collections import FixedKeyDict,PairMatrix
 from .math import Interpolator
 from . import extent
+from . import mpi
 
 class RDF(Interpolator):
     r"""Radial distribution function.
@@ -201,8 +202,7 @@ class Ensemble:
             An new Ensemble object.
 
         """
-        with open(filename) as f:
-            data = json.load(f)
+        data = mpi.world.load_json(filename)
 
         # create initial ensemble
         ExtentType = getattr(extent,data['V']['__name__'])

--- a/relentless/mpi.py
+++ b/relentless/mpi.py
@@ -37,7 +37,9 @@ see its documentation for more details.
     :members:
 
 """
+import json
 import os
+
 import numpy
 try:
     from mpi4py import MPI
@@ -313,6 +315,50 @@ class Communicator:
         else:
             dat = None
         dat = self.bcast_numpy(dat,root)
+
+        return dat
+
+    def load_json(self, filename, root=None):
+        """Load a JSON file and broadcast.
+
+        Data is loaded from file using :func:`json.load` on the ``root`` rank,
+        then broadcast to all ranks. This function can be called with essentially
+        no overhead in single-processor calculations, but prevents oversubscribing
+        file handles when running under MPI.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the file to load.
+        root : int
+            Rank to broadcast from. If ``None`` (default), broadcast from the
+            :attr:`root` of the communicator.
+
+        Returns
+        -------
+        dict
+            The data from ``filename``.
+
+        Example
+        -------
+        Load a file:
+
+        .. code::
+
+            comm = relentless.mpi.Communicator()
+            dat = comm.load_json("ensemble.json")
+
+
+        """
+        if root is None:
+            root = self.root
+
+        if self.rank == root:
+            with open(filename) as f:
+                dat = json.load(f)
+        else:
+            dat = None
+        dat = self.bcast(dat, root)
 
         return dat
 

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -10,8 +10,13 @@ class test_Dilute(unittest.TestCase):
     """Unit tests for relentless.simulate.Dilute"""
 
     def setUp(self):
-        self._tmp = tempfile.TemporaryDirectory()
-        self.directory = relentless.data.Directory(self._tmp.name)
+        if relentless.mpi.world.rank_is_root:
+            self._tmp = tempfile.TemporaryDirectory()
+            directory = self._tmp.name
+        else:
+            directory = None
+        directory = relentless.mpi.world.bcast(directory)
+        self.directory = relentless.data.Directory(directory)
 
     def test_run(self):
         """Test run method."""
@@ -67,7 +72,10 @@ class test_Dilute(unittest.TestCase):
         self.assertAlmostEqual(ens_.P, -1.1987890)
 
     def tearDown(self):
-        self._tmp.cleanup()
+        if relentless.mpi.world.rank_is_root:
+            self._tmp.cleanup()
+            del self._tmp
+        del self.directory
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -72,29 +72,31 @@ class test_LAMMPS(unittest.TestCase):
             z5 = '0.0'
         else:
             raise ValueError('LAMMPS supports 2d and 3d simulations')
-        
-        with open(file_,'w') as f:
-            f.write(('LAMMPS test data\n'
-                    '\n'
-                    '5 atoms\n'
-                    '2 atom types\n'
-                    '\n'
-                    '-5.0 5.0 xlo xhi\n'
-                    '-5.0 5.0 ylo yhi\n'
-                    '{} {} zlo zhi\n'
-                    '\n'
-                    'Atoms\n'
-                    '\n'
-                    '1 1 -4.0 -4.0 {}\n'
-                    '2 1 -2.0 -2.0 {}\n'
-                    '3 2 0.0 0.0 {}\n'
-                    '4 2 2.0 2.0 {}\n'
-                    '5 2 4.0 4.0 {}\n'
-                    '\n'
-                    'Masses\n'
-                    '\n'
-                    '1 0.3\n'
-                    '2 0.1').format(zlo, zhi, z1, z2, z3, z4, z5))
+
+        if relentless.mpi.world.rank_is_root:
+            with open(file_,'w') as f:
+                f.write(('LAMMPS test data\n'
+                        '\n'
+                        '5 atoms\n'
+                        '2 atom types\n'
+                        '\n'
+                        '-5.0 5.0 xlo xhi\n'
+                        '-5.0 5.0 ylo yhi\n'
+                        '{} {} zlo zhi\n'
+                        '\n'
+                        'Atoms\n'
+                        '\n'
+                        '1 1 -4.0 -4.0 {}\n'
+                        '2 1 -2.0 -2.0 {}\n'
+                        '3 2 0.0 0.0 {}\n'
+                        '4 2 2.0 2.0 {}\n'
+                        '5 2 4.0 4.0 {}\n'
+                        '\n'
+                        'Masses\n'
+                        '\n'
+                        '1 0.3\n'
+                        '2 0.1').format(zlo, zhi, z1, z2, z3, z4, z5))
+        relentless.mpi.world.barrier()
         return file_
 
     def test_initialize(self):

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -51,7 +51,7 @@ class test_Communicator(unittest.TestCase):
         # broadcast from specified root
         if self.comm.size >= 2:
             root = 1
-            if self.comm.rank_is_root:
+            if self.comm.rank == root:
                 x = 7
             else:
                 x = None
@@ -72,7 +72,7 @@ class test_Communicator(unittest.TestCase):
         # float array from specified root
         if self.comm.size >= 2:
             root = 1
-            if self.comm.rank_is_root:
+            if self.comm.rank == root:
                 x = numpy.array([3.,4.],dtype=numpy.float64)
             else:
                 x = None


### PR DESCRIPTION
This PR tries to fix some uncaught race conditions related to the filesystem in unit tests. It also fixes an error in one of the MPI unit tests where the data was set on the wrong rank before broadcasting. On my local system, all tests (skipping HOOMD/LAMMPS) pass under MPI on 2 ranks.