### PR TITLE
Require explicit rmin for LAMMPS tabulated pair potential

### DIFF
--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -749,7 +749,7 @@ class HOOMD(simulate.Simulation):
     .. warning::
 
         HOOMD requires that tabulated pair potentials be finite. A common place to have an
-        infinite value is at :math:`r=0`, since potentials like :class:`~relentless.potential.LennardJones`
+        infinite value is at :math:`r=0`, since potentials like :class:`~relentless.potential.pair.LennardJones`
         diverge there. You should make sure to exclude these values from the tabulated potentials,
         e.g., setting :attr:`~relentless.simulate.PairPotentialTabulator.rmin` to a small value larger than 0.
 

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -751,7 +751,7 @@ class HOOMD(simulate.Simulation):
         HOOMD requires that tabulated pair potentials be finite. A common place to have an
         infinite value is at :math:`r=0`, since potentials like :class:`~relentless.potential.LennardJones`
         diverge there. You should make sure to exclude these values from the tabulated potentials,
-        e.g., setting :attr`~relentless.simulate.PairPotentialTabulator.rmin` to a small value larger than 0.
+        e.g., setting :attr:`~relentless.simulate.PairPotentialTabulator.rmin` to a small value larger than 0.
 
     Raises
     ------

--- a/relentless/simulate/hoomd.py
+++ b/relentless/simulate/hoomd.py
@@ -746,6 +746,13 @@ class HOOMD(simulate.Simulation):
     both `pip` and `conda-forge`. Please refer to the package documentation for
     details of how to install these.
 
+    .. warning::
+
+        HOOMD requires that tabulated pair potentials be finite. A common place to have an
+        infinite value is at :math:`r=0`, since potentials like :class:`~relentless.potential.LennardJones`
+        diverge there. You should make sure to exclude these values from the tabulated potentials,
+        e.g., setting :attr`~relentless.simulate.PairPotentialTabulator.rmin` to a small value larger than 0.
+
     Raises
     ------
     ImportError
@@ -813,6 +820,8 @@ class HOOMD(simulate.Simulation):
                 r = sim.potentials.pair.r
                 u = sim.potentials.pair.energy((i,j))
                 f = sim.potentials.pair.force((i,j))
+                if numpy.any(numpy.isinf(u)) or numpy.any(numpy.isinf(f)):
+                    raise ValueError('Pair potential/force is infinite at evaluated r')
                 pair_potential.pair_coeff.set(i,j,
                                               func=_table_eval,
                                               rmin=r[0],

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -719,7 +719,7 @@ class LAMMPS(simulate.Simulation):
     .. warning::
 
         LAMMPS requires that tabulated pair potentials do not include an entry for
-        :math:`r = 0`. Make sure to set :attr`~relentless.simulate.PairPotentialTabulator.rmin`
+        :math:`r = 0`. Make sure to set :attr:`~relentless.simulate.PairPotentialTabulator.rmin`
         to a small value larger than 0.
 
     Parameters

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -716,7 +716,6 @@ class LAMMPS(simulate.Simulation):
     LAMMPS must be built with its `Python interface <https://docs.lammps.org/Python_head.html>`_
     and must be version 29 Sep 2021 or newer.
 
-
     .. warning::
 
         LAMMPS requires that tabulated pair potentials do not include an entry for

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -716,6 +716,13 @@ class LAMMPS(simulate.Simulation):
     LAMMPS must be built with its `Python interface <https://docs.lammps.org/Python_head.html>`_
     and must be version 29 Sep 2021 or newer.
 
+
+    .. warning::
+
+        LAMMPS requires that tabulated pair potentials do not include an entry for
+        :math:`r = 0`. Make sure to set :attr`~relentless.simulate.PairPotentialTabulator.rmin`
+        to a small value larger than 0.
+
     Parameters
     ----------
     initializer : :class:`~relentless.simulate.SimulationOperation`
@@ -788,9 +795,9 @@ class LAMMPS(simulate.Simulation):
             If the pair potentials do not have equally spaced ``r``.
 
         """
-        # lammps requires r > 0
-        flags = sim.potentials.pair.r > 0
-        r = sim.potentials.pair.r[flags]
+        if sim.potentials.pair.rmin == 0:
+            raise ValueError('LAMMPS requires rmin > 0 for pair potentials')
+        r = sim.potentials.pair.r
         Nr = len(r)
         if Nr == 1:
             raise ValueError('LAMMPS requires at least two points in the tabulated potential.')
@@ -829,8 +836,8 @@ class LAMMPS(simulate.Simulation):
                                                                 rmin=r[0],
                                                                 rmax=r[-1]))
 
-                    u = sim.potentials.pair.energy((i,j))[flags]
-                    f = sim.potentials.pair.force((i,j))[flags]
+                    u = sim.potentials.pair.energy((i,j))
+                    f = sim.potentials.pair.force((i,j))
                     for idx in range(Nr):
                         fw.write('{idx} {r} {u} {f}\n'.format(idx=idx+1,r=r[idx],u=u[idx],f=f[idx]))
 

--- a/relentless/simulate/simulate.py
+++ b/relentless/simulate/simulate.py
@@ -758,7 +758,7 @@ class InitializeRandomly(GenericOperation):
     diameters : dict
         Diameter of each particle type. Defaults to None, which means particles
         are randomly inserted without checking their sizes. The value of a
-        diameter can be a :class:`~variable.Variable`, which will be
+        diameter can be a :class:`~relentless.variable.Variable`, which will be
         evaluated at the time the operation is called.
 
     """


### PR DESCRIPTION
This PR explicitly requires the user to set a nonzero rmin when using LAMMPS.

Fixes #107 