### PR TITLE
Fix error in pair potential derivative

### DIFF
--- a/relentless/potential/pair.py
+++ b/relentless/potential/pair.py
@@ -445,7 +445,7 @@ class PairPotential(potential.Potential):
                 # rmin deriv
                 flags = r < params['rmin']
                 deriv[flags] += -self._force(params['rmin'], **params)*dp_dvar
-            if p=='rmax':
+            elif p=='rmax':
                 # rmax deriv
                 if params['shift']:
                     flags = r <= params['rmax']


### PR DESCRIPTION
I was unable to come up with a minimal unit test that reproduces the error Levi was seeing, but I am pretty sure this `if-if-else` should be an `if-elif-else` so that exactly one branch is taken when the parameter being differentiated is `rmin`.