### PR TITLE
Automatically generate LAMMPS IDs

### DIFF
--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -663,9 +663,7 @@ class AddEnsembleAnalyzer(LAMMPSOperation):
 
         # thermodynamic properties
         sim[self].thermo_file = sim.directory.file('lammps_thermo.dat')
-        cmds = ['thermo {every}'.format(every=self.check_thermo_every),
-                'thermo_style custom temp press lx ly lz xy xz yz',
-                'thermo_modify norm no flush no',
+        cmds = [
                 'variable {} equal temp'.format(var_ids['T']),
                 'variable {} equal press'.format(var_ids['P']),
                 'variable {} equal lx'.format(var_ids['Lx']),


### PR DESCRIPTION
This PR automatically generates IDs for computes, groups, and variables. This allows us to relax the requirement that there is only one ensemble analyzer, and lowers developer burden to carefully pick these IDs.

Fixes #116 