### PR TITLE
Add pre-commit hooks for code style and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,3 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8
-  
-  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+ci:
+  autoupdate_schedule: quarterly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+  
+  

--- a/doc/source/api/optimize.rst
+++ b/doc/source/api/optimize.rst
@@ -2,4 +2,3 @@
     :no-members:
     :no-inherited-members:
     :no-special-members:
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -8,28 +8,29 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
+
+sys.path.insert(0, os.path.abspath("../.."))
 
 # -- Project information -----------------------------------------------------
 
-project = 'relentless'
-copyright = '2021, Auburn University'
-author = 'Michael P. Howard'
-version = '0.1.0'
-release = '0.1.0'
+project = "relentless"
+copyright = "2021, Auburn University"
+author = "Michael P. Howard"
+version = "0.1.0"
+release = "0.1.0"
 
 # -- General configuration ---------------------------------------------------
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon',
-    'sphinx_design'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx_design",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 exclude_patterns = []
 
@@ -37,28 +38,25 @@ default_role = "any"
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 html_theme_options = {}
-html_static_path = ['_static']
-html_css_files = ['theme_overrides.css']
+html_static_path = ["_static"]
+html_css_files = ["theme_overrides.css"]
 
 # -- Options for autodoc & autosummary ---------------------------------------
 
 autosummary_generate = True
 
-autodoc_default_options = {
-    'inherited-members': None,
-    'special-members': False
-}
+autodoc_default_options = {"inherited-members": None, "special-members": False}
 
 # -- Options for intersphinx -------------------------------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'networkx': ('https://networkx.org/documentation/stable', None),
-    'mpi4py': ('https://mpi4py.readthedocs.io/en/stable', None),
-    'numpy': ('https://numpy.org/doc/stable', None),
-    'hoomd': ('https://hoomd-blue.readthedocs.io/en/v2.9.7', None),
-    'lammps': ('https://docs.lammps.org', None),
-    'freud': ('https://freud.readthedocs.io/en/stable', None)
+    "python": ("https://docs.python.org/3", None),
+    "networkx": ("https://networkx.org/documentation/stable", None),
+    "mpi4py": ("https://mpi4py.readthedocs.io/en/stable", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "hoomd": ("https://hoomd-blue.readthedocs.io/en/v2.9.7", None),
+    "lammps": ("https://docs.lammps.org", None),
+    "freud": ("https://freud.readthedocs.io/en/stable", None),
 }

--- a/doc/source/guide/credits.rst
+++ b/doc/source/guide/credits.rst
@@ -9,4 +9,3 @@ Contributors
 **Adithya N Sreenivasan**
 
 **Zachary M. Sherman**
-

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,23 +9,23 @@ Overview
     .. grid-item-card::
 
         User guide
-        
+
         .. button-ref:: guide/index
             :expand:
             :color: secondary
             :click-parent:
-            
+
             Go to user guide
 
     .. grid-item-card::
 
         API reference
-        
+
         .. button-ref:: api/index
             :expand:
             :color: secondary
             :click-parent:
-            
+
             Go to API reference
 
 .. toctree::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,10 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+
+[tool.isort]
+profile = "black"

--- a/relentless/__init__.py
+++ b/relentless/__init__.py
@@ -4,7 +4,4 @@ relentless
 
 """
 
-from . import model
-from . import mpi
-from . import optimize
-from . import simulate
+from . import model, mpi, optimize, simulate

--- a/relentless/collections.py
+++ b/relentless/collections.py
@@ -15,6 +15,7 @@ Collections (`relentless.collections`)
 """
 import collections
 
+
 class FixedKeyDict(collections.abc.MutableMapping):
     """Dictionary with fixed keys.
 
@@ -66,6 +67,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
         FixedKeyDict(keys=('A',))
 
     """
+
     def __init__(self, keys, default=None):
         self._keys = tuple(keys)
         self._data = {}
@@ -87,7 +89,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
 
         """
         if key not in self._keys:
-            raise KeyError('Key {} is not in dictionary.'.format(key))
+            raise KeyError("Key {} is not in dictionary.".format(key))
         return key
 
     def __getitem__(self, key):
@@ -112,6 +114,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
         """Clear entries in the dictionary, resetting to default."""
         for i in self._keys:
             self._data[i] = self._default
+
 
 class PairMatrix(collections.abc.MutableMapping):
     """Generic matrix of values per-pair.
@@ -177,11 +180,12 @@ class PairMatrix(collections.abc.MutableMapping):
         PairMatrix(types=('A',))
 
     """
+
     def __init__(self, types):
         if len(types) == 0:
-            raise ValueError('Cannot initialize with empty types')
+            raise ValueError("Cannot initialize with empty types")
         if not all(isinstance(t, str) for t in types):
-            raise TypeError('All types must be strings')
+            raise TypeError("All types must be strings")
         self.types = tuple(types)
 
         # flood data with type pairs
@@ -189,7 +193,7 @@ class PairMatrix(collections.abc.MutableMapping):
         for i in self.types:
             for j in self.types:
                 if j >= i:
-                    self._data[i,j] = {}
+                    self._data[i, j] = {}
 
     def _check_key(self, key):
         """Check that a pair key is valid.
@@ -206,17 +210,17 @@ class PairMatrix(collections.abc.MutableMapping):
 
         """
         if len(key) != 2:
-            raise KeyError('Coefficient matrix requires a pair of types.')
+            raise KeyError("Coefficient matrix requires a pair of types.")
 
         if key[0] not in self.types:
-            raise KeyError('Type {} is not in coefficient matrix.'.format(key[0]))
+            raise KeyError("Type {} is not in coefficient matrix.".format(key[0]))
         elif key[1] not in self.types:
-            raise KeyError('Type {} is not in coefficient matrix.'.format(key[1]))
+            raise KeyError("Type {} is not in coefficient matrix.".format(key[1]))
 
         if key[1] >= key[0]:
             return key
         else:
-            return (key[1],key[0])
+            return (key[1], key[0])
 
     def __getitem__(self, key):
         """Get all coefficients for the `(i,j)` pair."""
@@ -243,6 +247,7 @@ class PairMatrix(collections.abc.MutableMapping):
         """tuple: All unique pairs in the matrix."""
         return tuple(self._data.keys())
 
+
 class DefaultDict(collections.abc.MutableMapping):
     """Dictionary which supports a default value.
 
@@ -252,6 +257,7 @@ class DefaultDict(collections.abc.MutableMapping):
         The default value.
 
     """
+
     def __init__(self, default):
         self._data = {}
         self.default = default
@@ -272,7 +278,7 @@ class DefaultDict(collections.abc.MutableMapping):
     def __setitem__(self, key, value):
         """Set value of keyed item."""
         if key is None:
-            raise KeyError('A DefaultDict key cannot be None.')
+            raise KeyError("A DefaultDict key cannot be None.")
         self._data[key] = value
 
     def __len__(self):

--- a/relentless/data.py
+++ b/relentless/data.py
@@ -16,6 +16,7 @@ import shutil
 
 from . import mpi
 
+
 class Directory:
     """Context for a filesystem directory.
 
@@ -51,6 +52,7 @@ class Directory:
             f = open('bar.txt')
 
     """
+
     def __init__(self, path):
         self._start = []
 
@@ -64,7 +66,7 @@ class Directory:
             dir_error = None
         dir_error = mpi.world.bcast(dir_error)
         if dir_error:
-            raise OSError('The specified path is not a valid directory')
+            raise OSError("The specified path is not a valid directory")
         self._path = path
 
     @classmethod
@@ -227,5 +229,5 @@ class Directory:
                 if entry.is_file():
                     shutil.copy2(entry.path, dest.path)
                 elif entry.is_dir():
-                    shutil.copytree(entry.path, os.path.join(dest.path,entry.name))
+                    shutil.copytree(entry.path, os.path.join(dest.path, entry.name))
         mpi.world.barrier()

--- a/relentless/math.py
+++ b/relentless/math.py
@@ -17,6 +17,7 @@ import scipy.interpolate
 
 from .collections import FixedKeyDict
 
+
 class Interpolator:
     r"""Interpolating function.
 
@@ -69,18 +70,19 @@ class Interpolator:
         2.0
 
     """
+
     def __init__(self, x, y):
         x = numpy.atleast_1d(x)
         y = numpy.atleast_1d(y)
         if x.shape[0] == 1:
-            raise ValueError('x cannot be a scalar')
+            raise ValueError("x cannot be a scalar")
         if x.ndim > 1:
-            raise ValueError('x must be 1-dimensional')
+            raise ValueError("x must be 1-dimensional")
         if x.shape != y.shape:
-            raise ValueError('x and y must be the same shape')
+            raise ValueError("x and y must be the same shape")
         if not numpy.all(x[1:] > x[:-1]):
-            raise ValueError('x must be strictly increasing')
-        self._domain = (x[0],x[-1])
+            raise ValueError("x must be strictly increasing")
+        self._domain = (x[0], x[-1])
         if x.shape[0] > 2:
             self._spline = scipy.interpolate.Akima1DInterpolator(x=x, y=y)
         else:
@@ -113,7 +115,7 @@ class Interpolator:
         result[hi] = self._spline(self.domain[1])
 
         # evaluate in between
-        flags = numpy.logical_and(~lo,~hi)
+        flags = numpy.logical_and(~lo, ~hi)
         result[flags] = self._spline(x[flags])
 
         if scalar_x:
@@ -143,7 +145,7 @@ class Interpolator:
 
         """
         if not isinstance(n, int) and n <= 0:
-            raise ValueError('n must be a positive integer')
+            raise ValueError("n must be a positive integer")
         scalar_x = numpy.isscalar(x)
         x = numpy.atleast_1d(x)
         result = numpy.zeros(len(x))
@@ -157,7 +159,7 @@ class Interpolator:
         result[hi] = 0
 
         # evaluate in between
-        flags = numpy.logical_and(~lo,~hi)
+        flags = numpy.logical_and(~lo, ~hi)
         result[flags] = self._spline.derivative(n)(x[flags])
 
         if scalar_x:
@@ -169,6 +171,7 @@ class Interpolator:
     def domain(self):
         """tuple: The valid domain for interpolation."""
         return self._domain
+
 
 class KeyedArray(FixedKeyDict):
     """Numerical array with fixed keys.
@@ -235,12 +238,16 @@ class KeyedArray(FixedKeyDict):
         5.0
 
     """
+
     def __init__(self, keys, default=None):
         super().__init__(keys, default)
 
     def _assert_same_keys(self, val):
         if self.keys() != val.keys():
-            raise KeyError('Both KeyedArrays must have identical keys to perform mathematical operations.')
+            raise KeyError(
+                "Both KeyedArrays must have identical keys to"
+                " perform mathematical operations."
+            )
 
     def __add__(self, val):
         """Element-wise addition of two arrays, or of an array and a scalar."""
@@ -251,7 +258,7 @@ class KeyedArray(FixedKeyDict):
         elif numpy.isscalar(val):
             k.update({x: self[x] + val for x in self})
         else:
-            raise TypeError('A KeyedArray can only add a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only add a scalar or a KeyedArray.")
         return k
 
     def __radd__(self, val):
@@ -260,7 +267,7 @@ class KeyedArray(FixedKeyDict):
         if numpy.isscalar(val):
             k.update({x: val + self[x] for x in self})
         else:
-            raise TypeError('A KeyedArray can only add a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only add a scalar or a KeyedArray.")
         return k
 
     def __iadd__(self, val):
@@ -273,7 +280,7 @@ class KeyedArray(FixedKeyDict):
             for x in self:
                 self[x] += val
         else:
-            raise TypeError('A KeyedArray can only add a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only add a scalar or a KeyedArray.")
         return self
 
     def __sub__(self, val):
@@ -285,7 +292,7 @@ class KeyedArray(FixedKeyDict):
         elif numpy.isscalar(val):
             k.update({x: self[x] - val for x in self})
         else:
-            raise TypeError('A KeyedArray can only subtract a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only subtract a scalar or a KeyedArray.")
         return k
 
     def __rsub__(self, val):
@@ -294,11 +301,13 @@ class KeyedArray(FixedKeyDict):
         if numpy.isscalar(val):
             k.update({x: val - self[x] for x in self})
         else:
-            raise TypeError('A KeyedArray can only subtract a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only subtract a scalar or a KeyedArray.")
         return k
 
     def __isub__(self, val):
-        """In-place element-wise subtraction of two arrays, or of an array and a scalar."""
+        """In-place element-wise subtraction of two arrays,
+        or of an array and a scalar.
+        """
         if isinstance(val, KeyedArray):
             self._assert_same_keys(val)
             for x in self:
@@ -307,7 +316,7 @@ class KeyedArray(FixedKeyDict):
             for x in self:
                 self[x] -= val
         else:
-            raise TypeError('A KeyedArray can only subtract a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only subtract a scalar or a KeyedArray.")
         return self
 
     def __mul__(self, val):
@@ -315,24 +324,26 @@ class KeyedArray(FixedKeyDict):
         k = KeyedArray(keys=self.keys())
         if isinstance(val, KeyedArray):
             self._assert_same_keys(val)
-            k.update({x: self[x]*val[x] for x in self})
+            k.update({x: self[x] * val[x] for x in self})
         elif numpy.isscalar(val):
-            k.update({x: self[x]*val for x in self})
+            k.update({x: self[x] * val for x in self})
         else:
-            raise TypeError('A KeyedArray can only multiply a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only multiply a scalar or a KeyedArray.")
         return k
 
     def __rmul__(self, val):
         """Element-wise multiplication of a scalar by an array."""
         k = KeyedArray(keys=self.keys())
         if numpy.isscalar(val):
-            k.update({x: val*self[x] for x in self})
+            k.update({x: val * self[x] for x in self})
         else:
-            raise TypeError('A KeyedArray can only multiply a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only multiply a scalar or a KeyedArray.")
         return k
 
     def __imul__(self, val):
-        """In-place element-wise multiplication of two arrays, or of an array by a scalar."""
+        """In-place element-wise multiplication of two arrays,
+        or of an array by a scalar.
+        """
         if isinstance(val, KeyedArray):
             self._assert_same_keys(val)
             for x in self:
@@ -341,7 +352,7 @@ class KeyedArray(FixedKeyDict):
             for x in self:
                 self[x] *= val
         else:
-            raise TypeError('A KeyedArray can only multiply a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only multiply a scalar or a KeyedArray.")
         return self
 
     def __truediv__(self, val):
@@ -349,20 +360,20 @@ class KeyedArray(FixedKeyDict):
         k = KeyedArray(keys=self.keys())
         if isinstance(val, KeyedArray):
             self._assert_same_keys(val)
-            k.update({x: self[x]/val[x] for x in self})
+            k.update({x: self[x] / val[x] for x in self})
         elif numpy.isscalar(val):
-            k.update({x: self[x]/val for x in self})
+            k.update({x: self[x] / val for x in self})
         else:
-            raise TypeError('A KeyedArray can only divide a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only divide a scalar or a KeyedArray.")
         return k
 
     def __rtruediv__(self, val):
         """Element-wise division of a scalar by an array."""
         k = KeyedArray(keys=self.keys())
         if numpy.isscalar(val):
-            k.update({x: val/self[x] for x in self})
+            k.update({x: val / self[x] for x in self})
         else:
-            raise TypeError('A KeyedArray can only divide a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only divide a scalar or a KeyedArray.")
         return k
 
     def __itruediv__(self, val):
@@ -375,7 +386,7 @@ class KeyedArray(FixedKeyDict):
             for x in self:
                 self[x] /= val
         else:
-            raise TypeError('A KeyedArray can only divide a scalar or a KeyedArray.')
+            raise TypeError("A KeyedArray can only divide a scalar or a KeyedArray.")
         return self
 
     def __pow__(self, val):
@@ -383,11 +394,13 @@ class KeyedArray(FixedKeyDict):
         k = KeyedArray(keys=self.keys())
         if isinstance(val, KeyedArray):
             self._assert_same_keys(val)
-            k.update({x: self[x]**val[x] for x in self})
+            k.update({x: self[x] ** val[x] for x in self})
         elif numpy.isscalar(val):
-            k.update({x: self[x]**val for x in self})
+            k.update({x: self[x] ** val for x in self})
         else:
-            raise TypeError('A KeyedArray can only be exponentiated by a scalar or by a KeyedArray.')
+            raise TypeError(
+                "A KeyedArray can only be exponentiated by a scalar or by a KeyedArray."
+            )
         return k
 
     def __neg__(self):
@@ -437,4 +450,4 @@ class KeyedArray(FixedKeyDict):
 
         """
         self._assert_same_keys(val)
-        return numpy.sum([self[x]*val[x] for x in self])
+        return numpy.sum([self[x] * val[x] for x in self])

--- a/relentless/model/__init__.py
+++ b/relentless/model/__init__.py
@@ -73,11 +73,8 @@ Variables
     variable.VariableGraph
 
 """
-from .ensemble import (
-    Ensemble,
-    RDF,
-    )
-
+from . import potential
+from .ensemble import RDF, Ensemble
 from .extent import (
     Area,
     Cube,
@@ -88,10 +85,7 @@ from .extent import (
     Square,
     TriclinicBox,
     Volume,
-    )
-
-from . import potential
-
+)
 from .variable import (
     ArithmeticMean,
     ConstantVariable,
@@ -100,4 +94,4 @@ from .variable import (
     GeometricMean,
     IndependentVariable,
     Variable,
-    )
+)

--- a/relentless/model/extent.py
+++ b/relentless/model/extent.py
@@ -1,8 +1,8 @@
 """
 Extents
 =======
-An :class:`Extent` represents a region of space with a fixed, scalar volume or area. It corresponds
-to the "box" used in simulations. 
+An :class:`Extent` represents a region of space with a fixed, scalar volume or area.
+It corresponds to the "box" used in simulations.
 
 Examples
 --------
@@ -23,6 +23,7 @@ import abc
 
 import numpy
 
+
 class Extent(abc.ABC):
     r"""Abstract base class defining a region of space.
 
@@ -32,6 +33,7 @@ class Extent(abc.ABC):
     Extent must be specified so that the object can be saved to disk.
 
     """
+
     @classmethod
     @abc.abstractmethod
     def from_json(cls, data):
@@ -65,6 +67,7 @@ class Extent(abc.ABC):
         """
         pass
 
+
 class Volume(Extent):
     r"""Three-dimensional region of space.
 
@@ -75,6 +78,7 @@ class Volume(Extent):
 
     """
     pass
+
 
 class TriclinicBox(Volume):
     r"""Triclinic box.
@@ -132,29 +136,29 @@ class TriclinicBox(Volume):
 
     """
 
-    def __init__(self, Lx, Ly, Lz, xy, xz, yz, convention='LAMMPS'):
+    def __init__(self, Lx, Ly, Lz, xy, xz, yz, convention="LAMMPS"):
         if Lx <= 0 or Ly <= 0 or Lz <= 0:
-            raise ValueError('All side lengths must be positive.')
+            raise ValueError("All side lengths must be positive.")
 
         convention = convention.upper()
-        if convention == 'LAMMPS':
-            a = (Lx,0,0)
-            b = (xy,Ly,0)
-            c = (xz,yz,Lz)
-        elif convention == 'HOOMD':
-            a = (Lx,0,0)
-            b = (xy*Ly,Ly,0)
-            c = (xz*Lz,yz*Lz,Lz)
+        if convention == "LAMMPS":
+            a = (Lx, 0, 0)
+            b = (xy, Ly, 0)
+            c = (xz, yz, Lz)
+        elif convention == "HOOMD":
+            a = (Lx, 0, 0)
+            b = (xy * Ly, Ly, 0)
+            c = (xz * Lz, yz * Lz, Lz)
         else:
-            raise ValueError('Triclinic convention must be LAMMPS or HOOMD')
+            raise ValueError("Triclinic convention must be LAMMPS or HOOMD")
 
         self.a = numpy.array(a, dtype=numpy.float64)
         self.b = numpy.array(b, dtype=numpy.float64)
         self.c = numpy.array(c, dtype=numpy.float64)
 
         box_vec = self.a + self.b + self.c
-        self._low = -0.5*box_vec
-        self._high = 0.5*box_vec
+        self._low = -0.5 * box_vec
+        self._high = 0.5 * box_vec
         self._extent = numpy.dot(numpy.cross(self.a, self.b), self.c)
         self._convention = convention
 
@@ -218,18 +222,18 @@ class TriclinicBox(Volume):
         Lx = self.a[0]
         Ly = self.b[1]
         Lz = self.c[2]
-        if convention =='LAMMPS':
+        if convention == "LAMMPS":
             xy = self.b[0]
             xz = self.c[0]
             yz = self.c[1]
-        elif convention == 'HOOMD':
-            xy = self.b[0]/self.b[1]
-            xz = self.c[0]/self.c[2]
-            yz = self.c[1]/self.c[2]
+        elif convention == "HOOMD":
+            xy = self.b[0] / self.b[1]
+            xz = self.c[0] / self.c[2]
+            yz = self.c[1] / self.c[2]
         else:
-            raise TypeError('Convention must be LAMMPS or HOOMD')
+            raise TypeError("Convention must be LAMMPS or HOOMD")
 
-        return numpy.array([Lx,Ly,Lz,xy,xz,yz])
+        return numpy.array([Lx, Ly, Lz, xy, xz, yz])
 
     def coordinate_to_fraction(self, r):
         r"""Make fractional coordinates from Cartesian coordinates.
@@ -240,9 +244,11 @@ class TriclinicBox(Volume):
 
         .. math::
 
-            \mathbf{r} = \mathbf{r}_{\rm low} + (\mathbf{a}\quad\mathbf{b}\quad\mathbf{c}) \cdot \mathbf{x}
+            \mathbf{r} = \mathbf{r}_{\rm low}
+                + (\mathbf{a}\quad\mathbf{b}\quad\mathbf{c}) \cdot \mathbf{x}
 
-        where :math:`\mathbf{r}_{\rm low}` is the lower bound of the box, i.e., :attr:`low`.
+        where :math:`\mathbf{r}_{\rm low}` is the lower bound of the box,
+        i.e., :attr:`low`.
 
         Parameters
         ----------
@@ -255,20 +261,24 @@ class TriclinicBox(Volume):
             Fractional coordinates **x** corresponding to **r**.
 
         """
-        Lx,Ly,Lz,xy,xz,yz = self.as_array('LAMMPS')
+        Lx, Ly, Lz, xy, xz, yz = self.as_array("LAMMPS")
 
         # get difference from lower bound
         dx = -self.low + r
         is_1d = False
         if len(dx.shape) == 1:
-            dx = dx[numpy.newaxis,...]
+            dx = dx[numpy.newaxis, ...]
             is_1d = True
 
         # make fractional coordinate
         x = numpy.zeros_like(dx)
-        x[:,0] = (1.0/Lx)*dx[...,0] + (-xy/(Lx*Ly))*dx[...,1] + ((yz*xy-Ly*xz)/(Lx*Ly*Lz))*dx[...,2]
-        x[:,1] = (1.0/Ly)*dx[...,1] + (-yz/(Ly*Lz))*dx[...,2]
-        x[:,2] = (1.0/Lz)*dx[...,2]
+        x[:, 0] = (
+            (1.0 / Lx) * dx[..., 0]
+            + (-xy / (Lx * Ly)) * dx[..., 1]
+            + ((yz * xy - Ly * xz) / (Lx * Ly * Lz)) * dx[..., 2]
+        )
+        x[:, 1] = (1.0 / Ly) * dx[..., 1] + (-yz / (Ly * Lz)) * dx[..., 2]
+        x[:, 2] = (1.0 / Lz) * dx[..., 2]
         if is_1d:
             x = x[0]
 
@@ -292,17 +302,17 @@ class TriclinicBox(Volume):
             Cartesian coordinates **r** corresponding to **x**.
 
         """
-        Lx,Ly,Lz,xy,xz,yz = self.as_array('LAMMPS')
+        Lx, Ly, Lz, xy, xz, yz = self.as_array("LAMMPS")
 
         # make real coordinate
         r = numpy.array(x)
         is_1d = False
         if len(r.shape) == 1:
-            r = r[numpy.newaxis,...]
+            r = r[numpy.newaxis, ...]
             is_1d = True
-        r[:,0] = Lx*r[...,0] + xy*r[...,1] + xz*r[...,2]
-        r[:,1] = Ly*r[...,1] + yz*r[...,2]
-        r[:,2] = Lz*r[...,2]
+        r[:, 0] = Lx * r[..., 0] + xy * r[..., 1] + xz * r[..., 2]
+        r[:, 1] = Ly * r[..., 1] + yz * r[..., 2]
+        r[:, 2] = Lz * r[..., 2]
         r += self.low
         if is_1d:
             r = r[0]
@@ -322,15 +332,16 @@ class TriclinicBox(Volume):
             The serialized TriclinicBox.
 
         """
-        Lx,Ly,Lz,xy,xz,yz = self.as_array()
-        return {'Lx': Lx,
-                'Ly': Ly,
-                'Lz': Lz,
-                'xy': xy,
-                'xz': xz,
-                'yz': yz,
-                'convention': self._convention
-               }
+        Lx, Ly, Lz, xy, xz, yz = self.as_array()
+        return {
+            "Lx": Lx,
+            "Ly": Ly,
+            "Lz": Lz,
+            "xy": xy,
+            "xz": xz,
+            "yz": yz,
+            "convention": self._convention,
+        }
 
     def wrap(self, positions):
         """Wrap positions subject to periodic boundary conditions.
@@ -356,6 +367,7 @@ class TriclinicBox(Volume):
         r = self.fraction_to_coordinate(x)
         return r
 
+
 class Cuboid(TriclinicBox):
     r"""Orthorhombic box.
 
@@ -374,8 +386,9 @@ class Cuboid(TriclinicBox):
         Length along the :math:`z` axis.
 
     """
+
     def __init__(self, Lx, Ly, Lz):
-        super().__init__(Lx,Ly,Lz,0,0,0)
+        super().__init__(Lx, Ly, Lz, 0, 0, 0)
 
     @classmethod
     def from_json(cls, data):
@@ -407,10 +420,12 @@ class Cuboid(TriclinicBox):
             The serialized Cuboid.
 
         """
-        return {'Lx': self.a[0],
-                'Ly': self.b[1],
-                'Lz': self.c[2],
-               }
+        return {
+            "Lx": self.a[0],
+            "Ly": self.b[1],
+            "Lz": self.c[2],
+        }
+
 
 class Cube(Cuboid):
     r"""Cubic box.
@@ -424,8 +439,9 @@ class Cube(Cuboid):
         The edge length of the cube.
 
     """
+
     def __init__(self, L):
-        super().__init__(L,L,L)
+        super().__init__(L, L, L)
 
     @classmethod
     def from_json(cls, data):
@@ -456,7 +472,8 @@ class Cube(Cuboid):
             The serialized Cube.
 
         """
-        return {'L': self.a[0]}
+        return {"L": self.a[0]}
+
 
 class Area(Extent):
     r"""Two-dimensional region of space.
@@ -515,27 +532,27 @@ class ObliqueArea(Area):
 
     """
 
-    def __init__(self, Lx, Ly, xy, convention='LAMMPS'):
+    def __init__(self, Lx, Ly, xy, convention="LAMMPS"):
         if Lx <= 0 or Ly <= 0:
-            raise ValueError('All side lengths must be positive.')
+            raise ValueError("All side lengths must be positive.")
 
         convention = convention.upper()
-        if convention == 'LAMMPS':
-            a = (Lx,0)
-            b = (xy,Ly)
-        elif convention == 'HOOMD':
-            a = (Lx,0)
-            b = (xy*Ly,Ly)
+        if convention == "LAMMPS":
+            a = (Lx, 0)
+            b = (xy, Ly)
+        elif convention == "HOOMD":
+            a = (Lx, 0)
+            b = (xy * Ly, Ly)
         else:
-            raise ValueError('Triclinic convention must be LAMMPS or HOOMD')
+            raise ValueError("Triclinic convention must be LAMMPS or HOOMD")
 
         self.a = numpy.asarray(a, dtype=numpy.float64)
         self.b = numpy.asarray(b, dtype=numpy.float64)
 
         box_vec = self.a + self.b
-        self._low = -0.5*box_vec
-        self._high = 0.5*box_vec
-        self._extent = numpy.linalg.norm(numpy.cross(self.a,self.b))
+        self._low = -0.5 * box_vec
+        self._high = 0.5 * box_vec
+        self._extent = numpy.linalg.norm(numpy.cross(self.a, self.b))
         self._convention = convention
 
     @classmethod
@@ -592,13 +609,13 @@ class ObliqueArea(Area):
 
         Lx = self.a[0]
         Ly = self.b[1]
-        if convention == 'LAMMPS':
+        if convention == "LAMMPS":
             xy = self.b[0]
-        elif convention == 'HOOMD':
-            xy = self.b[0]/self.b[1]
+        elif convention == "HOOMD":
+            xy = self.b[0] / self.b[1]
         else:
-            raise TypeError('Convention must be HOOMD or LAMMPS')
-        return numpy.array([Lx,Ly,xy])
+            raise TypeError("Convention must be HOOMD or LAMMPS")
+        return numpy.array([Lx, Ly, xy])
 
     def coordinate_to_fraction(self, r):
         r"""Make fractional coordinates from Cartesian coordinates.
@@ -609,9 +626,11 @@ class ObliqueArea(Area):
 
         .. math::
 
-            \mathbf{r} = \mathbf{r}_{\rm low} + (\mathbf{a}\quad\mathbf{b}) \cdot \mathbf{x}
+            \mathbf{r} = \mathbf{r}_{\rm low}
+                + (\mathbf{a}\quad\mathbf{b}) \cdot \mathbf{x}
 
-        where :math:`\mathbf{r}_{\rm low}` is the lower bound of the box, i.e., :attr:`low`.
+        where :math:`\mathbf{r}_{\rm low}` is the lower bound of the box,
+        i.e., :attr:`low`.
 
         Parameters
         ----------
@@ -624,19 +643,19 @@ class ObliqueArea(Area):
             Fractional coordinates **x** corresponding to **r**.
 
         """
-        Lx,Ly,xy = self.as_array('LAMMPS')
+        Lx, Ly, xy = self.as_array("LAMMPS")
 
         # get difference from lower bound
         dx = -self.low + r
         is_1d = False
         if len(dx.shape) == 1:
-            dx = dx[numpy.newaxis,...]
+            dx = dx[numpy.newaxis, ...]
             is_1d = True
 
         # make fractional coordinate
         x = numpy.zeros_like(dx)
-        x[:,0] = (1.0/Lx)*dx[...,0] + (-xy/(Lx*Ly))*dx[...,1]
-        x[:,1] = (1.0/Ly)*dx[...,1]
+        x[:, 0] = (1.0 / Lx) * dx[..., 0] + (-xy / (Lx * Ly)) * dx[..., 1]
+        x[:, 1] = (1.0 / Ly) * dx[..., 1]
         if is_1d:
             x = x[0]
 
@@ -660,16 +679,16 @@ class ObliqueArea(Area):
             Cartesian coordinates **r** corresponding to **x**.
 
         """
-        Lx,Ly,xy = self.as_array('LAMMPS')
+        Lx, Ly, xy = self.as_array("LAMMPS")
 
         # make real coordinate
         r = numpy.array(x)
         is_1d = False
         if len(r.shape) == 1:
-            r = r[numpy.newaxis,...]
+            r = r[numpy.newaxis, ...]
             is_1d = True
-        r[:,0] = Lx*r[...,0] + xy*r[...,1]
-        r[:,1] = Ly*r[...,1]
+        r[:, 0] = Lx * r[..., 0] + xy * r[..., 1]
+        r[:, 1] = Ly * r[..., 1]
         r += self.low
         if is_1d:
             r = r[0]
@@ -689,12 +708,8 @@ class ObliqueArea(Area):
             The serialized ObliqueArea.
 
         """
-        Lx,Ly,xy = self.as_array()
-        return {'Lx': Lx,
-                'Ly': Ly,
-                'xy': xy,
-                'convention': self._convention
-               }
+        Lx, Ly, xy = self.as_array()
+        return {"Lx": Lx, "Ly": Ly, "xy": xy, "convention": self._convention}
 
     def wrap(self, positions):
         """Wrap positions subject to periodic boundary conditions.
@@ -716,9 +731,10 @@ class ObliqueArea(Area):
 
         """
         x = self.coordinate_to_fraction(positions)
-        x -= numpy.round(x-0.5)
+        x -= numpy.round(x - 0.5)
         r = self.fraction_to_coordinate(x)
         return r
+
 
 class Rectangle(ObliqueArea):
     r"""Rectangle box.
@@ -736,8 +752,9 @@ class Rectangle(ObliqueArea):
         Length along the :math:`y` axis..
 
     """
+
     def __init__(self, Lx, Ly):
-        super().__init__(Lx,Ly,0)
+        super().__init__(Lx, Ly, 0)
 
     @classmethod
     def from_json(cls, data):
@@ -769,9 +786,11 @@ class Rectangle(ObliqueArea):
             The serialized Rectangle.
 
         """
-        return {'Lx': self.a[0],
-                'Ly': self.b[1],
-               }
+        return {
+            "Lx": self.a[0],
+            "Ly": self.b[1],
+        }
+
 
 class Square(Rectangle):
     r"""Square box.
@@ -785,8 +804,9 @@ class Square(Rectangle):
         The edge length of the square.
 
     """
+
     def __init__(self, L):
-        super().__init__(L,L)
+        super().__init__(L, L)
 
     @classmethod
     def from_json(cls, data):
@@ -817,4 +837,4 @@ class Square(Rectangle):
             The serialized Square.
 
         """
-        return {'L': self.a[0]}
+        return {"L": self.a[0]}

--- a/relentless/model/potential/__init__.py
+++ b/relentless/model/potential/__init__.py
@@ -28,11 +28,6 @@ Developer classes
     PairParameters
 
 """
-from .potential import (
-    Parameters,
-    Potential,
-    )
-
 from .pair import (
     Depletion,
     LennardJones,
@@ -40,4 +35,5 @@ from .pair import (
     PairPotential,
     PairSpline,
     Yukawa,
-    )
+)
+from .potential import Parameters, Potential

--- a/relentless/model/potential/pair.py
+++ b/relentless/model/potential/pair.py
@@ -2,10 +2,11 @@ import abc
 
 import numpy
 
-from relentless import collections
-from relentless import math
+from relentless import collections, math
 from relentless.model import variable
+
 from . import potential
+
 
 class PairParameters(potential.Parameters):
     """Parameters for pairs of types.
@@ -75,8 +76,6 @@ class PairParameters(potential.Parameters):
     objects. To get the *value* of all parameters, use :meth:`evaluate`::
 
         >>> coeff['A','A']['epsilon'] = relentless.variable.DesignVariable(1.0)
-        >>> print(coeff['A','A'])
-        {'epsilon':<relentless.variable.DesignVariable object at 0x561124456>, 'sigma':2.5}
         >>> print(coeff.evaluate(('A','A')))
         {'epsilon':1.0, 'sigma':2.5}
 
@@ -92,6 +91,7 @@ class PairParameters(potential.Parameters):
         {'epsilon':0.5, 'sigma':0.1}
 
     """
+
     def __init__(self, types, params):
         super().__init__(types, params)
 
@@ -117,6 +117,7 @@ class PairParameters(potential.Parameters):
     def pairs(self):
         """tuple[tuple[str]]: Pairs in matrix."""
         return self._per_pair.pairs
+
 
 class PairPotential(potential.Potential):
     r"""Abstract base class for a pair potential.
@@ -206,22 +207,23 @@ class PairPotential(potential.Potential):
         Parameters of the potential for each pair.
 
     """
+
     def __init__(self, types, params):
         # force in standard potential parameters if they are not explicitly set
         params = list(params)
-        if 'rmin' not in params:
-            params.append('rmin')
-        if 'rmax' not in params:
-            params.append('rmax')
-        if 'shift' not in params:
-            params.append('shift')
+        if "rmin" not in params:
+            params.append("rmin")
+        if "rmax" not in params:
+            params.append("rmax")
+        if "shift" not in params:
+            params.append("shift")
 
         super().__init__(types, params, PairParameters)
 
         for p in self.coeff:
-            self.coeff[p]['rmin'] = False
-            self.coeff[p]['rmax'] = False
-            self.coeff[p]['shift'] = False
+            self.coeff[p]["rmin"] = False
+            self.coeff[p]["rmax"] = False
+            self.coeff[p]["shift"] = False
 
     def energy(self, pair, r):
         """Evaluate pair energy.
@@ -251,30 +253,30 @@ class PairPotential(potential.Potential):
 
         """
         params = self.coeff.evaluate(pair)
-        r,u,scalar_r = self._zeros(r)
+        r, u, scalar_r = self._zeros(r)
         if any(r < 0):
-            raise ValueError('r cannot be negative')
+            raise ValueError("r cannot be negative")
 
         # evaluate at points below rmax (if set) first, including rmin cutoff (if set)
         flags = numpy.ones(r.shape[0], dtype=bool)
-        if params['rmin'] is not False:
-            range_ = r < params['rmin']
+        if params["rmin"] is not False:
+            range_ = r < params["rmin"]
             flags[range_] = False
-            u[range_] = self._energy(params['rmin'], **params)
-        if params['rmax'] is not False:
-            flags[r > params['rmax']] = False
+            u[range_] = self._energy(params["rmin"], **params)
+        if params["rmax"] is not False:
+            flags[r > params["rmax"]] = False
         u[flags] = self._energy(r[flags], **params)
 
         # if rmax is set, truncate or shift depending on the mode
-        if params['rmax'] is not False:
+        if params["rmax"] is not False:
             # with shifting, move the whole potential up
             # otherwise, set energy to constant for any r beyond rmax
-            if params['shift']:
-                u[r <= params['rmax']] -= self._energy(params['rmax'], **params)
+            if params["shift"]:
+                u[r <= params["rmax"]] -= self._energy(params["rmax"], **params)
             else:
-                u[r > params['rmax']] = self._energy(params['rmax'], **params)
-        elif params['shift'] is True:
-            raise ValueError('Cannot shift potential without rmax')
+                u[r > params["rmax"]] = self._energy(params["rmax"], **params)
+        elif params["shift"] is True:
+            raise ValueError("Cannot shift potential without rmax")
 
         # coerce u back into shape of the input
         if scalar_r:
@@ -307,16 +309,16 @@ class PairPotential(potential.Potential):
 
         """
         params = self.coeff.evaluate(pair)
-        r,f,scalar_r = self._zeros(r)
+        r, f, scalar_r = self._zeros(r)
         if any(r < 0):
-            raise ValueError('r cannot be negative')
+            raise ValueError("r cannot be negative")
 
         # only evaluate at points inside [rmin,rmax], if specified
         flags = numpy.ones(r.shape[0], dtype=bool)
-        if params['rmin'] is not False:
-            flags[r < params['rmin']] = False
-        if params['rmax'] is not False:
-            flags[r > params['rmax']] = False
+        if params["rmin"] is not False:
+            flags[r < params["rmin"]] = False
+        if params["rmax"] is not False:
+            flags[r > params["rmax"]] = False
         f[flags] = self._force(r[flags], **params)
 
         # coerce f back into shape of the input
@@ -362,17 +364,20 @@ class PairPotential(potential.Potential):
 
         """
         params = self.coeff.evaluate(pair)
-        r,deriv,scalar_r = self._zeros(r)
+        r, deriv, scalar_r = self._zeros(r)
         if any(r < 0):
-            raise ValueError('r cannot be negative')
+            raise ValueError("r cannot be negative")
         if not isinstance(var, variable.Variable):
-            raise TypeError('Parameter with respect to which to take the derivative must be a Variable.')
+            raise TypeError(
+                "Parameter with respect to which to take the derivative"
+                " must be a Variable."
+            )
 
         flags = numpy.ones(r.shape[0], dtype=bool)
 
         for p in self.coeff.params:
             # skip shift parameter
-            if p == 'shift':
+            if p == "shift":
                 continue
 
             # try to take chain rule w.r.t. variable first
@@ -389,34 +394,38 @@ class PairPotential(potential.Potential):
                 continue
 
             # now take the parameter derivative
-            if p=='rmin':
+            if p == "rmin":
                 # rmin deriv
-                flags = r < params['rmin']
-                deriv[flags] += -self._force(params['rmin'], **params)*dp_dvar
-            elif p=='rmax':
+                flags = r < params["rmin"]
+                deriv[flags] += -self._force(params["rmin"], **params) * dp_dvar
+            elif p == "rmax":
                 # rmax deriv
-                if params['shift']:
-                    flags = r <= params['rmax']
-                    deriv[flags] += self._force(params['rmax'], **params)*dp_dvar
+                if params["shift"]:
+                    flags = r <= params["rmax"]
+                    deriv[flags] += self._force(params["rmax"], **params) * dp_dvar
                 else:
-                    flags = r > params['rmax']
-                    deriv[flags] += -self._force(params['rmax'], **params)*dp_dvar
+                    flags = r > params["rmax"]
+                    deriv[flags] += -self._force(params["rmax"], **params) * dp_dvar
             else:
                 # regular parameter derivative
                 below = numpy.zeros(r.shape[0], dtype=bool)
-                if params['rmin'] is not False:
-                    below = r < params['rmin']
-                    deriv[below] += self._derivative(p, params['rmin'], **params)*dp_dvar
+                if params["rmin"] is not False:
+                    below = r < params["rmin"]
+                    deriv[below] += (
+                        self._derivative(p, params["rmin"], **params) * dp_dvar
+                    )
                 above = numpy.zeros(r.shape[0], dtype=bool)
-                if params['rmax'] is not False:
-                    above = r > params['rmax']
-                    deriv[above] += self._derivative(p, params['rmax'], **params)*dp_dvar
-                elif params['shift']:
-                    raise ValueError('Cannot shift without setting rmax.')
+                if params["rmax"] is not False:
+                    above = r > params["rmax"]
+                    deriv[above] += (
+                        self._derivative(p, params["rmax"], **params) * dp_dvar
+                    )
+                elif params["shift"]:
+                    raise ValueError("Cannot shift without setting rmax.")
                 flags = numpy.logical_and(~below, ~above)
-                deriv[flags] += self._derivative(p, r[flags], **params)*dp_dvar
-                if params['shift']:
-                    deriv -= self._derivative(p, params['rmax'], **params)*dp_dvar
+                deriv[flags] += self._derivative(p, r[flags], **params) * dp_dvar
+                if params["shift"]:
+                    deriv -= self._derivative(p, params["rmax"], **params) * dp_dvar
 
         # coerce derivative back into shape of the input
         if scalar_r:
@@ -499,6 +508,7 @@ class PairPotential(potential.Potential):
         """
         pass
 
+
 class Depletion(PairPotential):
     r"""Depletion pair potential.
 
@@ -507,8 +517,10 @@ class Depletion(PairPotential):
 
     .. math::
 
-        u(r) = -\frac{\pi P}{12 r} \left[\frac{1}{2}(\sigma_i+\sigma_j)+\sigma_d-r\right]^2
-            \left[r^2+r(\sigma_i+\sigma_j+2\sigma_d)-\frac{3}{4}(\sigma_i-\sigma_j)^2\right]
+        u(r) = -\frac{\pi P}{12 r}
+            \left[\frac{1}{2}(\sigma_i+\sigma_j)+\sigma_d-r\right]^2
+            \left[r^2+r(\sigma_i+\sigma_j+2\sigma_d) \right.
+            \left.-\frac{3}{4}(\sigma_i-\sigma_j)^2\right]
 
     where :math:`r` is the distance between two particles. The parameters for
     each :math:`(i,j)` pair are:
@@ -563,8 +575,9 @@ class Depletion(PairPotential):
         >>> u.coeff['A','B'].update({'sigma_i': 1.0, 'sigma_j': 2.0})
 
     """
+
     def __init__(self, types):
-        super().__init__(types=types, params=('P','sigma_i','sigma_j','sigma_d'))
+        super().__init__(types=types, params=("P", "sigma_i", "sigma_j", "sigma_d"))
 
     class Cutoff(variable.DependentVariable):
         r"""Physical cutoff for depletion potential.
@@ -586,38 +599,45 @@ class Depletion(PairPotential):
             Diameter :math:`\sigma_d` of depletant.
 
         """
+
         def __init__(self, sigma_i, sigma_j, sigma_d):
             super().__init__(sigma_i=sigma_i, sigma_j=sigma_j, sigma_d=sigma_d)
 
         def compute(self, sigma_i, sigma_j, sigma_d):
-            return 0.5*(sigma_i + sigma_j) + sigma_d
+            return 0.5 * (sigma_i + sigma_j) + sigma_d
 
         def compute_derivative(self, param, sigma_i, sigma_j, sigma_d):
-            if param == 'sigma_i':
+            if param == "sigma_i":
                 return 0.5
-            elif param == 'sigma_j':
+            elif param == "sigma_j":
                 return 0.5
-            elif param == 'sigma_d':
+            elif param == "sigma_d":
                 return 1.0
             else:
-                raise ValueError('Unknown parameter')
+                raise ValueError("Unknown parameter")
 
     def energy(self, pair, r):
         # Override parent method to set rmax as cutoff
-        if self.coeff[pair]['rmax'] is False:
-            self.coeff[pair]['rmax'] = self.Cutoff(self.coeff[pair]['sigma_i'],
-                                                   self.coeff[pair]['sigma_j'],
-                                                   self.coeff[pair]['sigma_d'])
+        if self.coeff[pair]["rmax"] is False:
+            self.coeff[pair]["rmax"] = self.Cutoff(
+                self.coeff[pair]["sigma_i"],
+                self.coeff[pair]["sigma_j"],
+                self.coeff[pair]["sigma_d"],
+            )
         return super().energy(pair, r)
 
     def _energy(self, r, P, sigma_i, sigma_j, sigma_d, **params):
-        if sigma_i<=0 or sigma_j<=0 or sigma_d<=0:
-            raise ValueError('sigma_i, sigma_j, and sigma_d must all be positive')
-        r,u,s = self._zeros(r)
+        if sigma_i <= 0 or sigma_j <= 0 or sigma_d <= 0:
+            raise ValueError("sigma_i, sigma_j, and sigma_d must all be positive")
+        r, u, s = self._zeros(r)
 
-        p1 = (0.5*(sigma_i + sigma_j) + sigma_d - r)**2
-        p2 = r**2 + r*(sigma_i + sigma_j + 2.*sigma_d) - 0.75*(sigma_i - sigma_j)**2
-        u = -(numpy.pi*P*p1*p2)/(12.*r)
+        p1 = (0.5 * (sigma_i + sigma_j) + sigma_d - r) ** 2
+        p2 = (
+            r**2
+            + r * (sigma_i + sigma_j + 2.0 * sigma_d)
+            - 0.75 * (sigma_i - sigma_j) ** 2
+        )
+        u = -(numpy.pi * P * p1 * p2) / (12.0 * r)
 
         if s:
             u = u.item()
@@ -625,20 +645,22 @@ class Depletion(PairPotential):
 
     def force(self, pair, r):
         # Override parent method to set rmax as cutoff
-        if self.coeff[pair]['rmax'] is False:
-            self.coeff[pair]['rmax'] = self.Cutoff(self.coeff[pair]['sigma_i'],
-                                                   self.coeff[pair]['sigma_j'],
-                                                   self.coeff[pair]['sigma_d'])
+        if self.coeff[pair]["rmax"] is False:
+            self.coeff[pair]["rmax"] = self.Cutoff(
+                self.coeff[pair]["sigma_i"],
+                self.coeff[pair]["sigma_j"],
+                self.coeff[pair]["sigma_d"],
+            )
         return super().force(pair, r)
 
     def _force(self, r, P, sigma_i, sigma_j, sigma_d, **params):
-        if sigma_i<=0 or sigma_j<=0 or sigma_d<=0:
-            raise ValueError('sigma_i, sigma_j, and sigma_d must all be positive')
-        r,f,s = self._zeros(r)
+        if sigma_i <= 0 or sigma_j <= 0 or sigma_d <= 0:
+            raise ValueError("sigma_i, sigma_j, and sigma_d must all be positive")
+        r, f, s = self._zeros(r)
 
-        p1 = r**2 - 0.25*(sigma_i - sigma_j)**2
-        p2 = (0.5*(sigma_i + sigma_j) + sigma_d)**2 - r**2
-        f = -(numpy.pi*P*p1*p2)/(4.*r**2)
+        p1 = r**2 - 0.25 * (sigma_i - sigma_j) ** 2
+        p2 = (0.5 * (sigma_i + sigma_j) + sigma_d) ** 2 - r**2
+        f = -(numpy.pi * P * p1 * p2) / (4.0 * r**2)
 
         if s:
             f = f.item()
@@ -646,42 +668,64 @@ class Depletion(PairPotential):
 
     def derivative(self, pair, var, r):
         # Override parent method to set rmax as cutoff
-        if self.coeff[pair]['rmax'] is False:
-            self.coeff[pair]['rmax'] = self.Cutoff(self.coeff[pair]['sigma_i'],
-                                                   self.coeff[pair]['sigma_j'],
-                                                   self.coeff[pair]['sigma_d'])
+        if self.coeff[pair]["rmax"] is False:
+            self.coeff[pair]["rmax"] = self.Cutoff(
+                self.coeff[pair]["sigma_i"],
+                self.coeff[pair]["sigma_j"],
+                self.coeff[pair]["sigma_d"],
+            )
         return super().derivative(pair, var, r)
 
     def _derivative(self, param, r, P, sigma_i, sigma_j, sigma_d, **params):
-        if sigma_i<=0 or sigma_j<=0 or sigma_d<=0:
-            raise ValueError('sigma_i, sigma_j, and sigma_d must all be positive')
-        r,d,s = self._zeros(r)
+        if sigma_i <= 0 or sigma_j <= 0 or sigma_d <= 0:
+            raise ValueError("sigma_i, sigma_j, and sigma_d must all be positive")
+        r, d, s = self._zeros(r)
 
-        if param == 'P':
-            p1 = (0.5*(sigma_i + sigma_j) + sigma_d - r)**2
-            p2 = r**2 + r*(sigma_i + sigma_j + 2.*sigma_d) - 0.75*(sigma_i - sigma_j)**2
-            d = -(numpy.pi*p1*p2)/(12.*r)
-        elif param == 'sigma_i':
-            p1 = ((0.5*(sigma_i + sigma_j) + sigma_d - r)
-                 *(r**2 + r*(sigma_i + sigma_j + 2.*sigma_d) - 0.75*(sigma_i - sigma_j)**2))
-            p2 = (r + 1.5*(sigma_j - sigma_i))*(0.5*(sigma_i + sigma_j) + sigma_d - r)**2
-            d = -(numpy.pi*P*(p1 + p2))/(12.*r)
-        elif param == 'sigma_j':
-            p1 = ((0.5*(sigma_i + sigma_j) + sigma_d - r)
-                 *(r**2 + r*(sigma_i + sigma_j + 2.*sigma_d) - 0.75*(sigma_i - sigma_j)**2))
-            p2 = (r + 1.5*(sigma_i - sigma_j))*(0.5*(sigma_i + sigma_j) + sigma_d - r)**2
-            d = -(numpy.pi*P*(p1 + p2))/(12.*r)
-        elif param == 'sigma_d':
-            p1 = ((sigma_i + sigma_j + 2.*sigma_d - 2.*r)
-                 *(r**2 + r*(sigma_i + sigma_j + 2.*sigma_d) - 0.75*(sigma_i - sigma_j)**2))
-            p2 = 2.*r*(0.5*(sigma_i + sigma_j) + sigma_d - r)**2
-            d = -(numpy.pi*P*(p1 + p2))/(12.*r)
+        if param == "P":
+            p1 = (0.5 * (sigma_i + sigma_j) + sigma_d - r) ** 2
+            p2 = (
+                r**2
+                + r * (sigma_i + sigma_j + 2.0 * sigma_d)
+                - 0.75 * (sigma_i - sigma_j) ** 2
+            )
+            d = -(numpy.pi * p1 * p2) / (12.0 * r)
+        elif param == "sigma_i":
+            p1 = (0.5 * (sigma_i + sigma_j) + sigma_d - r) * (
+                r**2
+                + r * (sigma_i + sigma_j + 2.0 * sigma_d)
+                - 0.75 * (sigma_i - sigma_j) ** 2
+            )
+            p2 = (r + 1.5 * (sigma_j - sigma_i)) * (
+                0.5 * (sigma_i + sigma_j) + sigma_d - r
+            ) ** 2
+            d = -(numpy.pi * P * (p1 + p2)) / (12.0 * r)
+        elif param == "sigma_j":
+            p1 = (0.5 * (sigma_i + sigma_j) + sigma_d - r) * (
+                r**2
+                + r * (sigma_i + sigma_j + 2.0 * sigma_d)
+                - 0.75 * (sigma_i - sigma_j) ** 2
+            )
+            p2 = (r + 1.5 * (sigma_i - sigma_j)) * (
+                0.5 * (sigma_i + sigma_j) + sigma_d - r
+            ) ** 2
+            d = -(numpy.pi * P * (p1 + p2)) / (12.0 * r)
+        elif param == "sigma_d":
+            p1 = (sigma_i + sigma_j + 2.0 * sigma_d - 2.0 * r) * (
+                r**2
+                + r * (sigma_i + sigma_j + 2.0 * sigma_d)
+                - 0.75 * (sigma_i - sigma_j) ** 2
+            )
+            p2 = 2.0 * r * (0.5 * (sigma_i + sigma_j) + sigma_d - r) ** 2
+            d = -(numpy.pi * P * (p1 + p2)) / (12.0 * r)
         else:
-            raise ValueError('The depletion parameters are P, sigma_i, sigma_j, and sigma_d.')
+            raise ValueError(
+                "The depletion parameters are P, sigma_i, sigma_j, and sigma_d."
+            )
 
         if s:
             d = d.item()
         return d
+
 
 class LennardJones(PairPotential):
     r"""Lennard-Jones 12-6 pair potential.
@@ -741,18 +785,19 @@ class LennardJones(PairPotential):
         0.0
 
     """
+
     def __init__(self, types):
-        super().__init__(types=types, params=('epsilon','sigma'))
+        super().__init__(types=types, params=("epsilon", "sigma"))
 
     def _energy(self, r, epsilon, sigma, **params):
         if sigma < 0:
-            raise ValueError('sigma must be positive')
-        r,u,s = self._zeros(r)
-        flags = ~numpy.isclose(r,0)
+            raise ValueError("sigma must be positive")
+        r, u, s = self._zeros(r)
+        flags = ~numpy.isclose(r, 0)
 
         # evaluate potential
-        r6_inv = numpy.power(sigma/r[flags], 6)
-        u[flags] = 4.*epsilon*(r6_inv**2 - r6_inv)
+        r6_inv = numpy.power(sigma / r[flags], 6)
+        u[flags] = 4.0 * epsilon * (r6_inv**2 - r6_inv)
         u[~flags] = numpy.inf
 
         if s:
@@ -761,14 +806,14 @@ class LennardJones(PairPotential):
 
     def _force(self, r, epsilon, sigma, **params):
         if sigma < 0:
-            raise ValueError('sigma must be positive')
-        r,f,s = self._zeros(r)
-        flags = ~numpy.isclose(r,0)
+            raise ValueError("sigma must be positive")
+        r, f, s = self._zeros(r)
+        flags = ~numpy.isclose(r, 0)
 
         # evaluate force
-        rinv = 1./r[flags]
-        r6_inv = numpy.power(sigma*rinv, 6)
-        f[flags] = (48.*epsilon*rinv)*(r6_inv**2-0.5*r6_inv)
+        rinv = 1.0 / r[flags]
+        r6_inv = numpy.power(sigma * rinv, 6)
+        f[flags] = (48.0 * epsilon * rinv) * (r6_inv**2 - 0.5 * r6_inv)
         f[~flags] = numpy.inf
 
         if s:
@@ -777,23 +822,24 @@ class LennardJones(PairPotential):
 
     def _derivative(self, param, r, epsilon, sigma, **params):
         if sigma < 0:
-            raise ValueError('sigma must be positive')
-        r,d,s = self._zeros(r)
-        flags = ~numpy.isclose(r,0)
+            raise ValueError("sigma must be positive")
+        r, d, s = self._zeros(r)
+        flags = ~numpy.isclose(r, 0)
 
         # evaluate derivative
-        r6_inv = numpy.power(sigma/r[flags], 6)
-        if param == 'epsilon':
-            d[flags] = 4*(r6_inv**2 - r6_inv)
-        elif param == 'sigma':
-            d[flags] = (48.*epsilon/sigma)*(r6_inv**2 - 0.5*r6_inv)
+        r6_inv = numpy.power(sigma / r[flags], 6)
+        if param == "epsilon":
+            d[flags] = 4 * (r6_inv**2 - r6_inv)
+        elif param == "sigma":
+            d[flags] = (48.0 * epsilon / sigma) * (r6_inv**2 - 0.5 * r6_inv)
         else:
-            raise ValueError('The Lennard-Jones parameters are sigma and epsilon.')
+            raise ValueError("The Lennard-Jones parameters are sigma and epsilon.")
         d[~flags] = numpy.inf
 
         if s:
             d = d.item()
         return d
+
 
 class PairSpline(PairPotential):
     """Spline pair potential.
@@ -808,11 +854,12 @@ class PairSpline(PairPotential):
     num_knots : int
         Number of knots.
     mode : str
-        Mode for storing the values of the knots in :class:`~relentless.variable.Variable`
-        that can be optimized. If ``mode='value'``, the knot amplitudes are stored
-        directly. If ``mode='diff'``, the amplitude of the *last* knot is stored
-        directly, and differences between neighboring knots are stored for all
-        other knots. Defaults to ``'diff'``.
+        Mode for storing the values of the knots in
+        :class:`~relentless.variable.Variable` that can be optimized. If
+        ``mode='value'``, the knot amplitudes are stored directly. If
+        ``mode='diff'``, the amplitude of the *last* knot is stored directly,
+        and differences between neighboring knots are stored for all other knots.
+        Defaults to ``'diff'``.
 
     Raises
     ------
@@ -835,25 +882,26 @@ class PairSpline(PairPotential):
             k.value = 1.0
 
     """
-    valid_modes = ('value','diff')
 
-    def __init__(self, types, num_knots, mode='diff'):
-        if isinstance(num_knots,int) and num_knots >= 2:
+    valid_modes = ("value", "diff")
+
+    def __init__(self, types, num_knots, mode="diff"):
+        if isinstance(num_knots, int) and num_knots >= 2:
             self._num_knots = num_knots
         else:
-            raise ValueError('Number of spline knots must be an integer >= 2.')
+            raise ValueError("Number of spline knots must be an integer >= 2.")
 
         if mode in self.valid_modes:
             self._mode = mode
         else:
-            raise ValueError('Invalid mode, choose from: ' + ','.join(self.valid_modes))
+            raise ValueError("Invalid mode, choose from: " + ",".join(self.valid_modes))
 
         params = []
         for i in range(self.num_knots):
-            ri,ki = self._knot_params(i)
+            ri, ki = self._knot_params(i)
             params.append(ri)
             params.append(ki)
-        super().__init__(types=types,params=params)
+        super().__init__(types=types, params=params)
 
     def from_array(self, pair, r, u):
         r"""Set up the potential from knot points.
@@ -880,26 +928,27 @@ class PairSpline(PairPotential):
         """
         # check that r and u have the right shape
         if len(r) != self.num_knots:
-            raise ValueError('r must have the same length as the number of knots')
+            raise ValueError("r must have the same length as the number of knots")
         if len(u) != self.num_knots:
-            raise ValueError('u must have the same length as the number of knots')
+            raise ValueError("u must have the same length as the number of knots")
 
         # convert to r,knot form given the mode
         rs = numpy.asarray(r, dtype=numpy.float64)
         ks = numpy.asarray(u, dtype=numpy.float64)
-        if self.mode == 'diff':
-            # difference is next knot minus my knot, with last knot fixed at its current value
+        if self.mode == "diff":
+            # difference is next knot minus my knot,
+            # with last knot fixed at its current value
             ks[:-1] -= ks[1:]
 
         # make all knots variables, but hold all r and the last knot const
         for i in range(self.num_knots):
-            ri,ki = self._knot_params(i)
+            ri, ki = self._knot_params(i)
             if self.coeff[pair][ri] is None:
                 self.coeff[pair][ri] = variable.IndependentVariable(rs[i])
             else:
                 self.coeff[pair][ri].value = rs[i]
             if self.coeff[pair][ki] is None:
-                if i < self.num_knots-1:
+                if i < self.num_knots - 1:
                     self.coeff[pair][ki] = variable.DesignVariable(ks[i])
                 else:
                     self.coeff[pair][ki] = variable.IndependentVariable(ks[i])
@@ -928,25 +977,25 @@ class PairSpline(PairPotential):
 
         """
         if not isinstance(i, int):
-            raise TypeError('Knots are keyed by integers')
-        return 'r-{}'.format(i), 'knot-{}'.format(i)
+            raise TypeError("Knots are keyed by integers")
+        return "r-{}".format(i), "knot-{}".format(i)
 
     def _energy(self, r, **params):
-        r,u,s = self._zeros(r)
+        r, u, s = self._zeros(r)
         u = self._interpolate(params)(r)
         if s:
             u = u.item()
         return u
 
     def _force(self, r, **params):
-        r,f,s = self._zeros(r)
+        r, f, s = self._zeros(r)
         f = -self._interpolate(params).derivative(r, 1)
         if s:
             f = f.item()
         return f
 
     def _derivative(self, param, r, **params):
-        r,d,s = self._zeros(r)
+        r, d, s = self._zeros(r)
         h = 0.001
 
         # perturb knot param value
@@ -957,7 +1006,7 @@ class PairSpline(PairPotential):
         f_low = self._interpolate(params)(r)
 
         params[param] = knot_p
-        d = (f_high - f_low)/(2*h)
+        d = (f_high - f_low) / (2 * h)
         if s:
             d = d.item()
         return d
@@ -979,11 +1028,11 @@ class PairSpline(PairPotential):
         r = numpy.zeros(self.num_knots)
         u = numpy.zeros(self.num_knots)
         for i in range(self.num_knots):
-            ri,ki = self._knot_params(i)
+            ri, ki = self._knot_params(i)
             r[i] = params[ri]
             u[i] = params[ki]
-        # reconstruct the energies from differences, starting from the end of the potential
-        if self.mode == 'diff':
+        # reconstruct the energies from differences, starting from the end
+        if self.mode == "diff":
             u = numpy.flip(numpy.cumsum(numpy.flip(u)))
         return math.Interpolator(x=r, y=u)
 
@@ -1014,22 +1063,23 @@ class PairSpline(PairPotential):
 
         """
         for i in range(self.num_knots):
-            ri,ki = self._knot_params(i)
+            ri, ki = self._knot_params(i)
             r = self.coeff[pair][ri]
             k = self.coeff[pair][ki]
-            yield r,k
+            yield r, k
 
     @property
     def design_variables(self):
         """tuple: Designable variables of the spline."""
         dvars = []
         for pair in self.coeff:
-            for r,k in self.knots(pair):
+            for r, k in self.knots(pair):
                 if isinstance(r, variable.DesignVariable):
                     dvars.append(r)
                 if isinstance(k, variable.DesignVariable):
                     dvars.append(k)
         return tuple(dvars)
+
 
 class Yukawa(PairPotential):
     r"""Yukawa pair potential.
@@ -1083,17 +1133,18 @@ class Yukawa(PairPotential):
         0.33689734995427334
 
     """
+
     def __init__(self, types):
-        super().__init__(types=types, params=('epsilon','kappa'))
+        super().__init__(types=types, params=("epsilon", "kappa"))
 
     def _energy(self, r, epsilon, kappa, **params):
         if kappa < 0:
-            raise ValueError('kappa must be positive')
-        r,u,s = self._zeros(r)
-        flags = ~numpy.isclose(r,0)
+            raise ValueError("kappa must be positive")
+        r, u, s = self._zeros(r)
+        flags = ~numpy.isclose(r, 0)
 
         # evaluate potential
-        u[flags] = epsilon*numpy.exp(-kappa*r[flags])/r[flags]
+        u[flags] = epsilon * numpy.exp(-kappa * r[flags]) / r[flags]
         u[~flags] = numpy.inf
 
         if s:
@@ -1102,12 +1153,17 @@ class Yukawa(PairPotential):
 
     def _force(self, r, epsilon, kappa, **params):
         if kappa < 0:
-            raise ValueError('kappa must be positive')
-        r,f,s = self._zeros(r)
-        flags = ~numpy.isclose(r,0)
+            raise ValueError("kappa must be positive")
+        r, f, s = self._zeros(r)
+        flags = ~numpy.isclose(r, 0)
 
         # evaluate force
-        f[flags] = epsilon*numpy.exp(-kappa*r[flags])*(1.+kappa*r[flags])/r[flags]**2
+        f[flags] = (
+            epsilon
+            * numpy.exp(-kappa * r[flags])
+            * (1.0 + kappa * r[flags])
+            / r[flags] ** 2
+        )
         f[~flags] = numpy.inf
 
         if s:
@@ -1116,18 +1172,18 @@ class Yukawa(PairPotential):
 
     def _derivative(self, param, r, epsilon, kappa, **params):
         if kappa < 0:
-            raise ValueError('kappa must be positive')
-        r,d,s = self._zeros(r)
-        flags = ~numpy.isclose(r,0)
+            raise ValueError("kappa must be positive")
+        r, d, s = self._zeros(r)
+        flags = ~numpy.isclose(r, 0)
 
         # evaluate derivative
-        if param == 'epsilon':
-            d[flags] = numpy.exp(-kappa*r[flags])/r[flags]
+        if param == "epsilon":
+            d[flags] = numpy.exp(-kappa * r[flags]) / r[flags]
             d[~flags] = numpy.inf
-        elif param == 'kappa':
-            d = -epsilon*numpy.exp(-kappa*r)
+        elif param == "kappa":
+            d = -epsilon * numpy.exp(-kappa * r)
         else:
-            raise ValueError('The Yukawa parameters are kappa and epsilon.')
+            raise ValueError("The Yukawa parameters are kappa and epsilon.")
 
         if s:
             d = d.item()

--- a/relentless/model/potential/potential.py
+++ b/relentless/model/potential/potential.py
@@ -6,6 +6,7 @@ import numpy
 from relentless import collections
 from relentless.model import variable
 
+
 class Parameters:
     """Parameters for types.
 
@@ -28,17 +29,18 @@ class Parameters:
         If ``params`` is not only strings.
 
     """
+
     def __init__(self, types, params):
         if len(types) == 0:
-            raise ValueError('Cannot initialize with empty types')
+            raise ValueError("Cannot initialize with empty types")
         if not all(isinstance(t, str) for t in types):
-            raise TypeError('All types must be strings')
+            raise TypeError("All types must be strings")
         self.types = tuple(types)
 
         if len(params) == 0:
-            raise ValueError('params cannot be initialized as empty')
+            raise ValueError("params cannot be initialized as empty")
         if not all(isinstance(p, str) for p in params):
-            raise TypeError('All parameters must be strings')
+            raise TypeError("All parameters must be strings")
         self.params = tuple(params)
 
         # shared params
@@ -78,7 +80,7 @@ class Parameters:
             elif self.shared[p] is not None:
                 v = self.shared[p]
             else:
-                raise ValueError('Parameter {} is not set for {}.'.format(p,str(key)))
+                raise ValueError("Parameter {} is not set for {}.".format(p, str(key)))
 
             # evaluate the variable
             if isinstance(v, variable.Variable):
@@ -86,11 +88,11 @@ class Parameters:
             elif numpy.isscalar(v):
                 params[p] = v
             else:
-                raise TypeError('Parameter type unrecognized')
+                raise TypeError("Parameter type unrecognized")
 
             # final check: error if variable is still not set
             if v is None:
-                raise ValueError('Parameter {} is not set for {}.'.format(p,str(key)))
+                raise ValueError("Parameter {} is not set for {}.".format(p, str(key)))
 
         return params
 
@@ -107,7 +109,7 @@ class Parameters:
         for key in self:
             data[str(key)] = self.evaluate(key)
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             json.dump(data, f, sort_keys=True, indent=4)
 
     def __getitem__(self, key):
@@ -116,7 +118,9 @@ class Parameters:
     def __setitem__(self, key, value):
         for p in value:
             if p not in self.params:
-                raise KeyError('Only the known parameters can be set in the coefficient matrix.')
+                raise KeyError(
+                    "Only the known parameters can be set in the coefficient matrix."
+                )
         self[key].clear()
         self[key].update(value)
 
@@ -130,6 +134,7 @@ class Parameters:
     def shared(self):
         """:class:`~relentless.collections.FixedKeyDict`: The shared parameters."""
         return self._shared
+
 
 class Potential(abc.ABC):
     """Abstract base class for interaction potential.
@@ -151,10 +156,11 @@ class Potential(abc.ABC):
         and ``params``.
 
     """
+
     def __init__(self, keys, params, container=None):
         if container is None:
             container = Parameters
-        self.coeff = container(keys,params)
+        self.coeff = container(keys, params)
 
     @abc.abstractmethod
     def energy(self, key, x):
@@ -247,8 +253,8 @@ class Potential(abc.ABC):
         s = numpy.isscalar(x)
         x = numpy.array(x, dtype=numpy.float64, ndmin=1)
         if len(x.shape) != 1:
-            raise TypeError('Potential coordinate must be 1D array.')
-        return x,numpy.zeros_like(x),s
+            raise TypeError("Potential coordinate must be 1D array.")
+        return x, numpy.zeros_like(x), s
 
     def save(self, filename):
         """Save the coefficient matrix to file as JSON data.

--- a/relentless/model/variable.py
+++ b/relentless/model/variable.py
@@ -83,6 +83,7 @@ from enum import Enum
 import networkx
 import numpy
 
+
 class Variable(abc.ABC):
     """Abstract base class for a variable.
 
@@ -131,15 +132,16 @@ class Variable(abc.ABC):
         -0.25
 
     """
+
     count = 0
     names = set()
 
     def __init__(self, name=None):
         self.id = Variable.count
         if name is None:
-            name = '__x[{}]'.format(self.id)
+            name = "__x[{}]".format(self.id)
         if name in self.names:
-            raise ValueError('Variable name already used')
+            raise ValueError("Variable name already used")
         else:
             self.names.add(name)
             self.name = name
@@ -195,6 +197,7 @@ class Variable(abc.ABC):
     def __str__(self):
         return str(self.value)
 
+
 class ConstantVariable(Variable):
     """Constant-value variable.
 
@@ -234,15 +237,17 @@ class ConstantVariable(Variable):
         If ``name`` is already used.
 
     """
+
     def __init__(self, value, name=None):
         if not isinstance(value, (float, int)):
-            raise TypeError('Constant values are only floats or ints')
+            raise TypeError("Constant values are only floats or ints")
         super().__init__(name=name)
         self._value = value
 
     @property
     def value(self):
         return self._value
+
 
 class IndependentVariable(Variable):
     """Independent quantity.
@@ -293,9 +298,10 @@ class IndependentVariable(Variable):
         If ``name`` is already used.
 
     """
+
     def __init__(self, value, name=None):
         if not isinstance(value, (float, int)):
-            raise TypeError('Independent variables are only float or int')
+            raise TypeError("Independent variables are only float or int")
         super().__init__(name=name)
         self._value = value
 
@@ -306,37 +312,46 @@ class IndependentVariable(Variable):
     @value.setter
     def value(self, value):
         if not isinstance(value, (float, int)):
-            raise TypeError('Independent variables are only float or int')
+            raise TypeError("Independent variables are only float or int")
         self._value = value
         graph.update(self)
 
     def __iadd__(self, val):
         """In-place addition of a variable with a scalar."""
         if isinstance(val, Variable):
-            raise TypeError('Variables are not allowed to operate in-place on another Variable')
+            raise TypeError(
+                "Variables are not allowed to operate in-place on another Variable"
+            )
         self.value += val
         return self
 
     def __isub__(self, val):
         """In-place subtraction of a variable with a scalar."""
         if isinstance(val, Variable):
-            raise TypeError('Variables are not allowed to operate in-place on another Variable')
+            raise TypeError(
+                "Variables are not allowed to operate in-place on another Variable"
+            )
         self.value -= val
         return self
 
     def __imul__(self, val):
         """In-place multiplication of a variable by a scalar."""
         if isinstance(val, Variable):
-            raise TypeError('Variables are not allowed to operate in-place on another Variable')
+            raise TypeError(
+                "Variables are not allowed to operate in-place on another Variable"
+            )
         self.value *= val
         return self
 
     def __itruediv__(self, val):
         """In-place division of a variable by a scalar."""
         if isinstance(val, Variable):
-            raise TypeError('Variables are not allowed to operate in-place on another Variable')
+            raise TypeError(
+                "Variables are not allowed to operate in-place on another Variable"
+            )
         self.value /= val
         return self
+
 
 class DesignVariable(IndependentVariable):
     """Constrained independent variable.
@@ -399,13 +414,14 @@ class DesignVariable(IndependentVariable):
             Variable is constrained to upper bound.
 
         """
+
         FREE = 0
         LOW = 1
         HIGH = 2
 
     def __init__(self, value, name=None, low=None, high=None):
         if not isinstance(value, (float, int)):
-            raise TypeError('Design variables are only float or int')
+            raise TypeError("Design variables are only float or int")
         super().__init__(name=name, value=value)
         self.low = low
         self.high = high
@@ -436,12 +452,12 @@ class DesignVariable(IndependentVariable):
             v = value
             b = DesignVariable.State.FREE
 
-        return v,b
+        return v, b
 
     @IndependentVariable.value.setter
     def value(self, value):
         if not isinstance(value, (float, int)):
-            raise TypeError('Design variables are only float or int')
+            raise TypeError("Design variables are only float or int")
         self._value, self._state = self.clamp(value)
         graph.update(self)
 
@@ -452,16 +468,16 @@ class DesignVariable(IndependentVariable):
 
     @low.setter
     def low(self, low):
-        if low is not None and not isinstance(low, (float,int)):
-            raise TypeError('Low bound must be a float or int')
+        if low is not None and not isinstance(low, (float, int)):
+            raise TypeError("Low bound must be a float or int")
         try:
             if low is None or self._high is None:
                 self._low = low
             elif low < self._high:
                 self._low = low
             else:
-                raise ValueError('The low bound must be less than the high bound')
-        except (AttributeError,TypeError):
+                raise ValueError("The low bound must be less than the high bound")
+        except (AttributeError, TypeError):
             self._low = low
 
         try:
@@ -476,16 +492,16 @@ class DesignVariable(IndependentVariable):
 
     @high.setter
     def high(self, high):
-        if high is not None and not isinstance(high, (float,int)):
-            raise TypeError('High bound must be a float or int')
+        if high is not None and not isinstance(high, (float, int)):
+            raise TypeError("High bound must be a float or int")
         try:
             if high is None or self._high is None:
                 self._high = high
             elif high > self._low:
                 self._high = high
             else:
-                raise ValueError('The high bound must be greater than the low bound')
-        except (AttributeError,TypeError):
+                raise ValueError("The high bound must be greater than the low bound")
+        except (AttributeError, TypeError):
             self._high = high
 
         try:
@@ -531,15 +547,16 @@ class DesignVariable(IndependentVariable):
         """
         return self.state is self.State.HIGH
 
+
 class DependentVariable(Variable):
     """Abstract base class for a variable that depends on other values.
 
     A dependent variable is composed from other variables. This is an abstract
-    base class for any such variable. In addition to the :attr:`~relentless.variable.Variable.value`
-    property of the :class:`Variable`, a :class:`DependentVariable` must also
-    define :math:`compute` and :meth:`compute_derivative` methods that define
-    how it (and its partial derivatives with respect to its dependencies) are
-    computed.
+    base class for any such variable. In addition to the
+    :attr:`~relentless.variable.Variable.value` property of the :class:`Variable`,
+    a :class:`DependentVariable` must also define :math:`compute` and
+    :meth:`compute_derivative` methods that define how it (and its partial
+    derivatives with respect to its dependencies) are computed.
 
     The names of the dependencies of the variable are automatically deduced
     by the base constructor using dictionary keys and keyword arguments and
@@ -563,6 +580,7 @@ class DependentVariable(Variable):
         Dependencies as an arbitrary number of keyword arguments.
 
     """
+
     def __init__(self, *vardicts, **kwvars):
         super().__init__()
 
@@ -642,11 +660,13 @@ class DependentVariable(Variable):
         """
         pass
 
+
 class UnaryOperator(DependentVariable):
     """Abstract base class for a value that depends on one variable.
 
-    Deriving classes still need to implement the :attr:`~relentless.variable.Variable.value`
-    and :meth:`~relentless.variable.DependentVariable._derivative` methods.
+    Deriving classes still need to implement the
+    :attr:`~relentless.variable.Variable.value` and
+    :meth:`~relentless.variable.DependentVariable._derivative` methods.
     :class:`UnaryOperator` is a convenience class implementing the constructor
     of a function that depends on one value, :math:`f(a)`.
 
@@ -656,8 +676,10 @@ class UnaryOperator(DependentVariable):
         The :class:`Variable` this value depends on.
 
     """
+
     def __init__(self, a):
         super().__init__(a=a)
+
 
 class SameAs(UnaryOperator):
     """Copy a value.
@@ -679,14 +701,16 @@ class SameAs(UnaryOperator):
         Variable to copy.
 
     """
+
     def compute(self, a):
         return a
 
     def compute_derivative(self, param, a):
-        if param == 'a':
+        if param == "a":
             return 1.0
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class Negation(UnaryOperator):
     r"""Takes the additive inverse of a value.
@@ -699,20 +723,23 @@ class Negation(UnaryOperator):
         The value.
 
     """
+
     def compute(self, a):
         return -a
 
     def compute_derivative(self, param, a):
-        if param == 'a':
+        if param == "a":
             return -1.0
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class BinaryOperator(DependentVariable):
     """Abstract base class for a value that depends on two variables.
 
-    Deriving classes still need to implement the :attr:`~relentless.variable.Variable.value`
-    and :meth:`~relentless.variable.DependentVariable._derivative` methods.
+    Deriving classes still need to implement the
+    :attr:`~relentless.variable.Variable.value` and
+    :meth:`~relentless.variable.DependentVariable._derivative` methods.
     :class:`BinaryOperator` is a convenience class implementing the constructor of
     a function that depends on two values, :math:`f(a,b)`.
 
@@ -724,8 +751,10 @@ class BinaryOperator(DependentVariable):
         The second :class:`Variable` this value depends on.
 
     """
+
     def __init__(self, a, b):
         super().__init__(a=a, b=b)
+
 
 class Sum(BinaryOperator):
     r"""Sum of two values.
@@ -740,16 +769,18 @@ class Sum(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
-        return a+b
+        return a + b
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             return 1.0
-        elif param == 'b':
+        elif param == "b":
             return 1.0
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class Difference(BinaryOperator):
     r"""Difference of two values.
@@ -764,16 +795,18 @@ class Difference(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
-        return a-b
+        return a - b
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             return 1.0
-        elif param == 'b':
+        elif param == "b":
             return -1.0
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class Product(BinaryOperator):
     r"""Product of two values.
@@ -788,16 +821,18 @@ class Product(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
-        return a*b
+        return a * b
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             return b
-        elif param == 'b':
+        elif param == "b":
             return a
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class Quotient(BinaryOperator):
     r"""Quotient of two values.
@@ -812,25 +847,27 @@ class Quotient(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
         if b != 0:
-            return a/b
+            return a / b
         else:
             return numpy.nan
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             if b != 0:
-                return 1.0/b
+                return 1.0 / b
             else:
                 return numpy.nan
-        elif param == 'b':
+        elif param == "b":
             if b != 0:
-                return -a/numpy.power(b, 2)
+                return -a / numpy.power(b, 2)
             else:
                 return numpy.nan
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class Power(BinaryOperator):
     r"""Takes a value to a power.
@@ -845,21 +882,23 @@ class Power(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
         return numpy.power(a, b)
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             if b == 0:
                 return 0.0
-            return b*numpy.power(a, b-1)
-        elif param == 'b':
+            return b * numpy.power(a, b - 1)
+        elif param == "b":
             if a == 0:
                 return 0.0
             else:
-                return numpy.log(a)*numpy.power(a, b)
+                return numpy.log(a) * numpy.power(a, b)
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class ArithmeticMean(BinaryOperator):
     r"""Arithmetic mean of two values.
@@ -880,16 +919,18 @@ class ArithmeticMean(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
-        return 0.5*(a+b)
+        return 0.5 * (a + b)
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             return 0.5
-        elif param == 'b':
+        elif param == "b":
             return 0.5
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class GeometricMean(BinaryOperator):
     r"""Geometric mean of two values.
@@ -910,22 +951,24 @@ class GeometricMean(BinaryOperator):
         Second value.
 
     """
+
     def compute(self, a, b):
-        return numpy.sqrt(a*b)
+        return numpy.sqrt(a * b)
 
     def compute_derivative(self, param, a, b):
-        if param == 'a':
+        if param == "a":
             if a != 0:
-                return 0.5*numpy.sqrt(b/a)
+                return 0.5 * numpy.sqrt(b / a)
             else:
                 return numpy.nan
-        elif param == 'b':
+        elif param == "b":
             if b != 0:
-                return 0.5*numpy.sqrt(a/b)
+                return 0.5 * numpy.sqrt(a / b)
             else:
                 return numpy.nan
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class VariableGraph:
     """Directed graph of variables and dependencies.
@@ -942,6 +985,7 @@ class VariableGraph:
     It is available as ``relentless.variable.graph``.
 
     """
+
     def __init__(self):
         self._graph = networkx.MultiDiGraph()
         self._is_acyclic = None
@@ -996,10 +1040,10 @@ class VariableGraph:
         """
         self._assert_in_graph(x)
         if not isinstance(x, DependentVariable):
-            raise TypeError('Dependencies can only be set for DependentVariable')
+            raise TypeError("Dependencies can only be set for DependentVariable")
 
         if set(x.params) != depends.keys():
-            raise KeyError('Not all dependencies are set')
+            raise KeyError("Not all dependencies are set")
 
         # remove any old edges and make new ones
         self._graph.remove_edges_from(self._graph.edges(x))
@@ -1035,7 +1079,7 @@ class VariableGraph:
         self._assert_is_variable(x)
         self._assert_in_graph(x)
         if not isinstance(x, IndependentVariable):
-            raise TypeError('Can only update independent variables')
+            raise TypeError("Can only update independent variables")
 
         for y in networkx.dfs_preorder_nodes(self._graph.reverse(), source=x):
             if isinstance(y, DependentVariable):
@@ -1073,9 +1117,9 @@ class VariableGraph:
             # evaluate the nodes, bottom up
             for y in networkx.dfs_postorder_nodes(self._graph, source=x):
                 if isinstance(y, DependentVariable):
-                    depends = self._graph.edges(y, data='depend')
+                    depends = self._graph.edges(y, data="depend")
                     # access _value directly to avoid evaluations
-                    y._value = y.compute(**{p: z.value for _,z,p in depends})
+                    y._value = y.compute(**{p: z.value for _, z, p in depends})
                     y._recompute = False
 
         return x.value
@@ -1118,13 +1162,15 @@ class VariableGraph:
         self.evaluate(f)
 
         # compute chain rule along all paths to the variable
-        deriv = 0.
+        deriv = 0.0
         for path in networkx.all_simple_edge_paths(self._graph, source=f, target=x):
-            path_deriv = 1.
+            path_deriv = 1.0
             for edge in path:
-                param = self._graph.edges[edge]['depend']
-                depends = self._graph.edges(edge[0], data='depend')
-                path_deriv *= edge[0].compute_derivative(param, **{p: y.value for _,y,p in depends})
+                param = self._graph.edges[edge]["depend"]
+                depends = self._graph.edges(edge[0], data="depend")
+                path_deriv *= edge[0].compute_derivative(
+                    param, **{p: y.value for _, y, p in depends}
+                )
             deriv += path_deriv
 
         return deriv
@@ -1183,25 +1229,25 @@ class VariableGraph:
             vars = (x,)
         for y in vars:
             if not isinstance(y, types):
-                raise TypeError('Variable does not have required type')
+                raise TypeError("Variable does not have required type")
             self._assert_in_graph(y)
         return vars
 
     def _assert_acyclic(self):
         """Assert graph is acyclic."""
         if not self.is_acyclic:
-            raise AssertionError('Circular dependency in variable graph')
+            raise AssertionError("Circular dependency in variable graph")
 
     def _assert_is_variable(self, x):
         """Assert object is a variable."""
         if not isinstance(x, Variable):
-            raise AssertionError('Object is not a variable')
+            raise AssertionError("Object is not a variable")
 
     def _assert_in_graph(self, x):
         """Assert object is a node in the graph."""
         self._assert_is_variable(x)
         if x not in self._graph:
-            raise AssertionError('Object has not been added to graph')
+            raise AssertionError("Object has not been added to graph")
 
     def _ensure_variable(self, x):
         """Coerce an object into a variable.
@@ -1239,8 +1285,9 @@ class VariableGraph:
 
         # confirm x has right type
         if not isinstance(x_, Variable):
-            raise TypeError('Type cannot be coerced to a variable.')
+            raise TypeError("Type cannot be coerced to a variable.")
 
         return x_
+
 
 graph = VariableGraph()

--- a/relentless/mpi.py
+++ b/relentless/mpi.py
@@ -42,11 +42,14 @@ import json
 import os
 
 import numpy
+
 try:
     from mpi4py import MPI
+
     _has_mpi4py = True
 except ImportError:
     _has_mpi4py = False
+
 
 def _mpi_running():
     """Check if MPI is running.
@@ -61,11 +64,14 @@ def _mpi_running():
         True if MPI seems to be running.
 
     """
-    hints = ('MV2_COMM_WORLD_LOCAL_RANK',
-             'OMPI_COMM_WORLD_RANK',
-             'PMI_RANK',
-             'ALPS_APP_PE')
+    hints = (
+        "MV2_COMM_WORLD_LOCAL_RANK",
+        "OMPI_COMM_WORLD_RANK",
+        "PMI_RANK",
+        "ALPS_APP_PE",
+    )
     return any(h in os.environ for h in hints)
+
 
 class Communicator:
     """MPI communicator.
@@ -88,6 +94,7 @@ class Communicator:
         If the ``root`` rank does not lie within the valid range for the communicator.
 
     """
+
     def __init__(self, comm=None, root=0):
         if _mpi_running():
             if _has_mpi4py:
@@ -97,7 +104,9 @@ class Communicator:
                     self._comm = comm
                 self._comm.Set_errhandler(MPI.ERRORS_ARE_FATAL)
             else:
-                raise RuntimeError('Python seems to running in MPI, but mpi4py is not installed.')
+                raise RuntimeError(
+                    "Python seems to running in MPI, but mpi4py is not installed."
+                )
         else:
             self._comm = None
 
@@ -111,7 +120,7 @@ class Communicator:
             self._root = 0
 
         if self.root < 0 or self.root >= self.size:
-            raise IndexError('Root rank ID out of bounds.')
+            raise IndexError("Root rank ID out of bounds.")
 
     @property
     def comm(self):
@@ -194,7 +203,7 @@ class Communicator:
         if root is None:
             root = self.root
 
-        return self.comm.bcast(data,root)
+        return self.comm.bcast(data, root)
 
     def bcast_numpy(self, data, root=None):
         """Broadcast NumPy array to all ranks.
@@ -257,8 +266,8 @@ class Communicator:
         else:
             shape = None
             dtype = None
-        shape = self.bcast(shape,root)
-        dtype = self.bcast(dtype,root)
+        shape = self.bcast(shape, root)
+        dtype = self.bcast(dtype, root)
 
         # allocate memory if needed (storage may already exist)
         if self.rank != root:
@@ -267,10 +276,10 @@ class Communicator:
             except AttributeError:
                 alloc = True
             if alloc:
-                data = numpy.empty(shape,dtype=dtype)
+                data = numpy.empty(shape, dtype=dtype)
 
         # broadcast from the root rank
-        self.comm.Bcast(data,root)
+        self.comm.Bcast(data, root)
 
         return data
 
@@ -315,7 +324,7 @@ class Communicator:
             dat = numpy.loadtxt(filename, **kwargs)
         else:
             dat = None
-        dat = self.bcast_numpy(dat,root)
+        dat = self.bcast_numpy(dat, root)
 
         return dat
 
@@ -362,5 +371,6 @@ class Communicator:
         dat = self.bcast(dat, root)
 
         return dat
+
 
 world = Communicator()

--- a/relentless/optimize/__init__.py
+++ b/relentless/optimize/__init__.py
@@ -51,21 +51,16 @@ Developer classes
 
 
 """
-from .criteria import (AllTest,
-                       AndTest,
-                       AnyTest,
-                       ConvergenceTest,
-                       GradientTest,
-                       LogicTest,
-                       OrTest,
-                       Tolerance,
-                       ValueTest)
-
-from .method import (FixedStepDescent,
-                     LineSearch,
-                     Optimizer,
-                     SteepestDescent)
-
-from .objective import (ObjectiveFunction,
-                        ObjectiveFunctionResult,
-                        RelativeEntropy)
+from .criteria import (
+    AllTest,
+    AndTest,
+    AnyTest,
+    ConvergenceTest,
+    GradientTest,
+    LogicTest,
+    OrTest,
+    Tolerance,
+    ValueTest,
+)
+from .method import FixedStepDescent, LineSearch, Optimizer, SteepestDescent
+from .objective import ObjectiveFunction, ObjectiveFunctionResult, RelativeEntropy

--- a/relentless/optimize/criteria.py
+++ b/relentless/optimize/criteria.py
@@ -78,15 +78,17 @@ import numpy
 from relentless import collections
 from relentless.model import variable
 
+
 class ConvergenceTest(abc.ABC):
     r"""Abstract base class for optimization convergence tests.
 
     A :class:`ConvergenceTest` defines a test to determine if an
-    :class:`~relentless.optimize.objective.ObjectiveFunction` :math:`f\left(\mathbf{x}\right)`,
-    defined on a set of design variables :math:`\mathbf{x}=\left[x_1,\cdots,x_n\right]`,
-    has converged to a desired point.
+    :class:`~relentless.optimize.objective.ObjectiveFunction`
+    :math:`f\left(\mathbf{x}\right)`, defined on a set of design variables
+    :math:`\mathbf{x}=\left[x_1,\cdots,x_n\right]`, has converged to a desired point.
 
     """
+
     @abc.abstractmethod
     def converged(self, result):
         """Check if the function is converged.
@@ -102,6 +104,7 @@ class ConvergenceTest(abc.ABC):
             True if the result is converged.
         """
         pass
+
 
 class Tolerance:
     r"""Tolerance for convergence tests.
@@ -131,6 +134,7 @@ class Tolerance:
         The default relative tolerance.
 
     """
+
     def __init__(self, absolute, relative):
         self._absolute = collections.DefaultDict(absolute)
         self._relative = collections.DefaultDict(relative)
@@ -152,9 +156,10 @@ class Tolerance:
 
         The test is performed using :func:`numpy.isclose`.
 
-        The default :attr:`absolute` and :attr:`relative` tolerances can be overridden based on a ``key``,
-        which can be any valid dictionary key other than ``None``. When testing for closeness, if a ``key``
-        is given, the keyed tolerance will be used if has been specified; otherwise, the default tolerance is used.
+        The default :attr:`absolute` and :attr:`relative` tolerances can be overridden
+        based on a ``key``, which can be any valid dictionary key other than ``None``.
+        When testing for closeness, if a ``key`` is given, the keyed tolerance will be
+        used if has been specified; otherwise, the default tolerance is used.
 
         Parameters
         ----------
@@ -179,18 +184,19 @@ class Tolerance:
 
         """
         if self.absolute[key] < 0:
-            raise ValueError('Absolute tolerances must be non-negative.')
+            raise ValueError("Absolute tolerances must be non-negative.")
         if self.relative[key] < 0 or self.relative[key] > 1:
-            raise ValueError('Relative tolerances must be between 0 and 1.')
+            raise ValueError("Relative tolerances must be between 0 and 1.")
         return numpy.isclose(a, b, atol=self.absolute[key], rtol=self.relative[key])
+
 
 class GradientTest(ConvergenceTest):
     r"""Gradient test for convergence using absolute tolerance.
 
     This test is useful for finding minima / maxima where the gradient should be zero.
     This is implemented using an absolute tolerance, :math:`\varepsilon_{\rm a}`, which
-    can be any non-negative numerical value. One ``tolerance`` must be initially specified
-    for all variables, but a different tolerance can be set for each variable:
+    can be any non-negative numerical value. One ``tolerance`` must be initially
+    specified for all variables, but a different tolerance can be set for each variable:
 
     .. code::
 
@@ -198,8 +204,8 @@ class GradientTest(ConvergenceTest):
         test.tolerance[x] = 1.e-2
 
     The result is converged with respect to an unconstrained design variable
-    :math:`x_i` (i.e., having :class:`~relentless.variable.DesignVariable.State` ``FREE``
-    if and only if:
+    :math:`x_i` (i.e., having :class:`~relentless.variable.DesignVariable.State`
+    ``FREE``) if and only if:
 
     .. math::
 
@@ -232,9 +238,12 @@ class GradientTest(ConvergenceTest):
         Variable(s) to test convergence for in gradient.
 
     """
+
     def __init__(self, tolerance, variables):
         self._tolerance = Tolerance(absolute=tolerance, relative=0)
-        self.variables = variable.graph.check_variables_and_types(variables, variable.Variable)
+        self.variables = variable.graph.check_variables_and_types(
+            variables, variable.Variable
+        )
 
     @property
     def tolerance(self):
@@ -263,10 +272,10 @@ class GradientTest(ConvergenceTest):
         converged = True
         for x in self.variables:
             if x not in result.gradient:
-                raise KeyError('Design variable not in result')
+                raise KeyError("Design variable not in result")
             grad = result.gradient[x]
             tol = self.tolerance[x]
-            if x.athigh() and  -grad < -tol:
+            if x.athigh() and -grad < -tol:
                 converged = False
                 break
             elif x.atlow() and -grad > tol:
@@ -277,6 +286,7 @@ class GradientTest(ConvergenceTest):
                 break
 
         return converged
+
 
 class ValueTest(ConvergenceTest):
     r"""Value test for convergence.
@@ -295,6 +305,7 @@ class ValueTest(ConvergenceTest):
         The default relative tolerance (defaults to ``1e-5``).
 
     """
+
     def __init__(self, value, absolute=1e-8, relative=1e-5):
         self._tolerance = Tolerance(absolute=absolute, relative=relative)
         self.value = value
@@ -345,8 +356,9 @@ class ValueTest(ConvergenceTest):
         """
         return self._tolerance.isclose(result.value, self.value)
 
+
 class LogicTest(ConvergenceTest):
-    """Abstract base class for logical convergence tests.
+    r"""Abstract base class for logical convergence tests.
 
     Parameters
     ----------
@@ -359,13 +371,15 @@ class LogicTest(ConvergenceTest):
         If all inputs are not :class:`ConvergenceTest`\s.
 
     """
+
     def __init__(self, *tests):
         if not all([isinstance(t, ConvergenceTest) for t in tests]):
-            raise TypeError('All inputs to a LogicTest must be ConvergenceTests.')
+            raise TypeError("All inputs to a LogicTest must be ConvergenceTests.")
         self.tests = tests
 
+
 class AnyTest(LogicTest):
-    """Logic test if any specified test returns convergence.
+    r"""Logic test if any specified test returns convergence.
 
     Check if the function is determined to be converged by any of the specified
     convergence tests.
@@ -376,6 +390,7 @@ class AnyTest(LogicTest):
         The :class:`ConvergenceTest`\s to be used.
 
     """
+
     def converged(self, result):
         """Check if the function has converged by any of the specified tests.
 
@@ -392,8 +407,9 @@ class AnyTest(LogicTest):
         """
         return any(t.converged(result) for t in self.tests)
 
+
 class AllTest(LogicTest):
-    """Logic test if all specified tests return convergence.
+    r"""Logic test if all specified tests return convergence.
 
     Check if the function is determined to be converged by all of the specified
     convergence tests.
@@ -404,6 +420,7 @@ class AllTest(LogicTest):
         The :class:`ConvergenceTest`\s to be used.
 
     """
+
     def converged(self, result):
         """Check if the function is converged by all of the specified tests.
 
@@ -420,6 +437,7 @@ class AllTest(LogicTest):
         """
         return all(t.converged(result) for t in self.tests)
 
+
 class OrTest(AnyTest):
     """Logic test if either of the specified tests return convergence.
 
@@ -434,8 +452,10 @@ class OrTest(AnyTest):
         The second convergence test to use.
 
     """
+
     def __init__(self, a, b):
         super().__init__(a, b)
+
 
 class AndTest(AllTest):
     """Logic test if both specified tests return convergence.
@@ -451,5 +471,6 @@ class AndTest(AllTest):
         The second convergence test to use.
 
     """
+
     def __init__(self, a, b):
         super().__init__(a, b)

--- a/relentless/optimize/objective.py
+++ b/relentless/optimize/objective.py
@@ -6,7 +6,8 @@ An objective function is the quantity to be minimized in an optimization problem
 by adjusting the variables on which the function depends.
 
 This function, :math:`f`, is a scalar value that is defined as a function of :math:`n`
-problem :class:`~relentless.variable.DesignVariable`\s :math:`\mathbf{x}=\left[x_1,\ldots,x_n\right]`.
+problem :class:`~relentless.variable.DesignVariable`\s
+:math:`\mathbf{x}=\left[x_1,\ldots,x_n\right]`.
 
 The value of the function, :math:`f\left(\mathbf{x}\right)` is specified.
 The gradient is also specified for all of the design variables:
@@ -60,20 +61,20 @@ import tempfile
 import numpy
 import scipy.integrate
 
-from relentless import data
-from relentless.model import extent
-from relentless import math
-from relentless import mpi
-from relentless.model import variable
+from relentless import data, math, mpi
+from relentless.model import extent, variable
+
 
 class ObjectiveFunction(abc.ABC):
-    """Abstract base class for the optimization objective function.
+    r"""Abstract base class for the optimization objective function.
 
     An :class:`ObjectiveFunction` defines the objective function parametrized on
     one or more adjustable :class:`~relentless.variable.DesignVariable`\s.
-    The function must also have a defined value and gradient for all values of its parameters.
+    The function must also have a defined value and gradient for all values of its
+    parameters.
 
     """
+
     @abc.abstractmethod
     def compute(self, variables, directory=None):
         """Evaluate the value and gradient of the objective function.
@@ -94,6 +95,7 @@ class ObjectiveFunction(abc.ABC):
 
         """
         pass
+
 
 class ObjectiveFunctionResult:
     """Class storing the value and gradient of a :class:`ObjectiveFunction`.
@@ -119,6 +121,7 @@ class ObjectiveFunctionResult:
         don't match.
 
     """
+
     def __init__(self, variables=None, value=None, gradient=None, directory=None):
         self.variables = variables
         self.value = value
@@ -129,7 +132,7 @@ class ObjectiveFunctionResult:
     def variables(self):
         """:class:`~relentless.math.KeyedArray`: Recorded variables of the
         :class:`ObjectiveFunction`."""
-        return getattr(self, '_variables', None)
+        return getattr(self, "_variables", None)
 
     @variables.setter
     def variables(self, value):
@@ -145,7 +148,7 @@ class ObjectiveFunctionResult:
     @property
     def value(self):
         """float: The value of the evaluated objective function."""
-        return getattr(self, '_value', None)
+        return getattr(self, "_value", None)
 
     @value.setter
     def value(self, x):
@@ -155,7 +158,7 @@ class ObjectiveFunctionResult:
     def gradient(self):
         """:class:`~relentless.math.KeyedArray`: The gradient of the objective
         function, keyed on its design variables."""
-        return getattr(self, '_gradient', None)
+        return getattr(self, "_gradient", None)
 
     @gradient.setter
     def gradient(self, value):
@@ -170,7 +173,7 @@ class ObjectiveFunctionResult:
     @property
     def directory(self):
         """:class:`~relentless.data.Directory` Directory holding written output."""
-        return getattr(self, '_directory', None)
+        return getattr(self, "_directory", None)
 
     @directory.setter
     def directory(self, value):
@@ -187,14 +190,15 @@ class ObjectiveFunctionResult:
             The name of the file to save data in.
 
         """
-        data = {'variables': {x.name: v for x, v in self.variables.items()},
-                'value': self.value,
-                'gradient': {x.name: v for x, v in self.gradient.items()},
-                'directory': self.directory.path if self.directory is not None else None
-                }
+        data = {
+            "variables": {x.name: v for x, v in self.variables.items()},
+            "value": self.value,
+            "gradient": {x.name: v for x, v in self.gradient.items()},
+            "directory": self.directory.path if self.directory is not None else None,
+        }
 
         # dump data to json file
-        with open(filename,'w') as f:
+        with open(filename, "w") as f:
             json.dump(data, f, indent=4)
 
     def _assert_keys_match(self, vars, grad):
@@ -215,7 +219,8 @@ class ObjectiveFunctionResult:
         """
         if vars is not None and grad is not None:
             if vars.keys() != grad.keys():
-                raise AssertionError('Variable and gradient keys do not match!')
+                raise AssertionError("Variable and gradient keys do not match!")
+
 
 class RelativeEntropy(ObjectiveFunction):
     r"""Relative entropy.
@@ -228,7 +233,8 @@ class RelativeEntropy(ObjectiveFunction):
 
     .. math::
 
-        S_{\rm rel} = -\int d\Gamma p_0(\Gamma)\ln\left(\frac{p(\Gamma)}{p_0(\Gamma)}\right)
+        S_{\rm rel} =
+            -\int d\Gamma p_0(\Gamma)\ln\left(\frac{p(\Gamma)}{p_0(\Gamma)}\right)
 
     where :math:`\Gamma` is an element of phase space. The relative entropy is
     zero when the two ensembles overlap completely, and it is positive otherwise.
@@ -247,11 +253,14 @@ class RelativeEntropy(ObjectiveFunction):
 
     .. math::
 
-        \nabla_\mathbf{x} S_{\rm rel} = -\frac{1}{2}\sum_{i,j}\int{dr\left(4\pi r^2\right)\left[\frac{\beta N_i N_j}{V} g_{ij}(r)-\frac{\beta_0 N_{i,0} N_{j,0}}{V_0} g_{ij,0}(r)\right]\nabla_\mathbf{x} u_{ij}(r)}
+        \nabla_\mathbf{x} S_{\rm rel} = -\frac{1}{2} \sum_{i,j} \int dr 4\pi r^2
+            \left[\frac{\beta N_i N_j}{V} g_{ij}(r) \right.
+            \left. -\frac{\beta_0 N_{i,0} N_{j,0}}{V_0} g_{ij,0}(r)\right]
+            \nabla_\mathbf{x} u_{ij}(r)}
 
     where :math:`\beta=1/(k_{\rm B}T)`, :math:`N_i` is the number of particles
-    of type :math:`i`, :math:`V` is the extent, and :math:`u_{ij}(r)` is the pair potential
-    in the *model* ensemble. The corresponding properties of the *target*
+    of type :math:`i`, :math:`V` is the extent, and :math:`u_{ij}(r)` is the pair
+    potential in the *model* ensemble. The corresponding properties of the *target*
     ensemble are denoted with subscript :math:`0`.
 
     :math:`S_{\rm rel}` is extensive as written, meaning that it depends on the
@@ -277,6 +286,7 @@ class RelativeEntropy(ObjectiveFunction):
         ``False``).
 
     """
+
     def __init__(self, target, simulation, potentials, thermo, extensive=False):
         self.target = target
         self.simulation = simulation
@@ -331,8 +341,8 @@ class RelativeEntropy(ObjectiveFunction):
         # write the pair potential parameters *before* the run
         if not directory_is_tmp:
             if mpi.world.rank_is_root:
-                for n,p in enumerate(self.potentials.pair.potentials):
-                    p.save(directory.file('pair_potential.{}.json'.format(n)))
+                for n, p in enumerate(self.potentials.pair.potentials):
+                    p.save(directory.file("pair_potential.{}.json".format(n)))
 
         # run simulation and use result to compute gradient
         try:
@@ -346,18 +356,19 @@ class RelativeEntropy(ObjectiveFunction):
         # relative entropy *value* is None
         gradient = self.compute_gradient(sim_ens, variables)
         result = ObjectiveFunctionResult(
-                variables, None, gradient, directory if not directory_is_tmp else None)
+            variables, None, gradient, directory if not directory_is_tmp else None
+        )
 
         # optionally write ensemble and result *after* the simulation
         if not directory_is_tmp:
             if mpi.world.rank_is_root:
-                sim_ens.save(directory.file('ensemble.json'))
-                result.save(directory.file('result.json'))
+                sim_ens.save(directory.file("ensemble.json"))
+                result.save(directory.file("result.json"))
 
         return result
 
     def compute_gradient(self, ensemble, variables):
-        """Computes the relative entropy gradient for an ensemble.
+        r"""Computes the relative entropy gradient for an ensemble.
 
         Parameters
         ----------
@@ -380,10 +391,10 @@ class RelativeEntropy(ObjectiveFunction):
 
         for var in dvars:
             update = 0
-            for i,j in self.target.pairs:
+            for i, j in self.target.pairs:
                 rs = self.potentials.pair.r
-                us = self.potentials.pair.energy((i,j))
-                dus = self.potentials.pair.derivative((i,j),var)
+                us = self.potentials.pair.energy((i, j))
+                dus = self.potentials.pair.derivative((i, j), var)
 
                 # only count (continuous range of) finite values
                 flags = numpy.isinf(us)
@@ -396,31 +407,61 @@ class RelativeEntropy(ObjectiveFunction):
                     continue
 
                 # interpolate derivative wrt design variable with r
-                dudvar = math.Interpolator(rs,dus)
+                dudvar = math.Interpolator(rs, dus)
 
                 # find common domain to compare rdfs
-                r0 = max(g_sim[i,j].domain[0],g_tgt[i,j].domain[0],dudvar.domain[0])
-                r1 = min(g_sim[i,j].domain[-1],g_tgt[i,j].domain[-1],dudvar.domain[-1])
-                sim_dr = numpy.min(numpy.diff(g_sim[i,j].table[:,0]))
-                tgt_dr = numpy.min(numpy.diff(g_tgt[i,j].table[:,0]))
+                r0 = max(g_sim[i, j].domain[0], g_tgt[i, j].domain[0], dudvar.domain[0])
+                r1 = min(
+                    g_sim[i, j].domain[-1], g_tgt[i, j].domain[-1], dudvar.domain[-1]
+                )
+                sim_dr = numpy.min(numpy.diff(g_sim[i, j].table[:, 0]))
+                tgt_dr = numpy.min(numpy.diff(g_tgt[i, j].table[:, 0]))
                 dudvar_dr = numpy.min(numpy.diff(rs))
-                dr = min(sim_dr,tgt_dr,dudvar_dr)
-                r = numpy.arange(r0,r1+0.5*dr,dr)
+                dr = min(sim_dr, tgt_dr, dudvar_dr)
+                r = numpy.arange(r0, r1 + 0.5 * dr, dr)
 
                 # normalization to extensive or intensive as specified
-                norm_factor = self.target.V.extent if not self.extensive else 1.
+                norm_factor = self.target.V.extent if not self.extensive else 1.0
 
-                # take integral by trapezoidal rule              
-                sim_factor = ensemble.N[i]*ensemble.N[j]/(self.potentials.kB*ensemble.T*ensemble.V.extent*norm_factor)
-                tgt_factor = self.target.N[i]*self.target.N[j]/(self.potentials.kB*self.target.T*self.target.V.extent*norm_factor)
-                mult = 1 if i == j else 2 # 1 if same, otherwise need i,j and j,i contributions
+                # take integral by trapezoidal rule
+                sim_factor = (
+                    ensemble.N[i]
+                    * ensemble.N[j]
+                    / (
+                        self.potentials.kB
+                        * ensemble.T
+                        * ensemble.V.extent
+                        * norm_factor
+                    )
+                )
+                tgt_factor = (
+                    self.target.N[i]
+                    * self.target.N[j]
+                    / (
+                        self.potentials.kB
+                        * self.target.T
+                        * self.target.V.extent
+                        * norm_factor
+                    )
+                )
+                mult = (
+                    1 if i == j else 2
+                )  # 1 if same, otherwise need i,j and j,i contributions
                 if isinstance(self.target.V, extent.Volume):
-                    geo_prefactor = 4*numpy.pi*r**2
-                elif isinstance(self.target.V, extent.Area): 
-                    geo_prefactor = 2*numpy.pi*r
+                    geo_prefactor = 4 * numpy.pi * r**2
+                elif isinstance(self.target.V, extent.Area):
+                    geo_prefactor = 2 * numpy.pi * r
                 else:
-                    raise ValueError('Geometric integration factor unknown for extent type')
-                y = -0.5*mult*geo_prefactor*(sim_factor*g_sim[i,j](r)-tgt_factor*g_tgt[i,j](r))*dudvar(r)
+                    raise ValueError(
+                        "Geometric integration factor unknown for extent type"
+                    )
+                y = (
+                    -0.5
+                    * mult
+                    * geo_prefactor
+                    * (sim_factor * g_sim[i, j](r) - tgt_factor * g_tgt[i, j](r))
+                    * dudvar(r)
+                )
                 update += scipy.integrate.trapz(y, x=r)
 
             gradient[var] = update
@@ -436,5 +477,5 @@ class RelativeEntropy(ObjectiveFunction):
     @target.setter
     def target(self, value):
         if value.V is None or value.N is None:
-            raise ValueError('The target ensemble must have both V and N set.')
+            raise ValueError("The target ensemble must have both V and N set.")
         self._target = value

--- a/relentless/simulate/__init__.py
+++ b/relentless/simulate/__init__.py
@@ -99,7 +99,7 @@ Analyzers
     :toctree: generated/
 
     EnsembleAverage
-    
+
 Running a simulation
 ====================
 
@@ -134,25 +134,11 @@ Developer classes
     Thermostat
 
 """
-from .simulate import (
-    AnalysisOperation,
-    PairPotentialTabulator,
-    PotentialTabulator,
-    Potentials,
-    Simulation,
-    SimulationInstance,
-    SimulationOperation,
-    )
-
-from .analyze import (
-    EnsembleAverage,
-    )
-
-from .initialize import (
-    InitializeFromFile,
-    InitializeRandomly,
-    )
-
+from .analyze import EnsembleAverage
+from .dilute import Dilute
+from .hoomd import HOOMD
+from .initialize import InitializeFromFile, InitializeRandomly
+from .lammps import LAMMPS
 from .md import (
     Barostat,
     BerendsenBarostat,
@@ -164,10 +150,13 @@ from .md import (
     RunLangevinDynamics,
     RunMolecularDynamics,
     Thermostat,
-    )
-
-from .dilute import Dilute
-
-from .hoomd import HOOMD
-
-from .lammps import LAMMPS
+)
+from .simulate import (
+    AnalysisOperation,
+    PairPotentialTabulator,
+    Potentials,
+    PotentialTabulator,
+    Simulation,
+    SimulationInstance,
+    SimulationOperation,
+)

--- a/relentless/simulate/analyze.py
+++ b/relentless/simulate/analyze.py
@@ -1,17 +1,20 @@
 from . import simulate
 
+
 class EnsembleAverage(simulate.GenericAnalysisOperation):
     """Analyze the simulation ensemble.
 
     Parameters
     ----------
     check_thermo_every : int
-        Interval of time steps at which to log thermodynamic properties of the simulation.
+        Interval of time steps at which to log thermodynamic properties of
+        the simulation.
     check_rdf_every : int
         Interval of time steps at which to log the rdf of the simulation.
     rdf_dr : float
         The width (in units ``r``) of a bin in the histogram of the rdf.
 
     """
+
     def __init__(self, check_thermo_every, check_rdf_every, rdf_dr):
         super().__init__(check_thermo_every, check_rdf_every, rdf_dr)

--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -22,23 +22,22 @@ import uuid
 import lammpsio
 import numpy
 
-from relentless import data
-from relentless.model import ensemble
 from relentless import mpi
-from relentless.model import extent
+from relentless.model import ensemble, extent
 
-from . import simulate
-from . import initialize
-from . import md
+from . import initialize, md, simulate
 
 try:
     import lammps
+
     _lammps_found = True
 except ImportError:
     _lammps_found = False
 
+
 class LAMMPSOperation(simulate.SimulationOperation):
     """LAMMPS simulation operation."""
+
     _compute_counter = 1
     _fix_counter = 1
     _group_counter = 1
@@ -72,7 +71,7 @@ class LAMMPSOperation(simulate.SimulationOperation):
         """
         idx = int(LAMMPSOperation._compute_counter)
         LAMMPSOperation._compute_counter += 1
-        return 'c{}'.format(idx)
+        return "c{}".format(idx)
 
     @classmethod
     def new_fix_id(cls):
@@ -86,7 +85,7 @@ class LAMMPSOperation(simulate.SimulationOperation):
         """
         idx = int(LAMMPSOperation._fix_counter)
         LAMMPSOperation._fix_counter += 1
-        return 'f{}'.format(idx)
+        return "f{}".format(idx)
 
     @classmethod
     def new_group_id(cls):
@@ -100,7 +99,7 @@ class LAMMPSOperation(simulate.SimulationOperation):
         """
         idx = int(LAMMPSOperation._group_counter)
         LAMMPSOperation._group_counter += 1
-        return 'g{}'.format(idx)
+        return "g{}".format(idx)
 
     @classmethod
     def new_variable_id(cls):
@@ -114,7 +113,7 @@ class LAMMPSOperation(simulate.SimulationOperation):
         """
         idx = int(LAMMPSOperation._variable_counter)
         LAMMPSOperation._variable_counter += 1
-        return 'v{}'.format(idx)
+        return "v{}".format(idx)
 
     @abc.abstractmethod
     def to_commands(self, sim):
@@ -135,7 +134,8 @@ class LAMMPSOperation(simulate.SimulationOperation):
         """
         pass
 
-## initializers
+
+# initializers
 class _Initialize(LAMMPSOperation):
     """Initialize a simulation.
 
@@ -145,20 +145,23 @@ class _Initialize(LAMMPSOperation):
         Mapping of type names (`str`) to LAMMPS type integers.
 
     """
+
     def __init__(self, lammps_types):
         self.lammps_types = lammps_types
-        self.units = 'lj'
-        self.atom_style = 'atomic'
+        self.units = "lj"
+        self.atom_style = "atomic"
 
     def __call__(self, sim):
         super().__call__(sim)
         sim[self].lammps_types = dict(self.lammps_types)
 
     def to_commands(self, sim):
-        cmds = ['units {style}'.format(style=self.units),
-                'boundary p p p',
-                'dimension {dim}'.format(dim=sim.dimension),
-                'atom_style {style}'.format(style=self.atom_style)]
+        cmds = [
+            "units {style}".format(style=self.units),
+            "boundary p p p",
+            "dimension {dim}".format(dim=sim.dimension),
+            "atom_style {style}".format(style=self.atom_style),
+        ]
 
         return cmds
 
@@ -178,17 +181,19 @@ class InitializeFromFile(_Initialize):
         The file from which to read the system data.
 
     """
+
     def __init__(self, filename):
         super().__init__(None)
         self.filename = filename
 
     def to_commands(self, sim):
         if self.lammps_types is None:
-            raise ValueError('lammps_types needs to be manually specified with a file')
+            raise ValueError("lammps_types needs to be manually specified with a file")
 
         cmds = super().to_commands(sim)
-        cmds += ['read_data {filename}'.format(filename=self.filename)]
+        cmds += ["read_data {filename}".format(filename=self.filename)]
         return cmds
+
 
 class InitializeRandomly(_Initialize):
     """Initialize a randomly generated simulation box.
@@ -225,8 +230,9 @@ class InitializeRandomly(_Initialize):
         are randomly inserted without checking their sizes.
 
     """
+
     def __init__(self, seed, N, V, T, masses, diameters):
-        super().__init__({i: idx+1 for idx,i in enumerate(N.keys())})
+        super().__init__({i: idx + 1 for idx, i in enumerate(N.keys())})
         self.seed = seed
         self.N = N
         self.V = V
@@ -235,41 +241,48 @@ class InitializeRandomly(_Initialize):
         self.diameters = diameters
 
     def to_commands(self, sim):
-        if not isinstance(self.V, (extent.TriclinicBox,extent.ObliqueArea)):
-            raise TypeError('LAMMPS boxes must be derived from TriclinicBox or ObliqueArea')
-        elif ((sim.dimension == 3 and not isinstance(self.V, extent.TriclinicBox)) or
-            (sim.dimension == 2 and not isinstance(self.V, extent.ObliqueArea))):
-            raise TypeError('Mismatch between extent type and dimension')
+        if not isinstance(self.V, (extent.TriclinicBox, extent.ObliqueArea)):
+            raise TypeError(
+                "LAMMPS boxes must be derived from TriclinicBox or ObliqueArea"
+            )
+        elif (sim.dimension == 3 and not isinstance(self.V, extent.TriclinicBox)) or (
+            sim.dimension == 2 and not isinstance(self.V, extent.ObliqueArea)
+        ):
+            raise TypeError("Mismatch between extent type and dimension")
 
         if mpi.world.rank_is_root:
             # make box
             if sim.dimension == 3:
-                Lx,Ly,Lz,xy,xz,yz = self.V.as_array('LAMMPS')
+                Lx, Ly, Lz, xy, xz, yz = self.V.as_array("LAMMPS")
                 lo = self.V.low
             elif sim.dimension == 2:
-                Lx,Ly,xy = self.V.as_array('LAMMPS')
+                Lx, Ly, xy = self.V.as_array("LAMMPS")
                 Lz = 1.0
                 xz = 0.0
                 yz = 0.0
-                lo = numpy.array([self.V.low[0],self.V.low[1],-0.5*Lz])
+                lo = numpy.array([self.V.low[0], self.V.low[1], -0.5 * Lz])
             else:
-                raise ValueError('LAMMPS only supports 2d and 3d simulations')
-            hi = lo + [Lx,Ly,Lz]
-            tilt = numpy.array([xy,xz,yz])
-            if not numpy.all(numpy.isclose(tilt,0)):
-                box = lammpsio.Box(lo,hi,tilt)
+                raise ValueError("LAMMPS only supports 2d and 3d simulations")
+            hi = lo + [Lx, Ly, Lz]
+            tilt = numpy.array([xy, xz, yz])
+            if not numpy.all(numpy.isclose(tilt, 0)):
+                box = lammpsio.Box(lo, hi, tilt)
             else:
-                box = lammpsio.Box(lo,hi)
+                box = lammpsio.Box(lo, hi)
             snap = lammpsio.Snapshot(N=sum(self.N.values()), box=box)
 
             # generate the positions and types
             if self.diameters is not None:
-                positions, all_types = initialize.InitializeRandomly._pack_particles(self.seed, self.N, self.V, self.diameters)
+                positions, all_types = initialize.InitializeRandomly._pack_particles(
+                    self.seed, self.N, self.V, self.diameters
+                )
             else:
-                positions, all_types = initialize.InitializeRandomly._random_particles(self.seed, self.N, self.V)
+                positions, all_types = initialize.InitializeRandomly._random_particles(
+                    self.seed, self.N, self.V
+                )
 
             # set the positions
-            snap.position[:,:sim.dimension] = positions
+            snap.position[:, : sim.dimension] = positions
 
             # set the typeids
             snap.typeid = [self.lammps_types[i] for i in all_types]
@@ -282,30 +295,33 @@ class InitializeRandomly(_Initialize):
 
             # set velocities, defaulting to zeros
             if self.T is not None:
-                rng = numpy.random.default_rng(self.seed+1)
+                rng = numpy.random.default_rng(self.seed + 1)
                 # Maxwell-Boltzmann = normal with variance kT/m per component
-                vel = rng.normal(scale=numpy.sqrt(sim.potentials.kB*self.T),
-                                 size=(snap.N,sim.dimension))
-                vel /= numpy.sqrt(snap.mass[:,None])
+                vel = rng.normal(
+                    scale=numpy.sqrt(sim.potentials.kB * self.T),
+                    size=(snap.N, sim.dimension),
+                )
+                vel /= numpy.sqrt(snap.mass[:, None])
 
                 # zero the linear momentum
-                v_cm = numpy.sum(snap.mass[:,None]*vel, axis=0)/numpy.sum(snap.mass)
+                v_cm = numpy.sum(snap.mass[:, None] * vel, axis=0) / numpy.sum(
+                    snap.mass
+                )
                 vel -= v_cm
             else:
                 vel = numpy.zeros((snap.N, sim.dimension))
-            snap.velocity[:,:sim.dimension] = vel
+            snap.velocity[:, : sim.dimension] = vel
 
             init_file = sim.directory.file(str(uuid.uuid4().hex))
-            lammpsio.DataFile.create(init_file,
-                                     snap,
-                                     self.atom_style)
+            lammpsio.DataFile.create(init_file, snap, self.atom_style)
         else:
             init_file = None
         init_file = mpi.world.bcast(init_file)
 
         cmds = super().to_commands(sim)
-        cmds += ['read_data {}'.format(init_file)]
+        cmds += ["read_data {}".format(init_file)]
         return cmds
+
 
 class MinimizeEnergy(LAMMPSOperation):
     """Perform energy minimization on a configuration.
@@ -327,27 +343,37 @@ class MinimizeEnergy(LAMMPSOperation):
         Additional options for energy minimzer.
 
     """
+
     def __init__(self, energy_tolerance, force_tolerance, max_iterations, options):
         self.energy_tolerance = energy_tolerance
         self.force_tolerance = force_tolerance
         self.max_iterations = max_iterations
         self.options = options
-        if 'max_evaluations' not in self.options:
-            self.options['max_evaluations'] = None
+        if "max_evaluations" not in self.options:
+            self.options["max_evaluations"] = None
 
     def to_commands(self, sim):
-        if self.options['max_evaluations'] is None:
-            self.options['max_evaluations'] = 100*self.max_iterations
+        if self.options["max_evaluations"] is None:
+            self.options["max_evaluations"] = 100 * self.max_iterations
 
-        cmds = ['minimize {etol} {ftol} {maxiter} {maxeval}'.format(etol=self.energy_tolerance,
-                                                                    ftol=self.force_tolerance,
-                                                                    maxiter=self.max_iterations,
-                                                                    maxeval=self.options['max_evaluations'])]
+        cmds = [
+            "minimize {etol} {ftol} {maxiter} {maxeval}".format(
+                etol=self.energy_tolerance,
+                ftol=self.force_tolerance,
+                maxiter=self.max_iterations,
+                maxeval=self.options["max_evaluations"],
+            )
+        ]
         if sim.dimension == 2:
             fix_2d = self.new_fix_id()
-            cmds = ['fix {} all enforce2d'.format(fix_2d)] + cmds + ['unfix {}'.format(fix_2d)]
+            cmds = (
+                ["fix {} all enforce2d".format(fix_2d)]
+                + cmds
+                + ["unfix {}".format(fix_2d)]
+            )
 
         return cmds
+
 
 class _MDIntegrator(LAMMPSOperation):
     """Base LAMMPS molecular dynamics integrator.
@@ -362,6 +388,7 @@ class _MDIntegrator(LAMMPSOperation):
         Analysis operations to perform with run (defaults to ``None``).
 
     """
+
     def __init__(self, steps, timestep, analyzers):
         self.steps = steps
         self.timestep = timestep
@@ -393,14 +420,19 @@ class _MDIntegrator(LAMMPSOperation):
         self._analyzers = ops_
 
     def _run_commands(self, sim):
-        cmds = ['run {N}'.format(N=self.steps)]
+        cmds = ["run {N}".format(N=self.steps)]
 
         # wrap with fixes
         if sim.dimension == 2:
             fix_2d = self.new_fix_id()
-            cmds = ['fix {} all enforce2d'.format(fix_2d)] + cmds + ['unfix {}'.format(fix_2d)]
+            cmds = (
+                ["fix {} all enforce2d".format(fix_2d)]
+                + cmds
+                + ["unfix {}".format(fix_2d)]
+            )
 
         return cmds
+
 
 class RunLangevinDynamics(_MDIntegrator):
     """Perform a Langevin dynamics simulation.
@@ -423,6 +455,7 @@ class RunLangevinDynamics(_MDIntegrator):
         Analysis operations to perform with run (defaults to ``None``).
 
     """
+
     def __init__(self, steps, timestep, T, friction, seed, analyzers):
         super().__init__(steps, timestep, analyzers)
         self.T = T
@@ -432,9 +465,9 @@ class RunLangevinDynamics(_MDIntegrator):
     def to_commands(self, sim):
         # obtain per-type mass (arrays 1-indexed using lammps convention)
         Ntypes = len(sim.types)
-        mass = sim.lammps.numpy.extract_atom('mass')
-        if mass is None or mass.shape != (Ntypes+1,):
-            raise ValueError('Per-type masses not set.')
+        mass = sim.lammps.numpy.extract_atom("mass")
+        if mass is None or mass.shape != (Ntypes + 1,):
+            raise ValueError("Per-type masses not set.")
         mass = numpy.squeeze(mass)
 
         # obtain per-type friction factor
@@ -445,34 +478,40 @@ class RunLangevinDynamics(_MDIntegrator):
             except TypeError:
                 friction[sim[sim.initializer].lammps_types[t]] = self.friction
             except KeyError:
-                raise KeyError('The friction factor for type {} is not set.'.format(t))
+                raise KeyError("The friction factor for type {} is not set.".format(t))
 
         # compute per-type damping parameter and rescale if multiple types
-        damp = numpy.divide(mass, friction, where=(friction>0))
+        damp = numpy.divide(mass, friction, where=(friction > 0))
         damp_ref = damp[1]
-        if Ntypes>1:
-            scale = damp/damp_ref
-            scale_str = ' '.join(['scale {} {}'.format(i+1,s) for i,s in enumerate(scale[2:])])
+        if Ntypes > 1:
+            scale = damp / damp_ref
+            scale_str = " ".join(
+                ["scale {} {}".format(i + 1, s) for i, s in enumerate(scale[2:])]
+            )
         else:
-            scale_str = ''
+            scale_str = ""
 
-        fix_ids = {'nve': self.new_fix_id(), 'langevin': self.new_fix_id()}
+        fix_ids = {"nve": self.new_fix_id(), "langevin": self.new_fix_id()}
         cmds = [
-                'timestep {}'.format(self.timestep),
-                'fix {idx} {group_idx} nve'.format(
-                        idx=fix_ids['nve'],
-                        group_idx='all'),
-                'fix {idx} {group_idx} langevin {t_start} {t_stop} {damp} {seed} {scaling}'.format(
-                        idx=fix_ids['langevin'],
-                        group_idx='all',
-                        t_start=self.T,
-                        t_stop=self.T,
-                        damp=damp_ref,
-                        seed=self.seed,
-                        scaling=scale_str)]
+            "timestep {}".format(self.timestep),
+            "fix {idx} {group_idx} nve".format(idx=fix_ids["nve"], group_idx="all"),
+            (
+                "fix {idx} {group_idx} langevin {t_start} {t_stop}"
+                " {damp} {seed} {scaling}"
+            ).format(
+                idx=fix_ids["langevin"],
+                group_idx="all",
+                t_start=self.T,
+                t_stop=self.T,
+                damp=damp_ref,
+                seed=self.seed,
+                scaling=scale_str,
+            ),
+        ]
         cmds += self._run_commands(sim)
-        cmds += ['unfix {}'.format(idx) for idx in fix_ids.values()]
+        cmds += ["unfix {}".format(idx) for idx in fix_ids.values()]
         return cmds
+
 
 class RunMolecularDynamics(_MDIntegrator):
     """Perform a molecular dynamics simulation.
@@ -482,7 +521,8 @@ class RunMolecularDynamics(_MDIntegrator):
     - NVE integration
     - NVT integration with Nosé-Hoover or Berendsen thermostat
     - NPH integration with MTK or Berendsen barostat
-    - NPT integration with Nosé-Hoover or Berendsen thermostat and MTK or Berendsen barostat
+    - NPT integration with Nosé-Hoover or Berendsen thermostat and
+      MTK or Berendsen barostat
 
     Parameters
     ----------
@@ -503,62 +543,103 @@ class RunMolecularDynamics(_MDIntegrator):
         If an appropriate combination of thermostat and barostat is not set.
 
     """
+
     def __init__(self, steps, timestep, thermostat, barostat, analyzers):
         super().__init__(steps, timestep, analyzers)
         self.thermostat = thermostat
         self.barostat = barostat
 
     def to_commands(self, sim):
-        fix_ids = {'ig': self.new_fix_id()}
+        fix_ids = {"ig": self.new_fix_id()}
 
-        cmds = ['timestep {}'.format(self.timestep)]
-        if ((self.thermostat is None or isinstance(self.thermostat, md.BerendsenThermostat)) and
-            (self.barostat is None or isinstance(self.barostat, md.BerendsenBarostat))):
-            cmds += ['fix {idx} {group_idx} nve'.format(idx=fix_ids['ig'], group_idx='all')]
-        elif (isinstance(self.thermostat, md.NoseHooverThermostat) and
-             (self.barostat is None or isinstance(self.barostat, md.BerendsenBarostat))):
-            cmds += ['fix {idx} {group_idx} nvt temp {Tstart} {Tstop} {Tdamp}'.format(idx=fix_ids['ig'],
-                                                                                     group_idx='all',
-                                                                                     Tstart=self.thermostat.T,
-                                                                                     Tstop=self.thermostat.T,
-                                                                                     Tdamp=self.thermostat.tau)]
-        elif ((self.thermostat is None or isinstance(self.thermostat, md.BerendsenThermostat)) and
-              isinstance(self.barostat, md.MTKBarostat)):
-            cmds += ['fix {idx} {group_idx} nph iso {Pstart} {Pstop} {Pdamp}'.format(idx=fix_ids['ig'],
-                                                                                    group_idx='all',
-                                                                                    Pstart=self.barostat.P,
-                                                                                    Pstop=self.barostat.P,
-                                                                                    Pdamp=self.barostat.tau)]
-        elif isinstance(self.thermostat, md.NoseHooverThermostat) and isinstance(self.barostat, md.MTKBarostat):
-            cmds += ['fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp} iso {Pstart} {Pstop} {Pdamp}'.format(idx=fix_ids['ig'],
-                                                                                                                  group_idx='all',
-                                                                                                                  Tstart=self.thermostat.T,
-                                                                                                                  Tstop=self.thermostat.T,
-                                                                                                                  Tdamp=self.thermostat.tau,
-                                                                                                                  Pstart=self.barostat.P,
-                                                                                                                  Pstop=self.barostat.P,
-                                                                                                                  Pdamp=self.barostat.tau)]
+        cmds = ["timestep {}".format(self.timestep)]
+        if (
+            self.thermostat is None
+            or isinstance(self.thermostat, md.BerendsenThermostat)
+        ) and (
+            self.barostat is None or isinstance(self.barostat, md.BerendsenBarostat)
+        ):
+            cmds += [
+                "fix {idx} {group_idx} nve".format(idx=fix_ids["ig"], group_idx="all")
+            ]
+        elif isinstance(self.thermostat, md.NoseHooverThermostat) and (
+            self.barostat is None or isinstance(self.barostat, md.BerendsenBarostat)
+        ):
+            cmds += [
+                "fix {idx} {group_idx} nvt temp {Tstart} {Tstop} {Tdamp}".format(
+                    idx=fix_ids["ig"],
+                    group_idx="all",
+                    Tstart=self.thermostat.T,
+                    Tstop=self.thermostat.T,
+                    Tdamp=self.thermostat.tau,
+                )
+            ]
+        elif (
+            self.thermostat is None
+            or isinstance(self.thermostat, md.BerendsenThermostat)
+        ) and isinstance(self.barostat, md.MTKBarostat):
+            cmds += [
+                "fix {idx} {group_idx} nph iso {Pstart} {Pstop} {Pdamp}".format(
+                    idx=fix_ids["ig"],
+                    group_idx="all",
+                    Pstart=self.barostat.P,
+                    Pstop=self.barostat.P,
+                    Pdamp=self.barostat.tau,
+                )
+            ]
+        elif isinstance(self.thermostat, md.NoseHooverThermostat) and isinstance(
+            self.barostat, md.MTKBarostat
+        ):
+            cmds += [
+                (
+                    "fix {idx} {group_idx} npt temp {Tstart} {Tstop} {Tdamp}"
+                    " iso {Pstart} {Pstop} {Pdamp}"
+                ).format(
+                    idx=fix_ids["ig"],
+                    group_idx="all",
+                    Tstart=self.thermostat.T,
+                    Tstop=self.thermostat.T,
+                    Tdamp=self.thermostat.tau,
+                    Pstart=self.barostat.P,
+                    Pstop=self.barostat.P,
+                    Pdamp=self.barostat.tau,
+                )
+            ]
         else:
-            raise TypeError('An appropriate combination of thermostat and barostat must be set.')
+            raise TypeError(
+                "An appropriate combination of thermostat and barostat must be set."
+            )
 
         if isinstance(self.thermostat, md.BerendsenThermostat):
-            fix_ids['berendsen_temp'] = self.new_fix_id()
-            cmds += ['fix {idx} {group_idx} temp/berendsen {Tstart} {Tstop} {Tdamp}'.format(idx=fix_ids['berendsen_temp'],
-                                                                                            group_idx='all',
-                                                                                            Tstart=self.thermostat.T,
-                                                                                            Tstop=self.thermostat.T,
-                                                                                            Tdamp=self.thermostat.tau)]
+            fix_ids["berendsen_temp"] = self.new_fix_id()
+            cmds += [
+                "fix {idx} {group_idx} temp/berendsen {Tstart} {Tstop} {Tdamp}".format(
+                    idx=fix_ids["berendsen_temp"],
+                    group_idx="all",
+                    Tstart=self.thermostat.T,
+                    Tstop=self.thermostat.T,
+                    Tdamp=self.thermostat.tau,
+                )
+            ]
         if isinstance(self.barostat, md.BerendsenBarostat):
-            fix_ids['berendsen_press'] = self.new_fix_id()
-            cmds += ['fix {idx} {group_idx} press/berendsen iso {Pstart} {Pstop} {Pdamp}'.format(idx=fix_ids['berendsen_press'],
-                                                                                                 group_idx='all',
-                                                                                                 Pstart=self.barostat.P,
-                                                                                                 Pstop=self.barostat.P,
-                                                                                                 Pdamp=self.barostat.tau)]
+            fix_ids["berendsen_press"] = self.new_fix_id()
+            cmds += [
+                (
+                    "fix {idx} {group_idx} press/berendsen iso"
+                    " {Pstart} {Pstop} {Pdamp}"
+                ).format(
+                    idx=fix_ids["berendsen_press"],
+                    group_idx="all",
+                    Pstart=self.barostat.P,
+                    Pstop=self.barostat.P,
+                    Pdamp=self.barostat.tau,
+                )
+            ]
 
         cmds += self._run_commands(sim)
-        cmds += ['unfix {}'.format(idx) for idx in fix_ids.values()]
+        cmds += ["unfix {}".format(idx) for idx in fix_ids.values()]
         return cmds
+
 
 class EnsembleAverage(simulate.AnalysisOperation, LAMMPSOperation):
     """Analyzes the simulation ensemble and rdf at specified timestep intervals.
@@ -566,7 +647,8 @@ class EnsembleAverage(simulate.AnalysisOperation, LAMMPSOperation):
     Parameters
     ----------
     check_thermo_every : int
-        Interval of time steps at which to log thermodynamic properties of the simulation.
+        Interval of time steps at which to log thermodynamic properties of the
+        simulation.
     check_rdf_every : int
         Interval of time steps at which to log the rdf of the simulation.
     rdf_dr : float
@@ -579,113 +661,147 @@ class EnsembleAverage(simulate.AnalysisOperation, LAMMPSOperation):
         at the same time.
 
     """
+
     def __init__(self, check_thermo_every, check_rdf_every, rdf_dr):
         self.check_thermo_every = check_thermo_every
         self.check_rdf_every = check_rdf_every
         self.rdf_dr = rdf_dr
 
     def to_commands(self, sim):
-        fix_ids = {'thermo_avg': self.new_fix_id(),
-                   'rdf_avg': self.new_fix_id()}
-        compute_ids = {'rdf': self.new_compute_id()}
-        var_ids = {'T': self.new_variable_id(),
-                   'P': self.new_variable_id(),
-                   'Lx': self.new_variable_id(),
-                   'Ly': self.new_variable_id(),
-                   'Lz': self.new_variable_id(),
-                   'xy': self.new_variable_id(),
-                   'xz': self.new_variable_id(),
-                   'yz': self.new_variable_id()}
+        fix_ids = {"thermo_avg": self.new_fix_id(), "rdf_avg": self.new_fix_id()}
+        compute_ids = {"rdf": self.new_compute_id()}
+        var_ids = {
+            "T": self.new_variable_id(),
+            "P": self.new_variable_id(),
+            "Lx": self.new_variable_id(),
+            "Ly": self.new_variable_id(),
+            "Lz": self.new_variable_id(),
+            "xy": self.new_variable_id(),
+            "xz": self.new_variable_id(),
+            "yz": self.new_variable_id(),
+        }
 
         group_ids = {}
         for i in sim.types:
             typeid = sim[sim.initializer].lammps_types[i]
-            typekey = 'N_{}'.format(typeid)
+            typekey = "N_{}".format(typeid)
             group_ids[typekey] = self.new_group_id()
             var_ids[typekey] = self.new_variable_id()
 
         # generate temporary file names
         if mpi.world.rank_is_root:
-            file_ = {'thermo': sim.directory.file(str(uuid.uuid4().hex)),
-                     'rdf': sim.directory.file(str(uuid.uuid4().hex))}
+            file_ = {
+                "thermo": sim.directory.file(str(uuid.uuid4().hex)),
+                "rdf": sim.directory.file(str(uuid.uuid4().hex)),
+            }
         else:
             file_ = None
         file_ = mpi.world.bcast(file_)
 
         # thermodynamic properties
-        sim[self].thermo_file = file_['thermo']
+        sim[self].thermo_file = file_["thermo"]
         cmds = [
-                'variable {} equal temp'.format(var_ids['T']),
-                'variable {} equal press'.format(var_ids['P']),
-                'variable {} equal lx'.format(var_ids['Lx']),
-                'variable {} equal ly'.format(var_ids['Ly']),
-                'variable {} equal lz'.format(var_ids['Lz']),
-                'variable {} equal xy'.format(var_ids['xy']),
-                'variable {} equal xz'.format(var_ids['xz']),
-                'variable {} equal yz'.format(var_ids['yz'])]
+            "variable {} equal temp".format(var_ids["T"]),
+            "variable {} equal press".format(var_ids["P"]),
+            "variable {} equal lx".format(var_ids["Lx"]),
+            "variable {} equal ly".format(var_ids["Ly"]),
+            "variable {} equal lz".format(var_ids["Lz"]),
+            "variable {} equal xy".format(var_ids["xy"]),
+            "variable {} equal xz".format(var_ids["xz"]),
+            "variable {} equal yz".format(var_ids["yz"]),
+        ]
         N_vars = []
         for i in sim.types:
             typeid = sim[sim.initializer].lammps_types[i]
-            typekey = 'N_{}'.format(typeid)
-            cmds += ['group {gid} type {typeid}'.format(gid=group_ids[typekey], typeid=typeid),
-                     'variable {vid} equal "count({gid})"'.format(vid=var_ids[typekey], gid=group_ids[typekey])]
-            N_vars.append('v_{'  + typekey + '}')
+            typekey = "N_{}".format(typeid)
+            cmds += [
+                "group {gid} type {typeid}".format(
+                    gid=group_ids[typekey], typeid=typeid
+                ),
+                'variable {vid} equal "count({gid})"'.format(
+                    vid=var_ids[typekey], gid=group_ids[typekey]
+                ),
+            ]
+            N_vars.append("v_{" + typekey + "}")
         cmds += [
-                ('fix {fixid} all ave/time {every} 1 {every}'
-                 ' v_{T} v_{P} v_{Lx} v_{Ly} v_{Lz} v_{xy} v_{xz} v_{yz}'
-                 + ' ' + ' '.join(N_vars) +
-                 ' mode scalar ave running'
-                 ' file {filename} overwrite format " %.16e"').format(fixid=fix_ids['thermo_avg'],
-                                                                      every=self.check_thermo_every,
-                                                                      filename=sim[self].thermo_file,
-                                                                      **var_ids)
-                ]
+            (
+                "fix {fixid} all ave/time {every} 1 {every}"
+                " v_{T} v_{P} v_{Lx} v_{Ly} v_{Lz} v_{xy} v_{xz} v_{yz}"
+                + " "
+                + " ".join(N_vars)
+                + " mode scalar ave running"
+                ' file {filename} overwrite format " %.16e"'
+            ).format(
+                fixid=fix_ids["thermo_avg"],
+                every=self.check_thermo_every,
+                filename=sim[self].thermo_file,
+                **var_ids,
+            )
+        ]
 
         # pair distribution function
         rmax = sim.potentials.pair.r[-1]
-        sim[self].num_bins = numpy.round(rmax/self.rdf_dr).astype(int)
-        sim[self].rdf_file = file_['rdf']
+        sim[self].num_bins = numpy.round(rmax / self.rdf_dr).astype(int)
+        sim[self].rdf_file = file_["rdf"]
         sim[self].rdf_pairs = tuple(sim.pairs)
         # string format lammps arguments based on pairs
         # _pairs is the list of all pairs by LAMMPS type id, in ensemble order
         # _computes is the RDF values for each pair, with the r bin centers prepended
         _pairs = []
-        _computes = ['c_{}[1]'.format(compute_ids['rdf'])]
-        for idx,(i,j) in enumerate(sim[self].rdf_pairs):
-            _pairs.append('{} {}'.format(sim[sim.initializer].lammps_types[i],sim[sim.initializer].lammps_types[j]))
-            _computes.append('c_{}[{}]'.format(compute_ids['rdf'], 2*(idx+1)))
-        cmds += ['compute {rdf} all rdf {bins} {pairs}'.format(rdf=compute_ids['rdf'],bins=sim[self].num_bins,pairs=' '.join(_pairs)),
-                 ('fix {fixid} all ave/time {every} 1 {every}'
-                  ' {computes} mode vector ave running off 1'
-                  ' file {filename} overwrite format " %.16e"').format(fixid=fix_ids['rdf_avg'],
-                                                                       every=self.check_rdf_every,
-                                                                       computes=' '.join(_computes),
-                                                                       filename=sim[self].rdf_file)
-                ]
+        _computes = ["c_{}[1]".format(compute_ids["rdf"])]
+        for idx, (i, j) in enumerate(sim[self].rdf_pairs):
+            _pairs.append(
+                "{} {}".format(
+                    sim[sim.initializer].lammps_types[i],
+                    sim[sim.initializer].lammps_types[j],
+                )
+            )
+            _computes.append("c_{}[{}]".format(compute_ids["rdf"], 2 * (idx + 1)))
+        cmds += [
+            "compute {rdf} all rdf {bins} {pairs}".format(
+                rdf=compute_ids["rdf"], bins=sim[self].num_bins, pairs=" ".join(_pairs)
+            ),
+            (
+                "fix {fixid} all ave/time {every} 1 {every}"
+                " {computes} mode vector ave running off 1"
+                ' file {filename} overwrite format " %.16e"'
+            ).format(
+                fixid=fix_ids["rdf_avg"],
+                every=self.check_rdf_every,
+                computes=" ".join(_computes),
+                filename=sim[self].rdf_file,
+            ),
+        ]
 
         return cmds
 
     def finalize(self, sim):
         # extract thermo properties
-        # we skip the first 2 rows, which are LAMMPS junk, and slice out the timestep from col. 0
-        thermo = mpi.world.loadtxt(sim[self].thermo_file,skiprows=2)[1:]
-        N = {i: Ni for i,Ni in zip(sim.types, thermo[8:8+len(sim.types)])}
-        V = extent.TriclinicBox(Lx=thermo[2],Ly=thermo[3],Lz=thermo[4],
-                        xy=thermo[5],xz=thermo[6],yz=thermo[7],
-                        convention='LAMMPS')
-        ens = ensemble.Ensemble(N=N,
-                                T=thermo[0],
-                                P=thermo[1],
-                                V=V)
+        # we skip the first 2 rows, which are LAMMPS junk, and slice out the
+        # timestep from col. 0
+        thermo = mpi.world.loadtxt(sim[self].thermo_file, skiprows=2)[1:]
+        N = {i: Ni for i, Ni in zip(sim.types, thermo[8 : 8 + len(sim.types)])}
+        V = extent.TriclinicBox(
+            Lx=thermo[2],
+            Ly=thermo[3],
+            Lz=thermo[4],
+            xy=thermo[5],
+            xz=thermo[6],
+            yz=thermo[7],
+            convention="LAMMPS",
+        )
+        ens = ensemble.Ensemble(N=N, T=thermo[0], P=thermo[1], V=V)
 
         # extract rdfs
         # LAMMPS injects a column for the row index, so we start at column 1 for r
-        # we skip the first 4 rows, which are LAMMPS junk, and slice out the first column
-        rdf = mpi.world.loadtxt(sim[self].rdf_file,skiprows=4)[:,1:]
-        for i,pair in enumerate(sim[self].rdf_pairs):
-            ens.rdf[pair] = ensemble.RDF(rdf[:,0],rdf[:,i+1])
+        # we skip the first 4 rows, which are LAMMPS junk, and slice out the
+        # first column
+        rdf = mpi.world.loadtxt(sim[self].rdf_file, skiprows=4)[:, 1:]
+        for i, pair in enumerate(sim[self].rdf_pairs):
+            ens.rdf[pair] = ensemble.RDF(rdf[:, 0], rdf[:, i + 1])
 
         sim[self].ensemble = ens
+
 
 class LAMMPS(simulate.Simulation):
     """Simulation using LAMMPS.
@@ -695,14 +811,16 @@ class LAMMPS(simulate.Simulation):
     GPUs, as a single process or with MPI parallelism. The launch configuration
     will be automatically selected for you when the simulation is run.
 
-    LAMMPS must be built with its `Python interface <https://docs.lammps.org/Python_head.html>`_
-    and must be version 29 Sep 2021 or newer.
+    LAMMPS must be built with its
+    `Python interface <https://docs.lammps.org/Python_head.html>`_ and must be
+    version 29 Sep 2021 or newer.
 
     .. warning::
 
         LAMMPS requires that tabulated pair potentials do not include an entry for
-        :math:`r = 0`. Make sure to set :attr:`~relentless.simulate.PairPotentialTabulator.rmin`
-        to a small value larger than 0.
+        :math:`r = 0`. Make sure to set
+        :attr:`~relentless.simulate.PairPotentialTabulator.rmin` to a small value
+        larger than 0.
 
     Parameters
     ----------
@@ -724,9 +842,10 @@ class LAMMPS(simulate.Simulation):
         If the :mod:`lammps` package is not found.
 
     """
+
     def __init__(self, initializer, operations=None, dimension=3, quiet=True):
         if not _lammps_found:
-            raise ImportError('LAMMPS not found.')
+            raise ImportError("LAMMPS not found.")
 
         super().__init__(initializer, operations)
         self.dimension = dimension
@@ -738,17 +857,26 @@ class LAMMPS(simulate.Simulation):
         # add the lammps engine to the instance
         if self.quiet:
             # create lammps instance with all output disabled
-            launch_args = ['-echo','none',
-                           '-log','none',
-                           '-screen','none',
-                           '-nocite']
+            launch_args = [
+                "-echo",
+                "none",
+                "-log",
+                "none",
+                "-screen",
+                "none",
+                "-nocite",
+            ]
         else:
-            launch_args = ['-echo','screen',
-                           '-log', sim.directory.file('log.lammps'),
-                           '-nocite']
+            launch_args = [
+                "-echo",
+                "screen",
+                "-log",
+                sim.directory.file("log.lammps"),
+                "-nocite",
+            ]
         sim.lammps = lammps.lammps(cmdargs=launch_args)
         if sim.lammps.version() < 20210929:
-            raise ImportError('Only LAMMPS 29 Sep 2021 or newer is supported.')
+            raise ImportError("Only LAMMPS 29 Sep 2021 or newer is supported.")
 
         # run the initializer
         sim.dimension = self.dimension
@@ -777,59 +905,65 @@ class LAMMPS(simulate.Simulation):
 
         """
         if sim.potentials.pair.rmin == 0:
-            raise ValueError('LAMMPS requires rmin > 0 for pair potentials')
+            raise ValueError("LAMMPS requires rmin > 0 for pair potentials")
         r = sim.potentials.pair.r
         Nr = len(r)
         if Nr == 1:
-            raise ValueError('LAMMPS requires at least two points in the tabulated potential.')
+            raise ValueError(
+                "LAMMPS requires at least two points in the tabulated potential."
+            )
 
         # check that all r are equally spaced
-        dr = r[1:]-r[:-1]
-        if not numpy.all(numpy.isclose(dr,dr[0])):
-            raise ValueError('LAMMPS requires equally spaced r in pair potentials.')
+        dr = r[1:] - r[:-1]
+        if not numpy.all(numpy.isclose(dr, dr[0])):
+            raise ValueError("LAMMPS requires equally spaced r in pair potentials.")
 
-        def pair_map(sim,pair):
+        def pair_map(sim, pair):
             # Map lammps type indexes as a pair, lowest type first
-            i,j = pair
+            i, j = pair
             id_i = sim[sim.initializer].lammps_types[i]
             id_j = sim[sim.initializer].lammps_types[j]
             if id_i > id_j:
-                id_i,id_j = id_j,id_i
+                id_i, id_j = id_j, id_i
 
-            return id_i,id_j
+            return id_i, id_j
 
         # write all potentials into a file
         if mpi.world.rank_is_root:
             file_ = sim.directory.file(str(uuid.uuid4().hex))
-            with open(file_, 'w') as fw:
-                fw.write('# LAMMPS tabulated pair potentials\n')
+            with open(file_, "w") as fw:
+                fw.write("# LAMMPS tabulated pair potentials\n")
                 rcut = {}
-                for i,j in sim.pairs:
-                    id_i,id_j = pair_map(sim,(i,j))
-                    fw.write(('# pair ({i},{j})\n'
-                              '\n'
-                              'TABLE_{id_i}_{id_j}\n').format(i=i,
-                                                              j=j,
-                                                              id_i=id_i,
-                                                              id_j=id_j)
-                            )
-                    fw.write('N {N} R {rmin} {rmax}\n\n'.format(N=Nr,
-                                                                rmin=r[0],
-                                                                rmax=r[-1]))
+                for i, j in sim.pairs:
+                    id_i, id_j = pair_map(sim, (i, j))
+                    fw.write(
+                        ("# pair ({i},{j})\n" "\n" "TABLE_{id_i}_{id_j}\n").format(
+                            i=i, j=j, id_i=id_i, id_j=id_j
+                        )
+                    )
+                    fw.write(
+                        "N {N} R {rmin} {rmax}\n\n".format(N=Nr, rmin=r[0], rmax=r[-1])
+                    )
 
-                    u = sim.potentials.pair.energy((i,j))
-                    f = sim.potentials.pair.force((i,j))
+                    u = sim.potentials.pair.energy((i, j))
+                    f = sim.potentials.pair.force((i, j))
                     for idx in range(Nr):
-                        fw.write('{idx} {r} {u} {f}\n'.format(idx=idx+1,r=r[idx],u=u[idx],f=f[idx]))
+                        fw.write(
+                            "{idx} {r} {u} {f}\n".format(
+                                idx=idx + 1, r=r[idx], u=u[idx], f=f[idx]
+                            )
+                        )
 
                     # find r where potential and force are zero
-                    nonzero_r = numpy.flatnonzero(numpy.logical_and(~numpy.isclose(u,0),~numpy.isclose(f,0)))
+                    nonzero_r = numpy.flatnonzero(
+                        numpy.logical_and(~numpy.isclose(u, 0), ~numpy.isclose(f, 0))
+                    )
                     if len(nonzero_r) > 1:
                         # cutoff at last nonzero r (cannot be first r)
-                        rcut[(i,j)] = r[nonzero_r[-1]]
+                        rcut[(i, j)] = r[nonzero_r[-1]]
                     else:
                         # if first or second r is nonzero, cutoff at second
-                        rcut[(i,j)] = r[1]
+                        rcut[(i, j)] = r[1]
         else:
             rcut = None
             file_ = None
@@ -837,16 +971,20 @@ class LAMMPS(simulate.Simulation):
         file_ = mpi.world.bcast(file_)
 
         # process all lammps commands
-        cmds = ['neighbor {skin} multi'.format(skin=sim.potentials.pair.neighbor_buffer)]
-        cmds += ['pair_style table linear {N}'.format(N=Nr)]
+        cmds = [
+            "neighbor {skin} multi".format(skin=sim.potentials.pair.neighbor_buffer)
+        ]
+        cmds += ["pair_style table linear {N}".format(N=Nr)]
 
-        for i,j in sim.pairs:
+        for i, j in sim.pairs:
             # get lammps type indexes, lowest type first
-            id_i,id_j = pair_map(sim,(i,j))
-            cmds += ['pair_coeff {id_i} {id_j} {filename} TABLE_{id_i}_{id_j} {cutoff}'.format(id_i=id_i,
-                                                                                               id_j=id_j,
-                                                                                               filename=file_,
-                                                                                               cutoff=rcut[(i,j)])]
+            id_i, id_j = pair_map(sim, (i, j))
+            cmds += [
+                (
+                    "pair_coeff {id_i} {id_j} {filename}"
+                    " TABLE_{id_i}_{id_j} {cutoff}"
+                ).format(id_i=id_i, id_j=id_j, filename=file_, cutoff=rcut[(i, j)])
+            ]
 
         sim.lammps.commands_list(cmds)
 

--- a/relentless/simulate/md.py
+++ b/relentless/simulate/md.py
@@ -1,5 +1,6 @@
 from . import simulate
 
+
 class MinimizeEnergy(simulate.GenericOperation):
     """Perform energy minimization on a configuration.
 
@@ -17,8 +18,10 @@ class MinimizeEnergy(simulate.GenericOperation):
         Additional options for energy minimizer (defaults to ``None``).
 
     """
+
     def __init__(self, energy_tolerance, force_tolerance, max_iterations, options=None):
         super().__init__(energy_tolerance, force_tolerance, max_iterations, options)
+
 
 class RunBrownianDynamics(simulate.GenericOperation):
     """Perform a Brownian dynamics simulation.
@@ -41,8 +44,10 @@ class RunBrownianDynamics(simulate.GenericOperation):
         Analysis operations to perform with run (defaults to ``None``).
 
     """
+
     def __init__(self, steps, timestep, T, friction, seed, analyzers=None):
         super().__init__(steps, timestep, T, friction, seed, analyzers)
+
 
 class RunLangevinDynamics(simulate.GenericOperation):
     """Perform a Langevin dynamics simulation.
@@ -65,8 +70,10 @@ class RunLangevinDynamics(simulate.GenericOperation):
         Analysis operations to perform with run (defaults to ``None``).
 
     """
+
     def __init__(self, steps, timestep, T, friction, seed, analyzers=None):
         super().__init__(steps, timestep, T, friction, seed, analyzers)
+
 
 class RunMolecularDynamics(simulate.GenericOperation):
     """Perform a molecular dynamics simulation.
@@ -93,8 +100,10 @@ class RunMolecularDynamics(simulate.GenericOperation):
         Analysis operations to perform with run (defaults to ``None``).
 
     """
+
     def __init__(self, steps, timestep, thermostat=None, barostat=None, analyzers=None):
         super().__init__(steps, timestep, thermostat, barostat, analyzers)
+
 
 class Thermostat:
     """Thermostat.
@@ -108,8 +117,10 @@ class Thermostat:
         Target temperature.
 
     """
+
     def __init__(self, T):
         self.T = T
+
 
 class BerendsenThermostat(Thermostat):
     """Berendsen thermostat.
@@ -124,9 +135,11 @@ class BerendsenThermostat(Thermostat):
         Coupling time constant.
 
     """
+
     def __init__(self, T, tau):
         super().__init__(T)
         self.tau = tau
+
 
 class NoseHooverThermostat(Thermostat):
     """Nosé-Hoover thermostat.
@@ -139,9 +152,11 @@ class NoseHooverThermostat(Thermostat):
         Coupling time constant.
 
     """
+
     def __init__(self, T, tau):
         super().__init__(T)
         self.tau = tau
+
 
 class Barostat:
     """Barostat.
@@ -155,8 +170,10 @@ class Barostat:
         Target pressure.
 
     """
+
     def __init__(self, P):
         self.P = P
+
 
 class BerendsenBarostat(Barostat):
     """Berendsen barostat.
@@ -171,9 +188,11 @@ class BerendsenBarostat(Barostat):
         Coupling time constant.
 
     """
+
     def __init__(self, P, tau):
         super().__init__(P)
         self.tau = tau
+
 
 class MTKBarostat(Barostat):
     """MTK barostat.
@@ -188,7 +207,7 @@ class MTKBarostat(Barostat):
         Coupling time constant.
 
     """
+
     def __init__(self, P, tau):
         super().__init__(P)
         self.tau = tau
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
+black
+flake8
+isort
 pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,8 @@ install_requires =
     numpy
     packaging
     scipy
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+per-file-ignores = __init__.py:F401

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 import setuptools
+
 setuptools.setup()

--- a/tests/model/potential/test_pair.py
+++ b/tests/model/potential/test_pair.py
@@ -7,139 +7,154 @@ import numpy
 
 import relentless
 
+
 class test_PairParameters(unittest.TestCase):
     """Unit tests for relentless.pair.PairParameters"""
 
     def test_init(self):
         """Test creation from data"""
-        types = ('A','B')
-        pairs = (('A','B'), ('B','B'), ('A','A'))
-        params = ('energy', 'mass')
+        types = ("A", "B")
+        pairs = (("A", "B"), ("B", "B"), ("A", "A"))
+        params = ("energy", "mass")
 
         # test construction with tuple input
-        m = relentless.model.potential.PairParameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.model.potential.PairParameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         # test construction with list input
-        m = relentless.model.potential.PairParameters(types=['A','B'], params=('energy','mass'))
+        m = relentless.model.potential.PairParameters(
+            types=["A", "B"], params=("energy", "mass")
+        )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         # test construction with mixed tuple/list input
-        m = relentless.model.potential.PairParameters(types=('A','B'), params=['energy','mass'])
+        m = relentless.model.potential.PairParameters(
+            types=("A", "B"), params=["energy", "mass"]
+        )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
         self.assertCountEqual(m.pairs, pairs)
 
         # test construction with int type parameters
         with self.assertRaises(TypeError):
-            m = relentless.model.potential.PairParameters(types=('A','B'), params=(1,2))
+            m = relentless.model.potential.PairParameters(
+                types=("A", "B"), params=(1, 2)
+            )
 
         # test construction with mixed type parameters
         with self.assertRaises(TypeError):
-            m = relentless.model.potential.PairParameters(types=('A','B'), params=('1',2))
+            m = relentless.model.potential.PairParameters(
+                types=("A", "B"), params=("1", 2)
+            )
 
     def test_param_types(self):
         """Test various get and set methods on pair parameter types"""
-        m = relentless.model.potential.PairParameters(types=('A','B'), params=('energy', 'mass'))
+        m = relentless.model.potential.PairParameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
 
-        self.assertEqual(m.shared['energy'], None)
-        self.assertEqual(m.shared['mass'], None)
-        self.assertEqual(m['A','A']['energy'], None)
-        self.assertEqual(m['A','A']['mass'], None)
-        self.assertEqual(m['A','B']['energy'], None)
-        self.assertEqual(m['A','B']['mass'], None)
-        self.assertEqual(m['B','B']['energy'], None)
-        self.assertEqual(m['B','B']['mass'], None)
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        self.assertEqual(m.shared["energy"], None)
+        self.assertEqual(m.shared["mass"], None)
+        self.assertEqual(m["A", "A"]["energy"], None)
+        self.assertEqual(m["A", "A"]["mass"], None)
+        self.assertEqual(m["A", "B"]["energy"], None)
+        self.assertEqual(m["A", "B"]["mass"], None)
+        self.assertEqual(m["B", "B"]["energy"], None)
+        self.assertEqual(m["B", "B"]["mass"], None)
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
         # test setting shared params
         m.shared.update(energy=1.0, mass=2.0)
 
-        self.assertEqual(m.shared['energy'], 1.0)
-        self.assertEqual(m.shared['mass'], 2.0)
-        self.assertEqual(m['A','A']['energy'], None)
-        self.assertEqual(m['A','A']['mass'], None)
-        self.assertEqual(m['A','B']['energy'], None)
-        self.assertEqual(m['A','B']['mass'], None)
-        self.assertEqual(m['B','B']['energy'], None)
-        self.assertEqual(m['B','B']['mass'], None)
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        self.assertEqual(m.shared["energy"], 1.0)
+        self.assertEqual(m.shared["mass"], 2.0)
+        self.assertEqual(m["A", "A"]["energy"], None)
+        self.assertEqual(m["A", "A"]["mass"], None)
+        self.assertEqual(m["A", "B"]["energy"], None)
+        self.assertEqual(m["A", "B"]["mass"], None)
+        self.assertEqual(m["B", "B"]["energy"], None)
+        self.assertEqual(m["B", "B"]["mass"], None)
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
         # test setting per-pair params
-        m['A','A'].update(energy=1.5, mass=2.5)
-        m['A','B'].update(energy=2.0, mass=3.0)
-        m['B','B'].update(energy=0.5, mass=0.7)
+        m["A", "A"].update(energy=1.5, mass=2.5)
+        m["A", "B"].update(energy=2.0, mass=3.0)
+        m["B", "B"].update(energy=0.5, mass=0.7)
 
-        self.assertEqual(m.shared['energy'], 1.0)
-        self.assertEqual(m.shared['mass'], 2.0)
-        self.assertEqual(m['A','A']['energy'], 1.5)
-        self.assertEqual(m['A','A']['mass'], 2.5)
-        self.assertEqual(m['A','B']['energy'], 2.0)
-        self.assertEqual(m['A','B']['mass'], 3.0)
-        self.assertEqual(m['B','B']['energy'], 0.5)
-        self.assertEqual(m['B','B']['mass'], 0.7)
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        self.assertEqual(m.shared["energy"], 1.0)
+        self.assertEqual(m.shared["mass"], 2.0)
+        self.assertEqual(m["A", "A"]["energy"], 1.5)
+        self.assertEqual(m["A", "A"]["mass"], 2.5)
+        self.assertEqual(m["A", "B"]["energy"], 2.0)
+        self.assertEqual(m["A", "B"]["mass"], 3.0)
+        self.assertEqual(m["B", "B"]["energy"], 0.5)
+        self.assertEqual(m["B", "B"]["mass"], 0.7)
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
         # test setting per-type params
-        m['A'].update(energy=0.1, mass=0.2)
-        m['B'].update(energy=0.2, mass=0.1)
+        m["A"].update(energy=0.1, mass=0.2)
+        m["B"].update(energy=0.2, mass=0.1)
 
-        self.assertEqual(m.shared['energy'], 1.0)
-        self.assertEqual(m.shared['mass'], 2.0)
-        self.assertEqual(m['A','A']['energy'], 1.5)
-        self.assertEqual(m['A','A']['mass'], 2.5)
-        self.assertEqual(m['A','B']['energy'], 2.0)
-        self.assertEqual(m['A','B']['mass'], 3.0)
-        self.assertEqual(m['B','B']['energy'], 0.5)
-        self.assertEqual(m['B','B']['mass'], 0.7)
-        self.assertEqual(m['A']['energy'], 0.1)
-        self.assertEqual(m['A']['mass'], 0.2)
-        self.assertEqual(m['B']['energy'], 0.2)
-        self.assertEqual(m['B']['mass'], 0.1)
+        self.assertEqual(m.shared["energy"], 1.0)
+        self.assertEqual(m.shared["mass"], 2.0)
+        self.assertEqual(m["A", "A"]["energy"], 1.5)
+        self.assertEqual(m["A", "A"]["mass"], 2.5)
+        self.assertEqual(m["A", "B"]["energy"], 2.0)
+        self.assertEqual(m["A", "B"]["mass"], 3.0)
+        self.assertEqual(m["B", "B"]["energy"], 0.5)
+        self.assertEqual(m["B", "B"]["mass"], 0.7)
+        self.assertEqual(m["A"]["energy"], 0.1)
+        self.assertEqual(m["A"]["mass"], 0.2)
+        self.assertEqual(m["B"]["energy"], 0.2)
+        self.assertEqual(m["B"]["mass"], 0.1)
+
 
 class LinPot(relentless.model.potential.PairPotential):
-    """Linear potential function used to test relentless.model.potential.PairPotential"""
+    """Linear potential function"""
 
     def __init__(self, types, params):
         super().__init__(types, params)
 
     def _energy(self, r, m, **params):
-        r,u,s = self._zeros(r)
-        u[:] = m*r
+        r, u, s = self._zeros(r)
+        u[:] = m * r
         if s:
             u = u.item()
         return u
 
     def _force(self, r, m, **params):
-        r,f,s = self._zeros(r)
+        r, f, s = self._zeros(r)
         f[:] = -m
         if s:
             f = f.item()
         return f
 
     def _derivative(self, param, r, **params):
-        r,d,s = self._zeros(r)
-        if param == 'm':
+        r, d, s = self._zeros(r)
+        if param == "m":
             d[:] = r
         if s:
             d = d.item()
         return d
 
+
 class TwoVarPot(relentless.model.potential.PairPotential):
-    """Mock potential function used to test relentless.model.potential.PairPotential.derivative"""
+    """Mock potential function"""
 
     def __init__(self, types, params):
         super().__init__(types, params)
@@ -152,14 +167,15 @@ class TwoVarPot(relentless.model.potential.PairPotential):
 
     def _derivative(self, param, r, **params):
         # not real derivative, just used to test functionality
-        r,d,s = self._zeros(r)
-        if param == 'x':
-            d[:] = 2*r
-        elif param == 'y':
-            d[:] = 3*r
+        r, d, s = self._zeros(r)
+        if param == "x":
+            d[:] = 2 * r
+        elif param == "y":
+            d[:] = 3 * r
         if s:
             d = d.item()
         return d
+
 
 class test_PairPotential(unittest.TestCase):
     """Unit tests for relentless.model.potential.PairPotential"""
@@ -167,305 +183,327 @@ class test_PairPotential(unittest.TestCase):
     def test_init(self):
         """Test creation from data"""
         # test creation with only m
-        p = LinPot(types=('1',), params=('m',))
-        p.coeff['1','1']['m'] = 3.5
+        p = LinPot(types=("1",), params=("m",))
+        p.coeff["1", "1"]["m"] = 3.5
 
-        coeff = relentless.model.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
-        coeff['1','1']['m'] = 3.5
-        coeff['1','1']['rmin'] = False
-        coeff['1','1']['rmax'] = False
-        coeff['1','1']['shift'] = False
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("m", "rmin", "rmax", "shift")
+        )
+        coeff["1", "1"]["m"] = 3.5
+        coeff["1", "1"]["rmin"] = False
+        coeff["1", "1"]["rmax"] = False
+        coeff["1", "1"]["shift"] = False
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(("1", "1")), coeff.evaluate(("1", "1")))
 
         # test creation with m and rmin
-        p = LinPot(types=('1',), params=('m','rmin'))
-        p.coeff['1','1']['m'] = 3.5
-        p.coeff['1','1']['rmin'] = 0.0
+        p = LinPot(types=("1",), params=("m", "rmin"))
+        p.coeff["1", "1"]["m"] = 3.5
+        p.coeff["1", "1"]["rmin"] = 0.0
 
-        coeff = relentless.model.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
-        coeff['1','1']['m'] = 3.5
-        coeff['1','1']['rmin'] = 0.0
-        coeff['1','1']['rmax'] = False
-        coeff['1','1']['shift'] = False
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("m", "rmin", "rmax", "shift")
+        )
+        coeff["1", "1"]["m"] = 3.5
+        coeff["1", "1"]["rmin"] = 0.0
+        coeff["1", "1"]["rmax"] = False
+        coeff["1", "1"]["shift"] = False
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(("1", "1")), coeff.evaluate(("1", "1")))
 
         # test creation with m and rmax
-        p = LinPot(types=('1',), params=('m','rmax'))
-        p.coeff['1','1']['m'] = 3.5
-        p.coeff['1','1']['rmax'] = 1.0
+        p = LinPot(types=("1",), params=("m", "rmax"))
+        p.coeff["1", "1"]["m"] = 3.5
+        p.coeff["1", "1"]["rmax"] = 1.0
 
-        coeff = relentless.model.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
-        coeff['1','1']['m'] = 3.5
-        coeff['1','1']['rmin'] = False
-        coeff['1','1']['rmax'] = 1.0
-        coeff['1','1']['shift'] = False
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("m", "rmin", "rmax", "shift")
+        )
+        coeff["1", "1"]["m"] = 3.5
+        coeff["1", "1"]["rmin"] = False
+        coeff["1", "1"]["rmax"] = 1.0
+        coeff["1", "1"]["shift"] = False
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(("1", "1")), coeff.evaluate(("1", "1")))
 
         # test creation with m and shift
-        p = LinPot(types=('1',), params=('m','shift'))
-        p.coeff['1','1']['m'] = 3.5
-        p.coeff['1','1']['shift'] = True
+        p = LinPot(types=("1",), params=("m", "shift"))
+        p.coeff["1", "1"]["m"] = 3.5
+        p.coeff["1", "1"]["shift"] = True
 
-        coeff = relentless.model.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
-        coeff['1','1']['m'] = 3.5
-        coeff['1','1']['rmin'] = False
-        coeff['1','1']['rmax'] = False
-        coeff['1','1']['shift'] = True
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("m", "rmin", "rmax", "shift")
+        )
+        coeff["1", "1"]["m"] = 3.5
+        coeff["1", "1"]["rmin"] = False
+        coeff["1", "1"]["rmax"] = False
+        coeff["1", "1"]["shift"] = True
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(("1", "1")), coeff.evaluate(("1", "1")))
 
         # test creation with all params
-        p = LinPot(types=('1',), params=('m','rmin','rmax','shift'))
-        p.coeff['1','1']['m'] = 3.5
-        p.coeff['1','1']['rmin'] = 0.0
-        p.coeff['1','1']['rmax'] = 1.0
-        p.coeff['1','1']['shift'] = True
+        p = LinPot(types=("1",), params=("m", "rmin", "rmax", "shift"))
+        p.coeff["1", "1"]["m"] = 3.5
+        p.coeff["1", "1"]["rmin"] = 0.0
+        p.coeff["1", "1"]["rmax"] = 1.0
+        p.coeff["1", "1"]["shift"] = True
 
-        coeff = relentless.model.potential.PairParameters(types=('1',), params=('m','rmin','rmax','shift'))
-        coeff['1','1']['m'] = 3.5
-        coeff['1','1']['rmin'] = 0.0
-        coeff['1','1']['rmax'] = 1.0
-        coeff['1','1']['shift'] = True
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("m", "rmin", "rmax", "shift")
+        )
+        coeff["1", "1"]["m"] = 3.5
+        coeff["1", "1"]["rmin"] = 0.0
+        coeff["1", "1"]["rmax"] = 1.0
+        coeff["1", "1"]["shift"] = True
 
         self.assertCountEqual(p.coeff.types, coeff.types)
         self.assertCountEqual(p.coeff.params, coeff.params)
-        self.assertEqual(p.coeff.evaluate(('1','1')), coeff.evaluate(('1','1')))
+        self.assertEqual(p.coeff.evaluate(("1", "1")), coeff.evaluate(("1", "1")))
 
     def test_energy(self):
         """Test energy method"""
-        p = LinPot(types=('1',), params=('m',))
-        p.coeff['1','1']['m'] = 2.0
+        p = LinPot(types=("1",), params=("m",))
+        p.coeff["1", "1"]["m"] = 2.0
 
         # test with no cutoffs
-        u = p.energy(pair=('1','1'), r=0.5)
+        u = p.energy(pair=("1", "1"), r=0.5)
         self.assertAlmostEqual(u, 1.0)
-        u = p.energy(pair=('1','1'), r=[0.25,0.75])
-        numpy.testing.assert_allclose(u, [0.5,1.5])
+        u = p.energy(pair=("1", "1"), r=[0.25, 0.75])
+        numpy.testing.assert_allclose(u, [0.5, 1.5])
 
         # test with rmin set
-        p.coeff['1','1']['rmin'] = 0.5
-        u = p.energy(pair=('1','1'), r=0.6)
+        p.coeff["1", "1"]["rmin"] = 0.5
+        u = p.energy(pair=("1", "1"), r=0.6)
         self.assertAlmostEqual(u, 1.2)
-        u = p.energy(pair=('1','1'), r=[0.25,0.75])
-        numpy.testing.assert_allclose(u, [1.0,1.5])
+        u = p.energy(pair=("1", "1"), r=[0.25, 0.75])
+        numpy.testing.assert_allclose(u, [1.0, 1.5])
 
         # test with rmax set
-        p.coeff['1','1'].update(rmin=False, rmax=1.5)
-        u = p.energy(pair=('1','1'), r=1.0)
+        p.coeff["1", "1"].update(rmin=False, rmax=1.5)
+        u = p.energy(pair=("1", "1"), r=1.0)
         self.assertAlmostEqual(u, 2.0)
-        u = p.energy(pair=('1','1'), r=[0.25,1.75])
-        numpy.testing.assert_allclose(u, [0.5,3.0])
+        u = p.energy(pair=("1", "1"), r=[0.25, 1.75])
+        numpy.testing.assert_allclose(u, [0.5, 3.0])
 
         # test with rmin and rmax set
-        p.coeff['1','1']['rmin'] = 0.5
-        u = p.energy(pair=('1','1'), r=0.75)
+        p.coeff["1", "1"]["rmin"] = 0.5
+        u = p.energy(pair=("1", "1"), r=0.75)
         self.assertAlmostEqual(u, 1.5)
-        u = p.energy(pair=('1','1'), r=[0.25,0.5,1.5,1.75])
-        numpy.testing.assert_allclose(u, [1.0,1.0,3.0,3.0])
+        u = p.energy(pair=("1", "1"), r=[0.25, 0.5, 1.5, 1.75])
+        numpy.testing.assert_allclose(u, [1.0, 1.0, 3.0, 3.0])
 
         # test with shift set
-        p.coeff['1','1'].update(shift=True)
-        u = p.energy(pair=('1','1'), r=0.5)
+        p.coeff["1", "1"].update(shift=True)
+        u = p.energy(pair=("1", "1"), r=0.5)
         self.assertAlmostEqual(u, -2.0)
-        u = p.energy(pair=('1','1'), r=[0.25,0.75,1.0,1.5])
-        numpy.testing.assert_allclose(u, [-2.0,-1.5,-1.0,0.0])
+        u = p.energy(pair=("1", "1"), r=[0.25, 0.75, 1.0, 1.5])
+        numpy.testing.assert_allclose(u, [-2.0, -1.5, -1.0, 0.0])
 
         # test with shift set without rmax
-        p.coeff['1','1'].update(rmax=False)
+        p.coeff["1", "1"].update(rmax=False)
         with self.assertRaises(ValueError):
-            u = p.energy(pair=('1','1'), r=0.5)
+            u = p.energy(pair=("1", "1"), r=0.5)
 
     def test_force(self):
         """Test force method"""
-        p = LinPot(types=('1',), params=('m',))
-        p.coeff['1','1']['m'] = 2.0
+        p = LinPot(types=("1",), params=("m",))
+        p.coeff["1", "1"]["m"] = 2.0
 
         # test with no cutoffs
-        f = p.force(pair=('1','1'), r=0.5)
+        f = p.force(pair=("1", "1"), r=0.5)
         self.assertAlmostEqual(f, -2.0)
-        f = p.force(pair=('1','1'), r=[0.25,0.75])
-        numpy.testing.assert_allclose(f, [-2.0,-2.0])
+        f = p.force(pair=("1", "1"), r=[0.25, 0.75])
+        numpy.testing.assert_allclose(f, [-2.0, -2.0])
 
         # test with rmin set
-        p.coeff['1','1']['rmin'] = 0.5
-        f = p.force(pair=('1','1'), r=0.6)
+        p.coeff["1", "1"]["rmin"] = 0.5
+        f = p.force(pair=("1", "1"), r=0.6)
         self.assertAlmostEqual(f, -2.0)
-        f = p.force(pair=('1','1'), r=[0.25,0.75])
-        numpy.testing.assert_allclose(f, [0.0,-2.0])
+        f = p.force(pair=("1", "1"), r=[0.25, 0.75])
+        numpy.testing.assert_allclose(f, [0.0, -2.0])
 
         # test with rmax set
-        p.coeff['1','1'].update(rmin=False, rmax=1.5)
-        f = p.force(pair=('1','1'), r=1.0)
+        p.coeff["1", "1"].update(rmin=False, rmax=1.5)
+        f = p.force(pair=("1", "1"), r=1.0)
         self.assertAlmostEqual(f, -2.0)
-        f = p.force(pair=('1','1'), r=[0.25,1.75])
-        numpy.testing.assert_allclose(f, [-2.0,0.0])
+        f = p.force(pair=("1", "1"), r=[0.25, 1.75])
+        numpy.testing.assert_allclose(f, [-2.0, 0.0])
 
         # test with rmin and rmax set
-        p.coeff['1','1']['rmin'] = 0.5
-        f = p.force(pair=('1','1'), r=0.75)
+        p.coeff["1", "1"]["rmin"] = 0.5
+        f = p.force(pair=("1", "1"), r=0.75)
         self.assertAlmostEqual(f, -2.0)
-        f = p.force(pair=('1','1'), r=[0.25,0.5,1.5,1.75])
-        numpy.testing.assert_allclose(f, [0.0,-2.0,-2.0,0.0])
+        f = p.force(pair=("1", "1"), r=[0.25, 0.5, 1.5, 1.75])
+        numpy.testing.assert_allclose(f, [0.0, -2.0, -2.0, 0.0])
 
         # test with shift set
-        p.coeff['1','1'].update(shift=True)
-        f = p.force(pair=('1','1'), r=0.5)
+        p.coeff["1", "1"].update(shift=True)
+        f = p.force(pair=("1", "1"), r=0.5)
         self.assertAlmostEqual(f, -2.0)
-        f = p.force(pair=('1','1'), r=[1.0,1.5])
-        numpy.testing.assert_allclose(f, [-2.0,-2.0])
+        f = p.force(pair=("1", "1"), r=[1.0, 1.5])
+        numpy.testing.assert_allclose(f, [-2.0, -2.0])
 
     def test_derivative_values(self):
         """Test derivative method with different param values"""
-        p = LinPot(types=('1',), params=('m',))
+        p = LinPot(types=("1",), params=("m",))
         x = relentless.model.DesignVariable(value=2.0)
-        p.coeff['1','1']['m'] = x
+        p.coeff["1", "1"]["m"] = x
 
         # test with no cutoffs
-        d = p.derivative(pair=('1','1'), var=x, r=0.5)
+        d = p.derivative(pair=("1", "1"), var=x, r=0.5)
         self.assertAlmostEqual(d, 0.5)
-        d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
-        numpy.testing.assert_allclose(d, [0.25,0.75])
+        d = p.derivative(pair=("1", "1"), var=x, r=[0.25, 0.75])
+        numpy.testing.assert_allclose(d, [0.25, 0.75])
 
         # test with rmin set
         rmin = relentless.model.DesignVariable(value=0.5)
-        p.coeff['1','1']['rmin'] = rmin
-        d = p.derivative(pair=('1','1'), var=x, r=0.6)
+        p.coeff["1", "1"]["rmin"] = rmin
+        d = p.derivative(pair=("1", "1"), var=x, r=0.6)
         self.assertAlmostEqual(d, 0.6)
-        d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.75])
-        numpy.testing.assert_allclose(d, [0.5,0.75])
+        d = p.derivative(pair=("1", "1"), var=x, r=[0.25, 0.75])
+        numpy.testing.assert_allclose(d, [0.5, 0.75])
 
         # test with rmax set
         rmax = relentless.model.DesignVariable(value=1.5)
-        p.coeff['1','1'].update(rmin=False, rmax=rmax)
-        d = p.derivative(pair=('1','1'), var=x, r=1.0)
+        p.coeff["1", "1"].update(rmin=False, rmax=rmax)
+        d = p.derivative(pair=("1", "1"), var=x, r=1.0)
         self.assertAlmostEqual(d, 1.0)
-        d = p.derivative(pair=('1','1'), var=x, r=[0.25,1.75])
-        numpy.testing.assert_allclose(d, [0.25,1.5])
+        d = p.derivative(pair=("1", "1"), var=x, r=[0.25, 1.75])
+        numpy.testing.assert_allclose(d, [0.25, 1.5])
 
         # test with rmin and rmax set
-        p.coeff['1','1']['rmin'] = rmin
-        d = p.derivative(pair=('1','1'), var=x, r=0.75)
+        p.coeff["1", "1"]["rmin"] = rmin
+        d = p.derivative(pair=("1", "1"), var=x, r=0.75)
         self.assertAlmostEqual(d, 0.75)
-        d = p.derivative(pair=('1','1'), var=x, r=[0.25,0.5,1.5,1.75])
-        numpy.testing.assert_allclose(d, [0.5,0.5,1.5,1.5])
+        d = p.derivative(pair=("1", "1"), var=x, r=[0.25, 0.5, 1.5, 1.75])
+        numpy.testing.assert_allclose(d, [0.5, 0.5, 1.5, 1.5])
 
         # test w.r.t. rmin and rmax
-        d = p.derivative(pair=('1','1'), var=rmin, r=[0.25,1.0,2.0])
-        numpy.testing.assert_allclose(d, [2.0,0.0,0.0])
-        d = p.derivative(pair=('1','1'), var=rmax, r=[0.25,1.0,2.0])
-        numpy.testing.assert_allclose(d, [0.0,0.0,2.0])
+        d = p.derivative(pair=("1", "1"), var=rmin, r=[0.25, 1.0, 2.0])
+        numpy.testing.assert_allclose(d, [2.0, 0.0, 0.0])
+        d = p.derivative(pair=("1", "1"), var=rmax, r=[0.25, 1.0, 2.0])
+        numpy.testing.assert_allclose(d, [0.0, 0.0, 2.0])
 
         # test parameter derivative with shift set
-        p.coeff['1','1'].update(shift=True)
-        d = p.derivative(pair=('1','1'), var=x, r=0.5)
+        p.coeff["1", "1"].update(shift=True)
+        d = p.derivative(pair=("1", "1"), var=x, r=0.5)
         self.assertAlmostEqual(d, -1.0)
-        d = p.derivative(pair=('1','1'), var=x, r=[0.25,1.0,1.5,1.75])
-        numpy.testing.assert_allclose(d, [-1.0,-0.5,0.0,0.0])
+        d = p.derivative(pair=("1", "1"), var=x, r=[0.25, 1.0, 1.5, 1.75])
+        numpy.testing.assert_allclose(d, [-1.0, -0.5, 0.0, 0.0])
 
         # test w.r.t. rmin and rmax, shift set
-        d = p.derivative(pair=('1','1'), var=rmin, r=[0.25,1.0,2.0])
-        numpy.testing.assert_allclose(d, [2.0,0.0,0.0])
-        d = p.derivative(pair=('1','1'), var=rmax, r=[0.25,1.0,2.0])
-        numpy.testing.assert_allclose(d, [-2.0,-2.0,0.0])
+        d = p.derivative(pair=("1", "1"), var=rmin, r=[0.25, 1.0, 2.0])
+        numpy.testing.assert_allclose(d, [2.0, 0.0, 0.0])
+        d = p.derivative(pair=("1", "1"), var=rmax, r=[0.25, 1.0, 2.0])
+        numpy.testing.assert_allclose(d, [-2.0, -2.0, 0.0])
 
     def test_derivative_types(self):
         """Test derivative method with different param types."""
-        q = LinPot(types=('1',), params=('m',))
+        q = LinPot(types=("1",), params=("m",))
         x = relentless.model.DesignVariable(value=4.0)
         y = relentless.model.DesignVariable(value=64.0)
         z = relentless.model.GeometricMean(x, y)
-        q.coeff['1','1']['m'] = z
+        q.coeff["1", "1"]["m"] = z
 
         # test with respect to dependent variable parameter
-        d = q.derivative(pair=('1','1'), var=z, r=2.0)
+        d = q.derivative(pair=("1", "1"), var=z, r=2.0)
         self.assertAlmostEqual(d, 2.0)
 
         # test with respect to independent variable on which parameter is dependent
-        d = q.derivative(pair=('1','1'), var=x, r=1.5)
+        d = q.derivative(pair=("1", "1"), var=x, r=1.5)
         self.assertAlmostEqual(d, 3.0)
-        d = q.derivative(pair=('1','1'), var=y, r=4.0)
+        d = q.derivative(pair=("1", "1"), var=y, r=4.0)
         self.assertAlmostEqual(d, 0.5)
 
         # test invalid derivative w.r.t. scalar
         a = 2.5
-        q.coeff['1','1']['m'] = a
+        q.coeff["1", "1"]["m"] = a
         with self.assertRaises(TypeError):
-            d = q.derivative(pair=('1','1'), var=a, r=2.0)
+            d = q.derivative(pair=("1", "1"), var=a, r=2.0)
 
-        # test with respect to independent variable which is related to a SameAs variable
-        r = TwoVarPot(types=('1',), params=('x','y'))
+        # test with respect to independent variable which is
+        # related to a SameAs variable
+        r = TwoVarPot(types=("1",), params=("x", "y"))
 
-        r.coeff['1','1']['x'] = x
-        r.coeff['1','1']['y'] = relentless.model.variable.SameAs(x)
-        d = r.derivative(pair=('1','1'), var=x, r=4.0)
+        r.coeff["1", "1"]["x"] = x
+        r.coeff["1", "1"]["y"] = relentless.model.variable.SameAs(x)
+        d = r.derivative(pair=("1", "1"), var=x, r=4.0)
         self.assertAlmostEqual(d, 20.0)
 
-        r.coeff['1','1']['y'] = x
-        r.coeff['1','1']['x'] = relentless.model.variable.SameAs(x)
-        d = r.derivative(pair=('1','1'), var=x, r=4.0)
+        r.coeff["1", "1"]["y"] = x
+        r.coeff["1", "1"]["x"] = relentless.model.variable.SameAs(x)
+        d = r.derivative(pair=("1", "1"), var=x, r=4.0)
         self.assertAlmostEqual(d, 20.0)
 
     def test_iteration(self):
         """Test iteration on PairPotential object"""
-        p = LinPot(types=('1','2'), params=('m',))
+        p = LinPot(types=("1", "2"), params=("m",))
         for pair in p.coeff:
-            p.coeff[pair]['m'] = 2.0
-            p.coeff[pair]['rmin'] = 0.0
-            p.coeff[pair]['rmax'] = 1.0
+            p.coeff[pair]["m"] = 2.0
+            p.coeff[pair]["rmin"] = 0.0
+            p.coeff[pair]["rmax"] = 1.0
 
-        self.assertEqual(dict(p.coeff['1','1']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
-        self.assertEqual(dict(p.coeff['1','2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
-        self.assertEqual(dict(p.coeff['2','2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0, 'shift':False})
+        self.assertEqual(
+            dict(p.coeff["1", "1"]),
+            {"m": 2.0, "rmin": 0.0, "rmax": 1.0, "shift": False},
+        )
+        self.assertEqual(
+            dict(p.coeff["1", "2"]),
+            {"m": 2.0, "rmin": 0.0, "rmax": 1.0, "shift": False},
+        )
+        self.assertEqual(
+            dict(p.coeff["2", "2"]),
+            {"m": 2.0, "rmin": 0.0, "rmax": 1.0, "shift": False},
+        )
 
     def test_save(self):
         """Test saving to file"""
         temp = tempfile.NamedTemporaryFile()
-        p = LinPot(types=('1',), params=('m','rmin','rmax'))
-        p.coeff['1','1']['m'] = 2.0
-        p.coeff['1','1']['rmin'] = 0.0
-        p.coeff['1','1']['rmax'] = 1.0
-        p.coeff['1','1']['shift'] = True
+        p = LinPot(types=("1",), params=("m", "rmin", "rmax"))
+        p.coeff["1", "1"]["m"] = 2.0
+        p.coeff["1", "1"]["rmin"] = 0.0
+        p.coeff["1", "1"]["rmax"] = 1.0
+        p.coeff["1", "1"]["shift"] = True
 
         p.save(temp.name)
-        with open(temp.name, 'r') as f:
+        with open(temp.name, "r") as f:
             x = json.load(f)
 
-        self.assertEqual(p.coeff['1','1']['m'], x["('1', '1')"]['m'])
-        self.assertEqual(p.coeff['1','1']['rmin'], x["('1', '1')"]['rmin'])
-        self.assertEqual(p.coeff['1','1']['rmax'], x["('1', '1')"]['rmax'])
-        self.assertEqual(p.coeff['1','1']['shift'], x["('1', '1')"]['shift'])
+        self.assertEqual(p.coeff["1", "1"]["m"], x["('1', '1')"]["m"])
+        self.assertEqual(p.coeff["1", "1"]["rmin"], x["('1', '1')"]["rmin"])
+        self.assertEqual(p.coeff["1", "1"]["rmax"], x["('1', '1')"]["rmax"])
+        self.assertEqual(p.coeff["1", "1"]["shift"], x["('1', '1')"]["shift"])
 
         temp.close()
+
 
 class test_LennardJones(unittest.TestCase):
     """Unit tests for relentless.model.potential.LennardJones"""
 
     def test_init(self):
         """Test creation from data"""
-        lj = relentless.model.potential.LennardJones(types=('1',))
-        coeff = relentless.model.potential.PairParameters(types=('1',),
-                                                    params=('epsilon','sigma','rmin','rmax','shift'))
+        lj = relentless.model.potential.LennardJones(types=("1",))
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("epsilon", "sigma", "rmin", "rmax", "shift")
+        )
         for pair in coeff.pairs:
-            coeff[pair]['rmin'] = False
-            coeff[pair]['rmax'] = False
-            coeff[pair]['shift'] = False
+            coeff[pair]["rmin"] = False
+            coeff[pair]["rmax"] = False
+            coeff[pair]["shift"] = False
         self.assertCountEqual(lj.coeff.types, coeff.types)
         self.assertCountEqual(lj.coeff.params, coeff.params)
 
     def test_energy(self):
         """Test _energy method"""
-        lj = relentless.model.potential.LennardJones(types=('1',))
+        lj = relentless.model.potential.LennardJones(types=("1",))
 
         # test scalar r
         r_input = 0.5
@@ -474,8 +512,8 @@ class test_LennardJones(unittest.TestCase):
         self.assertAlmostEqual(u, u_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        u_actual = numpy.array([numpy.inf,-0.061523438,-0.0054794417])
+        r_input = numpy.array([0, 1, 1.5])
+        u_actual = numpy.array([numpy.inf, -0.061523438, -0.0054794417])
         u = lj._energy(r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(u, u_actual)
 
@@ -485,7 +523,7 @@ class test_LennardJones(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        lj = relentless.model.potential.LennardJones(types=('1',))
+        lj = relentless.model.potential.LennardJones(types=("1",))
 
         # test scalar r
         r_input = 0.5
@@ -494,52 +532,53 @@ class test_LennardJones(unittest.TestCase):
         self.assertAlmostEqual(f, f_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        f_actual = numpy.array([numpy.inf,-0.36328125,-0.02188766])
+        r_input = numpy.array([0, 1, 1.5])
+        f_actual = numpy.array([numpy.inf, -0.36328125, -0.02188766])
         f = lj._force(r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(f, f_actual)
 
         # test negative sigma
         with self.assertRaises(ValueError):
-            u = lj._force(r=r_input, epsilon=1.0, sigma=-1.0)
+            lj._force(r=r_input, epsilon=1.0, sigma=-1.0)
 
     def test_derivative(self):
         """Test _derivative method"""
-        lj = relentless.model.potential.LennardJones(types=('1',))
+        lj = relentless.model.potential.LennardJones(types=("1",))
 
         # w.r.t. epsilon
         # test scalar r
         r_input = 0.5
         d_actual = 0
-        d = lj._derivative(param='epsilon', r=r_input, epsilon=1.0, sigma=0.5)
+        d = lj._derivative(param="epsilon", r=r_input, epsilon=1.0, sigma=0.5)
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        d_actual = numpy.array([numpy.inf,-0.061523438,-0.0054794417])
-        d = lj._derivative(param='epsilon', r=r_input, epsilon=1.0, sigma=0.5)
+        r_input = numpy.array([0, 1, 1.5])
+        d_actual = numpy.array([numpy.inf, -0.061523438, -0.0054794417])
+        d = lj._derivative(param="epsilon", r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
         # w.r.t. sigma
         # test scalar r
         r_input = 0.5
         d_actual = 48
-        d = lj._derivative(param='sigma', r=r_input, epsilon=1.0, sigma=0.5)
+        d = lj._derivative(param="sigma", r=r_input, epsilon=1.0, sigma=0.5)
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        d_actual = numpy.array([numpy.inf,-0.7265625,-0.06566298])
-        d = lj._derivative(param='sigma', r=r_input, epsilon=1.0, sigma=0.5)
+        r_input = numpy.array([0, 1, 1.5])
+        d_actual = numpy.array([numpy.inf, -0.7265625, -0.06566298])
+        d = lj._derivative(param="sigma", r=r_input, epsilon=1.0, sigma=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
         # test negative sigma
         with self.assertRaises(ValueError):
-            u = lj._derivative(param='sigma', r=r_input, epsilon=1.0, sigma=-1.0)
+            lj._derivative(param="sigma", r=r_input, epsilon=1.0, sigma=-1.0)
 
         # test invalid param
         with self.assertRaises(ValueError):
-            u = lj._derivative(param='simga', r=r_input, epsilon=1.0, sigma=1.0)
+            lj._derivative(param="simga", r=r_input, epsilon=1.0, sigma=1.0)
+
 
 class test_PairSpline(unittest.TestCase):
     """Unit tests for relentless.model.potential.PairSpline"""
@@ -547,47 +586,75 @@ class test_PairSpline(unittest.TestCase):
     def test_init(self):
         """Test creation from data"""
         # test diff mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3)
+        s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
         self.assertEqual(s.num_knots, 3)
-        self.assertEqual(s.mode, 'diff')
-        coeff = relentless.model.potential.PairParameters(types=('1',),
-                                                    params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
+        self.assertEqual(s.mode, "diff")
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",),
+            params=(
+                "r-0",
+                "r-1",
+                "r-2",
+                "knot-0",
+                "knot-1",
+                "knot-2",
+                "rmin",
+                "rmax",
+                "shift",
+            ),
+        )
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
 
         # test value mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3, mode='value')
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=3, mode="value"
+        )
         self.assertEqual(s.num_knots, 3)
-        self.assertEqual(s.mode, 'value')
-        coeff = relentless.model.potential.PairParameters(types=('1',),
-                                                    params=('r-0','r-1','r-2','knot-0','knot-1','knot-2','rmin','rmax','shift'))
+        self.assertEqual(s.mode, "value")
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",),
+            params=(
+                "r-0",
+                "r-1",
+                "r-2",
+                "knot-0",
+                "knot-1",
+                "knot-2",
+                "rmin",
+                "rmax",
+                "shift",
+            ),
+        )
         self.assertCountEqual(s.coeff.types, coeff.types)
         self.assertCountEqual(s.coeff.params, coeff.params)
 
         # test invalid number of knots
         with self.assertRaises(ValueError):
-            s = relentless.model.potential.PairSpline(types=('1',), num_knots=1)
+            s = relentless.model.potential.PairSpline(types=("1",), num_knots=1)
 
         # test invalid mode
         with self.assertRaises(ValueError):
-            s = relentless.model.potential.PairSpline(types=('1',), num_knots=3, mode='val')
+            s = relentless.model.potential.PairSpline(
+                types=("1",), num_knots=3, mode="val"
+            )
 
     def test_from_array(self):
         """Test from_array method and knots generator"""
-        r_arr = [1,2,3]
-        u_arr = [9,4,1]
-        u_arr_diff = [5,3,1]
+        r_arr = [1, 2, 3]
+        u_arr = [9, 4, 1]
+        u_arr_diff = [5, 3, 1]
 
         # test diff mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3)
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
+        s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
 
         dvars = []
-        for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
+        for i, (r, k) in enumerate(s.knots(pair=("1", "1"))):
             self.assertAlmostEqual(r.value, r_arr[i])
             self.assertAlmostEqual(k.value, u_arr_diff[i])
             self.assertIsInstance(r, relentless.model.IndependentVariable)
-            if i == s.num_knots-1:
+            if i == s.num_knots - 1:
                 self.assertIsInstance(k, relentless.model.IndependentVariable)
             else:
                 self.assertIsInstance(k, relentless.model.DesignVariable)
@@ -595,15 +662,17 @@ class test_PairSpline(unittest.TestCase):
         self.assertCountEqual(s.design_variables, dvars)
 
         # test value mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3, mode='value')
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=3, mode="value"
+        )
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
 
         dvars = []
-        for i,(r,k) in enumerate(s.knots(pair=('1','1'))):
+        for i, (r, k) in enumerate(s.knots(pair=("1", "1"))):
             self.assertAlmostEqual(r.value, r_arr[i])
             self.assertAlmostEqual(k.value, u_arr[i])
             self.assertIsInstance(r, relentless.model.IndependentVariable)
-            if i == s.num_knots-1:
+            if i == s.num_knots - 1:
                 self.assertIsInstance(k, relentless.model.IndependentVariable)
             else:
                 self.assertIsInstance(k, relentless.model.DesignVariable)
@@ -611,103 +680,116 @@ class test_PairSpline(unittest.TestCase):
         self.assertCountEqual(s.design_variables, dvars)
 
         # test invalid r and u shapes
-        r_arr = [2,3]
+        r_arr = [2, 3]
         with self.assertRaises(ValueError):
-            s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
+            s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
 
-        r_arr = [1,2,3]
-        u_arr = [1,2]
+        r_arr = [1, 2, 3]
+        u_arr = [1, 2]
         with self.assertRaises(ValueError):
-            s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
+            s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
 
     def test_energy(self):
         """Test energy method"""
-        r_arr = [1,2,3]
-        u_arr = [9,4,1]
+        r_arr = [1, 2, 3]
+        u_arr = [9, 4, 1]
 
         # test diff mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3)
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
-        u_actual = numpy.array([6.25,2.25,1])
-        u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
+        s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
+        u_actual = numpy.array([6.25, 2.25, 1])
+        u = s.energy(pair=("1", "1"), r=[1.5, 2.5, 3.5])
         numpy.testing.assert_allclose(u, u_actual)
 
         # test value mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3, mode='value')
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
-        u_actual = numpy.array([6.25,2.25,1])
-        u = s.energy(pair=('1','1'), r=[1.5,2.5,3.5])
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=3, mode="value"
+        )
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
+        u_actual = numpy.array([6.25, 2.25, 1])
+        u = s.energy(pair=("1", "1"), r=[1.5, 2.5, 3.5])
         numpy.testing.assert_allclose(u, u_actual)
 
         # test PairSpline with 2 knots
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=2, mode='value')
-        s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
-        u = s.energy(pair=('1','1'), r=1.5)
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=2, mode="value"
+        )
+        s.from_array(pair=("1", "1"), r=[1, 2], u=[4, 2])
+        u = s.energy(pair=("1", "1"), r=1.5)
         self.assertAlmostEqual(u, 3)
 
     def test_force(self):
         """Test force method"""
-        r_arr = [1,2,3]
-        u_arr = [9,4,1]
+        r_arr = [1, 2, 3]
+        u_arr = [9, 4, 1]
 
         # test diff mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3)
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
-        f_actual = numpy.array([5,3,0])
-        f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
+        s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
+        f_actual = numpy.array([5, 3, 0])
+        f = s.force(pair=("1", "1"), r=[1.5, 2.5, 3.5])
         numpy.testing.assert_allclose(f, f_actual)
 
         # test value mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3, mode='value')
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
-        f_actual = numpy.array([5,3,0])
-        f = s.force(pair=('1','1'), r=[1.5,2.5,3.5])
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=3, mode="value"
+        )
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
+        f_actual = numpy.array([5, 3, 0])
+        f = s.force(pair=("1", "1"), r=[1.5, 2.5, 3.5])
         numpy.testing.assert_allclose(f, f_actual)
 
         # test PairSpline with 2 knots
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=2, mode='value')
-        s.from_array(pair=('1','1'), r=[1,2], u=[4,2])
-        f = s.force(pair=('1','1'), r=1.5)
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=2, mode="value"
+        )
+        s.from_array(pair=("1", "1"), r=[1, 2], u=[4, 2])
+        f = s.force(pair=("1", "1"), r=1.5)
         self.assertAlmostEqual(f, 2)
 
     def test_derivative(self):
         """Test derivative method"""
-        r_arr = [1,2,3]
-        u_arr = [9,4,1]
+        r_arr = [1, 2, 3]
+        u_arr = [9, 4, 1]
 
         # test diff mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3)
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
-        d_actual = numpy.array([1.125,0.625,0])
-        param = list(s.knots(('1','1')))[1][1]
-        d = s.derivative(pair=('1','1'), var=param, r=[1.5,2.5,3.5])
+        s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
+        d_actual = numpy.array([1.125, 0.625, 0])
+        param = list(s.knots(("1", "1")))[1][1]
+        d = s.derivative(pair=("1", "1"), var=param, r=[1.5, 2.5, 3.5])
         numpy.testing.assert_allclose(d, d_actual)
 
         # test value mode
-        s = relentless.model.potential.PairSpline(types=('1',), num_knots=3, mode='value')
-        s.from_array(pair=('1','1'), r=r_arr, u=u_arr)
-        d_actual = numpy.array([0.75,0.75,0])
-        param = list(s.knots(('1','1')))[1][1]
-        d = s.derivative(pair=('1','1'), var=param, r=[1.5,2.5,3.5])
+        s = relentless.model.potential.PairSpline(
+            types=("1",), num_knots=3, mode="value"
+        )
+        s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
+        d_actual = numpy.array([0.75, 0.75, 0])
+        param = list(s.knots(("1", "1")))[1][1]
+        d = s.derivative(pair=("1", "1"), var=param, r=[1.5, 2.5, 3.5])
         numpy.testing.assert_allclose(d, d_actual)
+
 
 class test_Yukawa(unittest.TestCase):
     """Unit tests for relentless.model.potential.Yukawa"""
 
     def test_init(self):
         """Test creation from data"""
-        y = relentless.model.potential.Yukawa(types=('1',))
-        coeff = relentless.model.potential.PairParameters(types=('1',), params=('epsilon','kappa','rmin','rmax','shift'))
+        y = relentless.model.potential.Yukawa(types=("1",))
+        coeff = relentless.model.potential.PairParameters(
+            types=("1",), params=("epsilon", "kappa", "rmin", "rmax", "shift")
+        )
         for pair in coeff.pairs:
-            coeff[pair]['rmin'] = False
-            coeff[pair]['rmax'] = False
-            coeff[pair]['shift'] = False
+            coeff[pair]["rmin"] = False
+            coeff[pair]["rmax"] = False
+            coeff[pair]["shift"] = False
         self.assertCountEqual(y.coeff.types, coeff.types)
         self.assertCountEqual(y.coeff.params, coeff.params)
 
     def test_energy(self):
         """Test _energy method"""
-        y = relentless.model.potential.Yukawa(types=('1',))
+        y = relentless.model.potential.Yukawa(types=("1",))
 
         # test scalar r
         r_input = 0.5
@@ -716,8 +798,8 @@ class test_Yukawa(unittest.TestCase):
         self.assertAlmostEqual(u, u_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        u_actual = numpy.array([numpy.inf,0.60653066,0.31491104])
+        r_input = numpy.array([0, 1, 1.5])
+        u_actual = numpy.array([numpy.inf, 0.60653066, 0.31491104])
         u = y._energy(r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(u, u_actual)
 
@@ -727,7 +809,7 @@ class test_Yukawa(unittest.TestCase):
 
     def test_force(self):
         """Test _force method"""
-        y = relentless.model.potential.Yukawa(types=('1',))
+        y = relentless.model.potential.Yukawa(types=("1",))
 
         # test scalar r
         r_input = 0.5
@@ -736,97 +818,106 @@ class test_Yukawa(unittest.TestCase):
         self.assertAlmostEqual(f, f_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        f_actual = numpy.array([numpy.inf,0.90979599,0.36739621])
+        r_input = numpy.array([0, 1, 1.5])
+        f_actual = numpy.array([numpy.inf, 0.90979599, 0.36739621])
         f = y._force(r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(f, f_actual)
 
         # test negative kappa
         with self.assertRaises(ValueError):
-            u = y._force(r=r_input, epsilon=1.0, kappa=-1.0)
+            y._force(r=r_input, epsilon=1.0, kappa=-1.0)
 
     def test_derivative(self):
         """Test _derivative method"""
-        y = relentless.model.potential.Yukawa(types=('1',))
+        y = relentless.model.potential.Yukawa(types=("1",))
 
         # w.r.t. epsilon
         # test scalar r
         r_input = 0.5
         d_actual = 1.5576016
-        d = y._derivative(param='epsilon', r=r_input, epsilon=1.0, kappa=0.5)
+        d = y._derivative(param="epsilon", r=r_input, epsilon=1.0, kappa=0.5)
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        d_actual = numpy.array([numpy.inf,0.60653066,0.31491104])
-        d = y._derivative(param='epsilon', r=r_input, epsilon=1.0, kappa=0.5)
+        r_input = numpy.array([0, 1, 1.5])
+        d_actual = numpy.array([numpy.inf, 0.60653066, 0.31491104])
+        d = y._derivative(param="epsilon", r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
         # w.r.t. kappa
         # test scalar r
         r_input = 0.5
         d_actual = -0.77880078
-        d = y._derivative(param='kappa', r=r_input, epsilon=1.0, kappa=0.5)
+        d = y._derivative(param="kappa", r=r_input, epsilon=1.0, kappa=0.5)
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([0,1,1.5])
-        d_actual = numpy.array([-1,-0.60653066,-0.47236655])
-        d = y._derivative(param='kappa', r=r_input, epsilon=1.0, kappa=0.5)
+        r_input = numpy.array([0, 1, 1.5])
+        d_actual = numpy.array([-1, -0.60653066, -0.47236655])
+        d = y._derivative(param="kappa", r=r_input, epsilon=1.0, kappa=0.5)
         numpy.testing.assert_allclose(d, d_actual)
 
         # test negative kappa
         with self.assertRaises(ValueError):
-            u = y._derivative(param='kappa', r=r_input, epsilon=1.0, kappa=-1.0)
+            y._derivative(param="kappa", r=r_input, epsilon=1.0, kappa=-1.0)
 
         # test invalid param
         with self.assertRaises(ValueError):
-            u = y._derivative(param='kapppa', r=r_input, epsilon=1.0, kappa=1.0)
+            y._derivative(param="kapppa", r=r_input, epsilon=1.0, kappa=1.0)
+
 
 class test_Depletion(unittest.TestCase):
     """Unit tests for relentless.model.potential.Depletion"""
 
     def test_init(self):
         """Test creation from data"""
-        dp = relentless.model.potential.Depletion(types=('1','2'))
-        coeff = relentless.model.potential.PairParameters(types=('1','2'),
-                                                    params=('P','sigma_i','sigma_j','sigma_d','rmin','rmax','shift'))
+        dp = relentless.model.potential.Depletion(types=("1", "2"))
+        coeff = relentless.model.potential.PairParameters(
+            types=("1", "2"),
+            params=("P", "sigma_i", "sigma_j", "sigma_d", "rmin", "rmax", "shift"),
+        )
         self.assertCountEqual(dp.coeff.types, coeff.types)
         self.assertCountEqual(dp.coeff.params, coeff.params)
 
     def test_cutoff_init(self):
         """Test creation of Depletion.Cutoff from data"""
         # create object dependent on scalars
-        w = relentless.model.potential.Depletion.Cutoff(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
-        self.assertCountEqual(w.params, ('sigma_i','sigma_j','sigma_d'))
+        w = relentless.model.potential.Depletion.Cutoff(
+            sigma_i=1.0, sigma_j=2.0, sigma_d=0.25
+        )
+        self.assertCountEqual(w.params, ("sigma_i", "sigma_j", "sigma_d"))
 
     def test_cutoff_value(self):
-        w = relentless.model.potential.Depletion.Cutoff(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+        w = relentless.model.potential.Depletion.Cutoff(
+            sigma_i=1.0, sigma_j=2.0, sigma_d=0.25
+        )
         self.assertAlmostEqual(w.compute(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25), 1.75)
 
     def test_cutoff_derivative(self):
         """Test Depletion.Cutoff._derivative method"""
-        w = relentless.model.potential.Depletion.Cutoff(sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+        w = relentless.model.potential.Depletion.Cutoff(
+            sigma_i=1.0, sigma_j=2.0, sigma_d=0.25
+        )
 
         # calculate w.r.t. sigma_i
-        dw = w.compute_derivative('sigma_i', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+        dw = w.compute_derivative("sigma_i", sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertEqual(dw, 0.5)
 
         # calculate w.r.t. sigma_j
-        dw = w.compute_derivative('sigma_j', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+        dw = w.compute_derivative("sigma_j", sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertEqual(dw, 0.5)
 
         # calculate w.r.t. sigma_d
-        dw = w.compute_derivative('sigma_d', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+        dw = w.compute_derivative("sigma_d", sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
         self.assertEqual(dw, 1.0)
 
         # invalid parameter calculation
         with self.assertRaises(ValueError):
-            dw = w.compute_derivative('sigma', sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
+            dw = w.compute_derivative("sigma", sigma_i=1.0, sigma_j=2.0, sigma_d=0.25)
 
     def test_energy(self):
         """Test _energy and energy methods"""
-        dp = relentless.model.potential.Depletion(types=('1',))
+        dp = relentless.model.potential.Depletion(types=("1",))
 
         # test scalar r
         r_input = 3
@@ -835,8 +926,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(u, u_actual)
 
         # test array r
-        r_input = numpy.array([1.75,4.25])
-        u_actual = numpy.array([-16.59621119,0])
+        r_input = numpy.array([1.75, 4.25])
+        u_actual = numpy.array([-16.59621119, 0])
         u = dp._energy(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(u, u_actual)
 
@@ -849,16 +940,16 @@ class test_Depletion(unittest.TestCase):
             u = dp._energy(r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
         # test energy outside of low/high bounds
-        dp.coeff['1','1'].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
-        r_input = numpy.array([1,5])
-        u_actual = numpy.array([-25.7514468,0])
-        u = dp.energy(pair=('1','1'), r=r_input)
+        dp.coeff["1", "1"].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1, 5])
+        u_actual = numpy.array([-25.7514468, 0])
+        u = dp.energy(pair=("1", "1"), r=r_input)
         numpy.testing.assert_allclose(u, u_actual)
-        self.assertAlmostEqual(dp.coeff['1','1']['rmax'].value, 4.25)
+        self.assertAlmostEqual(dp.coeff["1", "1"]["rmax"].value, 4.25)
 
     def test_force(self):
         """Test _force and force methods"""
-        dp = relentless.model.potential.Depletion(types=('1',))
+        dp = relentless.model.potential.Depletion(types=("1",))
 
         # test scalar r
         r_input = 3
@@ -867,8 +958,8 @@ class test_Depletion(unittest.TestCase):
         self.assertAlmostEqual(f, f_actual)
 
         # test array r
-        r_input = numpy.array([1.75,4.25])
-        f_actual = numpy.array([-11.54054444,0])
+        r_input = numpy.array([1.75, 4.25])
+        f_actual = numpy.array([-11.54054444, 0])
         f = dp._force(r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
         numpy.testing.assert_allclose(f, f_actual)
 
@@ -881,89 +972,114 @@ class test_Depletion(unittest.TestCase):
             f = dp._force(r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
 
         # test force outside of low/high bounds
-        dp.coeff['1','1'].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
-        r_input = numpy.array([1,5])
-        f_actual = numpy.array([-12.5633027,0])
-        f = dp.force(pair=('1','1'), r=r_input)
+        dp.coeff["1", "1"].update(P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1, 5])
+        f_actual = numpy.array([-12.5633027, 0])
+        f = dp.force(pair=("1", "1"), r=r_input)
         numpy.testing.assert_allclose(f, f_actual)
-        self.assertAlmostEqual(dp.coeff['1','1']['rmax'].value, 4.25)
+        self.assertAlmostEqual(dp.coeff["1", "1"]["rmax"].value, 4.25)
 
     def test_derivative(self):
         """Test _derivative and derivative methods"""
-        dp = relentless.model.potential.Depletion(types=('1',))
+        dp = relentless.model.potential.Depletion(types=("1",))
 
         # w.r.t. P
         # test scalar r
         r_input = 3
         d_actual = -4.6786414
-        d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        d = dp._derivative(
+            param="P", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([1.75,4.25])
-        d_actual = numpy.array([-16.59621119,0])
-        d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1.75, 4.25])
+        d_actual = numpy.array([-16.59621119, 0])
+        d = dp._derivative(
+            param="P", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         numpy.testing.assert_allclose(d, d_actual)
 
         # w.r.t. sigma_i
         # test scalar r
         r_input = 3
         d_actual = -4.25424005
-        d = dp._derivative(param='sigma_i', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        d = dp._derivative(
+            param="sigma_i", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([1.75,4.25])
-        d_actual = numpy.array([-8.975979,0])
-        d = dp._derivative(param='sigma_i', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1.75, 4.25])
+        d_actual = numpy.array([-8.975979, 0])
+        d = dp._derivative(
+            param="sigma_i", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         numpy.testing.assert_allclose(d, d_actual)
 
         # w.r.t. sigma_j
         # test scalar r
         r_input = 3
         d_actual = -4.04970928
-        d = dp._derivative(param='sigma_j', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        d = dp._derivative(
+            param="sigma_j", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([1.75,4.25])
-        d_actual = numpy.array([-7.573482,0])
-        d = dp._derivative(param='sigma_j', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1.75, 4.25])
+        d_actual = numpy.array([-7.573482, 0])
+        d = dp._derivative(
+            param="sigma_j", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         numpy.testing.assert_allclose(d, d_actual)
 
         # w.r.t. sigma_d
         # test scalar r
         r_input = 3
         d_actual = -8.30394933
-        d = dp._derivative(param='sigma_d', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        d = dp._derivative(
+            param="sigma_d", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         self.assertAlmostEqual(d, d_actual)
 
         # test array r
-        r_input = numpy.array([1.75,4.25])
-        d_actual = numpy.array([-16.549461,0])
-        d = dp._derivative(param='sigma_d', r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1.75, 4.25])
+        d_actual = numpy.array([-16.549461, 0])
+        d = dp._derivative(
+            param="sigma_d", r=r_input, P=1, sigma_i=1.5, sigma_j=2, sigma_d=2.5
+        )
         numpy.testing.assert_allclose(d, d_actual)
 
         # test negative sigma
         with self.assertRaises(ValueError):
-            d = dp._derivative(param='P', r=r_input, P=1, sigma_i=-1, sigma_j=1, sigma_d=1)
+            d = dp._derivative(
+                param="P", r=r_input, P=1, sigma_i=-1, sigma_j=1, sigma_d=1
+            )
         with self.assertRaises(ValueError):
-            d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1, sigma_j=-1, sigma_d=1)
+            d = dp._derivative(
+                param="P", r=r_input, P=1, sigma_i=1, sigma_j=-1, sigma_d=1
+            )
         with self.assertRaises(ValueError):
-            d = dp._derivative(param='P', r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1)
+            d = dp._derivative(
+                param="P", r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=-1
+            )
 
         # test invalid param
         with self.assertRaises(ValueError):
-            d = dp._derivative(param='sigmaj', r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=1)
+            d = dp._derivative(
+                param="sigmaj", r=r_input, P=1, sigma_i=1, sigma_j=1, sigma_d=1
+            )
 
         # test derivative outside of low/high bounds
         P_var = relentless.model.DesignVariable(value=1.0)
-        dp.coeff['1','1'].update(P=P_var, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
-        r_input = numpy.array([1,5])
-        d_actual = numpy.array([-25.7514468,0])
-        d = dp.derivative(pair=('1','1'), var=P_var, r=r_input)
+        dp.coeff["1", "1"].update(P=P_var, sigma_i=1.5, sigma_j=2, sigma_d=2.5)
+        r_input = numpy.array([1, 5])
+        d_actual = numpy.array([-25.7514468, 0])
+        d = dp.derivative(pair=("1", "1"), var=P_var, r=r_input)
         numpy.testing.assert_allclose(d, d_actual)
-        self.assertAlmostEqual(dp.coeff['1','1']['rmax'].value, 4.25)
+        self.assertAlmostEqual(dp.coeff["1", "1"]["rmax"].value, 4.25)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/model/potential/test_potential.py
+++ b/tests/model/potential/test_potential.py
@@ -7,231 +7,259 @@ import numpy
 
 import relentless
 
+
 class test_Parameters(unittest.TestCase):
     """Unit tests for relentless.model.potential.Parameters"""
 
     def test_init(self):
         """Test creation from data"""
-        types = ('A','B')
-        params = ('energy', 'mass')
+        types = ("A", "B")
+        params = ("energy", "mass")
 
         # test construction with tuple input
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
 
         # test construction with list input
-        m = relentless.model.potential.Parameters(types=['A','B'], params=('energy','mass'))
+        m = relentless.model.potential.Parameters(
+            types=["A", "B"], params=("energy", "mass")
+        )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
 
         # test construction with mixed tuple/list input
-        m = relentless.model.potential.Parameters(types=('A','B'), params=['energy','mass'])
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=["energy", "mass"]
+        )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
 
         # test construction with invalid types
         with self.assertRaises(TypeError):
-            m = relentless.model.potential.Parameters(types=(1,'B'), params=(1,2))
+            m = relentless.model.potential.Parameters(types=(1, "B"), params=(1, 2))
 
         # test construction with invalid parameters
         with self.assertRaises(TypeError):
-            m = relentless.model.potential.Parameters(types=('A','B'), params=('1',2))
+            m = relentless.model.potential.Parameters(types=("A", "B"), params=("1", 2))
 
     def test_param_types(self):
         """Test various get and set methods on parameter types"""
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy', 'mass'))
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
 
-        self.assertEqual(m.shared['energy'], None)
-        self.assertEqual(m.shared['mass'], None)
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        self.assertEqual(m.shared["energy"], None)
+        self.assertEqual(m.shared["mass"], None)
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
         # test setting shared params
         m.shared.update(energy=1.0, mass=2.0)
 
-        self.assertEqual(m.shared['energy'], 1.0)
-        self.assertEqual(m.shared['mass'], 2.0)
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        self.assertEqual(m.shared["energy"], 1.0)
+        self.assertEqual(m.shared["mass"], 2.0)
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
         # test setting per-type params
-        m['A'].update(energy=0.1, mass=0.2)
-        m['B'].update(energy=0.2, mass=0.1)
+        m["A"].update(energy=0.1, mass=0.2)
+        m["B"].update(energy=0.2, mass=0.1)
 
-        self.assertEqual(m.shared['energy'], 1.0)
-        self.assertEqual(m.shared['mass'], 2.0)
-        self.assertEqual(m['A']['energy'], 0.1)
-        self.assertEqual(m['A']['mass'], 0.2)
-        self.assertEqual(m['B']['energy'], 0.2)
-        self.assertEqual(m['B']['mass'], 0.1)
+        self.assertEqual(m.shared["energy"], 1.0)
+        self.assertEqual(m.shared["mass"], 2.0)
+        self.assertEqual(m["A"]["energy"], 0.1)
+        self.assertEqual(m["A"]["mass"], 0.2)
+        self.assertEqual(m["B"]["energy"], 0.2)
+        self.assertEqual(m["B"]["mass"], 0.1)
 
     def test_accessor_methods(self):
         """Test various get and set methods on keys"""
-        m = relentless.model.potential.Parameters(types=('A',), params=('energy','mass'))
+        m = relentless.model.potential.Parameters(
+            types=("A",), params=("energy", "mass")
+        )
 
         # test set and get for each pair type and param
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
 
         # test setting all key values at once
-        m['A'] = {'energy':1.0, 'mass':2.0}
-        self.assertEqual(m['A']['energy'], 1.0)
-        self.assertEqual(m['A']['mass'], 2.0)
+        m["A"] = {"energy": 1.0, "mass": 2.0}
+        self.assertEqual(m["A"]["energy"], 1.0)
+        self.assertEqual(m["A"]["mass"], 2.0)
 
         # test setting key values partially with = operator
-        m['A'] = {'energy':1.5}
-        self.assertEqual(m['A']['energy'], 1.5)
-        self.assertEqual(m['A']['mass'], None)
+        m["A"] = {"energy": 1.5}
+        self.assertEqual(m["A"]["energy"], 1.5)
+        self.assertEqual(m["A"]["mass"], None)
 
-        m['A'] = {'mass':2.5}
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], 2.5)
+        m["A"] = {"mass": 2.5}
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], 2.5)
 
         # test setting key values partially using update()
-        m['A'].update(energy=2.5) # using keyword arg
-        self.assertEqual(m['A']['energy'], 2.5)
-        self.assertEqual(m['A']['mass'], 2.5)
+        m["A"].update(energy=2.5)  # using keyword arg
+        self.assertEqual(m["A"]["energy"], 2.5)
+        self.assertEqual(m["A"]["mass"], 2.5)
 
-        m['A'].update({'mass':0.5}) # using dict
-        self.assertEqual(m['A']['energy'], 2.5)
-        self.assertEqual(m['A']['mass'], 0.5)
+        m["A"].update({"mass": 0.5})  # using dict
+        self.assertEqual(m["A"]["energy"], 2.5)
+        self.assertEqual(m["A"]["mass"], 0.5)
 
         # test accessing key param values individually
-        m['A']['energy'] = 1.0
-        self.assertEqual(m['A']['energy'], 1.0)
-        self.assertEqual(m['A']['mass'], 0.5)
+        m["A"]["energy"] = 1.0
+        self.assertEqual(m["A"]["energy"], 1.0)
+        self.assertEqual(m["A"]["mass"], 0.5)
 
-        m['A']['mass'] = 2.0
-        self.assertEqual(m['A']['energy'], 1.0)
-        self.assertEqual(m['A']['mass'], 2.0)
+        m["A"]["mass"] = 2.0
+        self.assertEqual(m["A"]["energy"], 1.0)
+        self.assertEqual(m["A"]["mass"], 2.0)
 
         # test reset and get via iteration
-        params = ('energy', 'mass')
+        params = ("energy", "mass")
         for j in params:
-            m['A'][j] = 1.5
-        self.assertEqual(m['A']['energy'], 1.5)
-        self.assertEqual(m['A']['mass'], 1.5)
+            m["A"][j] = 1.5
+        self.assertEqual(m["A"]["energy"], 1.5)
+        self.assertEqual(m["A"]["mass"], 1.5)
 
         # test get and set on invalid keys/params
         with self.assertRaises(KeyError):
-            m['C']['energy'] = 2
+            m["C"]["energy"] = 2
         with self.assertRaises(KeyError):
-            x = m['C']['energy']
+            m["C"]["energy"]
         with self.assertRaises(KeyError):
-            m['A']['charge'] = 3
+            m["A"]["charge"] = 3
         with self.assertRaises(KeyError):
-            x = m['A']['charge']
+            m["A"]["charge"]
 
     def test_accessor_keys(self):
         """Test get and set methods for various keys"""
         # test set and get for initialized default
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy','mass'))
-        self.assertEqual(m['A']['energy'], None)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
+        self.assertEqual(m["A"]["energy"], None)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
         # test reset and get manually
-        m['A'] = {'energy':1.0, 'mass':2.0}
-        self.assertEqual(m['A']['energy'], 1.0)
-        self.assertEqual(m['A']['mass'], 2.0)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        m["A"] = {"energy": 1.0, "mass": 2.0}
+        self.assertEqual(m["A"]["energy"], 1.0)
+        self.assertEqual(m["A"]["mass"], 2.0)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
-        m['A'].update({'energy':1.5, 'mass':2.5})
-        self.assertEqual(m['A']['energy'], 1.5)
-        self.assertEqual(m['A']['mass'], 2.5)
-        self.assertEqual(m['B']['energy'], None)
-        self.assertEqual(m['B']['mass'], None)
+        m["A"].update({"energy": 1.5, "mass": 2.5})
+        self.assertEqual(m["A"]["energy"], 1.5)
+        self.assertEqual(m["A"]["mass"], 2.5)
+        self.assertEqual(m["B"]["energy"], None)
+        self.assertEqual(m["B"]["mass"], None)
 
-        m['B'] = {'energy':3.0, 'mass':4.0}
-        self.assertEqual(m['A']['energy'], 1.5)
-        self.assertEqual(m['A']['mass'], 2.5)
-        self.assertEqual(m['B']['energy'], 3.0)
-        self.assertEqual(m['B']['mass'], 4.0)
+        m["B"] = {"energy": 3.0, "mass": 4.0}
+        self.assertEqual(m["A"]["energy"], 1.5)
+        self.assertEqual(m["A"]["mass"], 2.5)
+        self.assertEqual(m["B"]["energy"], 3.0)
+        self.assertEqual(m["B"]["mass"], 4.0)
 
-        m['B'].update(energy=3.5, mass=4.5)
-        self.assertEqual(m['A']['energy'], 1.5)
-        self.assertEqual(m['A']['mass'], 2.5)
-        self.assertEqual(m['B']['energy'], 3.5)
-        self.assertEqual(m['B']['mass'], 4.5)
+        m["B"].update(energy=3.5, mass=4.5)
+        self.assertEqual(m["A"]["energy"], 1.5)
+        self.assertEqual(m["A"]["mass"], 2.5)
+        self.assertEqual(m["B"]["energy"], 3.5)
+        self.assertEqual(m["B"]["mass"], 4.5)
 
         # test that partial assignment resets other param to default value
-        m['A'] = {'energy':2.0}
-        self.assertEqual(m['A']['energy'], 2.0)
-        self.assertEqual(m['A']['mass'], None)
-        self.assertEqual(m['B']['energy'], 3.5)
-        self.assertEqual(m['B']['mass'], 4.5)
+        m["A"] = {"energy": 2.0}
+        self.assertEqual(m["A"]["energy"], 2.0)
+        self.assertEqual(m["A"]["mass"], None)
+        self.assertEqual(m["B"]["energy"], 3.5)
+        self.assertEqual(m["B"]["mass"], 4.5)
 
     def test_evaluate(self):
         """Test evaluation of keyed parameters"""
         # test evaluation with empty parameter values
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy','mass'))
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
         with self.assertRaises(ValueError):
-            x = m.evaluate('A')
+            m.evaluate("A")
 
         # test evaluation with invalid key called
         with self.assertRaises(KeyError):
-            x = m.evaluate('C')
+            m.evaluate("C")
 
         # test evaluation with initialized shared parameter values
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy','mass'))
-        m.shared['energy'] = 0.0
-        m.shared['mass'] = 0.5
-        self.assertEqual(m.evaluate('A'), {'energy':0.0, 'mass':0.5})
-        self.assertEqual(m.evaluate('B'), {'energy':0.0, 'mass':0.5})
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
+        m.shared["energy"] = 0.0
+        m.shared["mass"] = 0.5
+        self.assertEqual(m.evaluate("A"), {"energy": 0.0, "mass": 0.5})
+        self.assertEqual(m.evaluate("B"), {"energy": 0.0, "mass": 0.5})
 
         # test evaluation with initialized shared and individual parameter values
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy','mass'))
-        m.shared['energy'] = 0.0
-        m.shared['mass'] = 0.5
-        m['B']['energy'] = 1.5
-        self.assertEqual(m.evaluate('A'), {'energy':0.0, 'mass':0.5})
-        self.assertEqual(m.evaluate('B'), {'energy':1.5, 'mass':0.5})
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
+        m.shared["energy"] = 0.0
+        m.shared["mass"] = 0.5
+        m["B"]["energy"] = 1.5
+        self.assertEqual(m.evaluate("A"), {"energy": 0.0, "mass": 0.5})
+        self.assertEqual(m.evaluate("B"), {"energy": 1.5, "mass": 0.5})
 
         # test evaluation with initialized parameter values as DesignVariable types
-        m = relentless.model.potential.Parameters(types=('A',), params=('energy','mass'))
-        m['A']['energy'] = relentless.model.DesignVariable(value=-1.0,low=0.1)
-        m['A']['mass'] = relentless.model.DesignVariable(value=1.0,high=0.3)
-        self.assertEqual(m.evaluate('A'), {'energy':0.1, 'mass':0.3})
+        m = relentless.model.potential.Parameters(
+            types=("A",), params=("energy", "mass")
+        )
+        m["A"]["energy"] = relentless.model.DesignVariable(value=-1.0, low=0.1)
+        m["A"]["mass"] = relentless.model.DesignVariable(value=1.0, high=0.3)
+        self.assertEqual(m.evaluate("A"), {"energy": 0.1, "mass": 0.3})
 
         # test evaluation with initialized parameter values as unrecognized types
-        m = relentless.model.potential.Parameters(types=('A','B'), params=('energy','mass'))
-        m.shared['energy'] = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
-        m.shared['mass'] = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        m = relentless.model.potential.Parameters(
+            types=("A", "B"), params=("energy", "mass")
+        )
+        m.shared["energy"] = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
+        m.shared["mass"] = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
         with self.assertRaises(TypeError):
-            x = m.evaluate('A')
+            m.evaluate("A")
 
     def test_save(self):
         """Test saving to file"""
         temp = tempfile.NamedTemporaryFile()
 
         # test dumping/re-loading data with scalar parameter values
-        m = relentless.model.potential.Parameters(types=('A',), params=('energy','mass'))
-        m['A']['energy'] = 1.5
-        m['A']['mass'] = 2.5
+        m = relentless.model.potential.Parameters(
+            types=("A",), params=("energy", "mass")
+        )
+        m["A"]["energy"] = 1.5
+        m["A"]["mass"] = 2.5
         m.save(temp.name)
-        with open(temp.name, 'r') as f:
+        with open(temp.name, "r") as f:
             x = json.load(f)
-        self.assertEqual(m['A']['energy'], x['A']['energy'])
-        self.assertEqual(m['A']['mass'], x['A']['mass'])
+        self.assertEqual(m["A"]["energy"], x["A"]["energy"])
+        self.assertEqual(m["A"]["mass"], x["A"]["mass"])
 
         # test dumping/re-loading data with DesignVariable parameter values
-        m = relentless.model.potential.Parameters(types=('A',), params=('energy','mass'))
-        m['A']['energy'] = relentless.model.DesignVariable(value=0.5)
-        m['A']['mass'] = relentless.model.DesignVariable(value=2.0)
+        m = relentless.model.potential.Parameters(
+            types=("A",), params=("energy", "mass")
+        )
+        m["A"]["energy"] = relentless.model.DesignVariable(value=0.5)
+        m["A"]["mass"] = relentless.model.DesignVariable(value=2.0)
         m.save(temp.name)
-        with open(temp.name, 'r') as f:
+        with open(temp.name, "r") as f:
             x = json.load(f)
-        self.assertEqual(m['A']['energy'].value, x['A']['energy'])
-        self.assertEqual(m['A']['mass'].value, x['A']['mass'])
+        self.assertEqual(m["A"]["energy"].value, x["A"]["energy"])
+        self.assertEqual(m["A"]["mass"].value, x["A"]["mass"])
 
         temp.close()
+
 
 class MockPotential(relentless.model.potential.Potential):
     """Mock potential function used to test relentless.model.potential.Potential"""
@@ -248,12 +276,14 @@ class MockPotential(relentless.model.potential.Potential):
     def derivative(self, key, var, x):
         pass
 
+
 class MockContainer:
     """Mock container class used to test relentless.model.potential.Potential"""
 
     def __init__(self, types, params):
-        self.types = ('foo')
-        self.params = ('bar')
+        self.types = "foo"
+        self.params = "bar"
+
 
 class test_Potential(unittest.TestCase):
     """Unit tests for relentless.model.potential.Potential"""
@@ -261,18 +291,18 @@ class test_Potential(unittest.TestCase):
     def test_init(self):
         """Test creation from data"""
         # test creation with default container
-        p = MockPotential(types=('1',), params=('m',))
-        self.assertCountEqual(p.coeff.types, ('1',))
-        self.assertCountEqual(p.coeff.params, ('m',))
+        p = MockPotential(types=("1",), params=("m",))
+        self.assertCountEqual(p.coeff.types, ("1",))
+        self.assertCountEqual(p.coeff.params, ("m",))
 
         # test creation with custom container
-        p = MockPotential(types=('1',), params=('m',), container=MockContainer)
-        self.assertCountEqual(p.coeff.types, ('foo'))
-        self.assertCountEqual(p.coeff.params, ('bar'))
+        p = MockPotential(types=("1",), params=("m",), container=MockContainer)
+        self.assertCountEqual(p.coeff.types, ("foo"))
+        self.assertCountEqual(p.coeff.params, ("bar"))
 
     def test_zeros(self):
         """Test _zeros method"""
-        p = MockPotential(types=('1',), params=('m',))
+        p = MockPotential(types=("1",), params=("m",))
 
         # test with scalar r
         r = 0.5
@@ -318,32 +348,33 @@ class test_Potential(unittest.TestCase):
 
     def test_iteration(self):
         """Test iteration on Potential object"""
-        p = MockPotential(types=('1','2'), params=('m','rmin','rmax'))
+        p = MockPotential(types=("1", "2"), params=("m", "rmin", "rmax"))
         for t in p.coeff:
-            p.coeff[t]['m'] = 2.0
-            p.coeff[t]['rmin'] = 0.0
-            p.coeff[t]['rmax'] = 1.0
+            p.coeff[t]["m"] = 2.0
+            p.coeff[t]["rmin"] = 0.0
+            p.coeff[t]["rmax"] = 1.0
 
-        self.assertEqual(dict(p.coeff['1']), {'m':2.0, 'rmin':0.0, 'rmax':1.0})
-        self.assertEqual(dict(p.coeff['2']), {'m':2.0, 'rmin':0.0, 'rmax':1.0})
+        self.assertEqual(dict(p.coeff["1"]), {"m": 2.0, "rmin": 0.0, "rmax": 1.0})
+        self.assertEqual(dict(p.coeff["2"]), {"m": 2.0, "rmin": 0.0, "rmax": 1.0})
 
     def test_save(self):
         """Test saving to file"""
         temp = tempfile.NamedTemporaryFile()
-        p = MockPotential(types=('1',), params=('m','rmin','rmax'))
-        p.coeff['1']['m'] = 2.0
-        p.coeff['1']['rmin'] = 0.0
-        p.coeff['1']['rmax'] = 1.0
+        p = MockPotential(types=("1",), params=("m", "rmin", "rmax"))
+        p.coeff["1"]["m"] = 2.0
+        p.coeff["1"]["rmin"] = 0.0
+        p.coeff["1"]["rmax"] = 1.0
 
         p.save(temp.name)
-        with open(temp.name, 'r') as f:
+        with open(temp.name, "r") as f:
             x = json.load(f)
 
-        self.assertEqual(p.coeff['1']['m'], x['1']['m'])
-        self.assertEqual(p.coeff['1']['rmin'], x['1']['rmin'])
-        self.assertEqual(p.coeff['1']['rmax'], x['1']['rmax'])
+        self.assertEqual(p.coeff["1"]["m"], x["1"]["m"])
+        self.assertEqual(p.coeff["1"]["rmin"], x["1"]["rmin"])
+        self.assertEqual(p.coeff["1"]["rmax"], x["1"]["rmax"])
 
         temp.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/model/test_ensemble.py
+++ b/tests/model/test_ensemble.py
@@ -6,31 +6,31 @@ import numpy
 
 import relentless
 
+
 class test_RDF(unittest.TestCase):
     """Unit tests for relentless.model.RDF"""
 
     def test_init(self):
         """Test creation from data"""
         # test valid construction
-        r = [1,2,3]
-        g = [2,9,5]
+        r = [1, 2, 3]
+        g = [2, 9, 5]
         rdf = relentless.model.RDF(r=r, g=g)
-        numpy.testing.assert_allclose(rdf.table, numpy.array([[1,2],
-                                                              [2,9],
-                                                              [3,5]]))
+        numpy.testing.assert_allclose(rdf.table, numpy.array([[1, 2], [2, 9], [3, 5]]))
 
         # test interpolation
-        numpy.testing.assert_allclose(rdf([2.5,3.5]), [8.375,5.0])
+        numpy.testing.assert_allclose(rdf([2.5, 3.5]), [8.375, 5.0])
 
         # test invalid construction with r and g having different lengths
-        r = [1,2,3,4]
+        r = [1, 2, 3, 4]
         with self.assertRaises(ValueError):
             rdf = relentless.model.RDF(r=r, g=g)
 
         # test invalid construction with non-strictly-increasing r
-        r = [1,3,2]
+        r = [1, 3, 2]
         with self.assertRaises(ValueError):
             rdf = relentless.model.RDF(r=r, g=g)
+
 
 class test_Ensemble(unittest.TestCase):
     """Unit tests for relentless.model.Ensemble"""
@@ -38,64 +38,64 @@ class test_Ensemble(unittest.TestCase):
     def test_init(self):
         """Test creation from data."""
         # P and N set
-        ens = relentless.model.Ensemble(T=10, P=2.0, N={'A':1,'B':2})
-        self.assertCountEqual(ens.types, ('A','B'))
-        self.assertCountEqual(ens.rdf.pairs, (('A','B'),('A','A'),('B','B')))
+        ens = relentless.model.Ensemble(T=10, P=2.0, N={"A": 1, "B": 2})
+        self.assertCountEqual(ens.types, ("A", "B"))
+        self.assertCountEqual(ens.rdf.pairs, (("A", "B"), ("A", "A"), ("B", "B")))
         self.assertAlmostEqual(ens.T, 10)
         self.assertAlmostEqual(ens.P, 2.0)
         self.assertEqual(ens.V, None)
-        self.assertEqual(dict(ens.N), {'A':1,'B':2})
+        self.assertEqual(dict(ens.N), {"A": 1, "B": 2})
 
         # V and N set
         v_obj = relentless.model.Cube(L=3.0)
-        ens = relentless.model.Ensemble(T=20, V=v_obj, N={'A':1,'B':2})
-        self.assertCountEqual(ens.types, ('A','B'))
-        self.assertCountEqual(ens.rdf.pairs, (('A','B'),('A','A'),('B','B')))
+        ens = relentless.model.Ensemble(T=20, V=v_obj, N={"A": 1, "B": 2})
+        self.assertCountEqual(ens.types, ("A", "B"))
+        self.assertCountEqual(ens.rdf.pairs, (("A", "B"), ("A", "A"), ("B", "B")))
         self.assertAlmostEqual(ens.T, 20)
         self.assertEqual(ens.P, None)
-        self.assertIs(ens.V,v_obj)
+        self.assertIs(ens.V, v_obj)
         self.assertAlmostEqual(ens.V.extent, 27.0)
-        self.assertEqual(dict(ens.N), {'A':1,'B':2})
+        self.assertEqual(dict(ens.N), {"A": 1, "B": 2})
 
         # one N is None
-        ens = relentless.model.Ensemble(T=100, V=v_obj, N={'A':None, 'B':2})
-        self.assertCountEqual(ens.types, ('A','B'))
-        self.assertCountEqual(ens.rdf.pairs, (('A','B'),('A','A'),('B','B')))
+        ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": None, "B": 2})
+        self.assertCountEqual(ens.types, ("A", "B"))
+        self.assertCountEqual(ens.rdf.pairs, (("A", "B"), ("A", "A"), ("B", "B")))
         self.assertAlmostEqual(ens.T, 100)
         self.assertEqual(ens.P, None)
-        self.assertIs(ens.V,v_obj)
+        self.assertIs(ens.V, v_obj)
         self.assertAlmostEqual(ens.V.extent, 27.0)
-        self.assertEqual(dict(ens.N), {'A':None,'B':2})
+        self.assertEqual(dict(ens.N), {"A": None, "B": 2})
 
         # test creation with single type
-        ens = relentless.model.Ensemble(T=100, V=v_obj, N={'A':10})
-        self.assertCountEqual(ens.types, ('A',))
-        self.assertCountEqual(ens.rdf.pairs, (('A','A'),))
+        ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": 10})
+        self.assertCountEqual(ens.types, ("A",))
+        self.assertCountEqual(ens.rdf.pairs, (("A", "A"),))
         self.assertAlmostEqual(ens.T, 100)
         self.assertEqual(ens.P, None)
-        self.assertIs(ens.V,v_obj)
+        self.assertIs(ens.V, v_obj)
         self.assertAlmostEqual(ens.V.extent, 27.0)
-        self.assertEqual(dict(ens.N), {'A':10})
+        self.assertEqual(dict(ens.N), {"A": 10})
 
         # test setting rdf
-        ens = relentless.model.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
-        r = [1,2,3]
-        ens.rdf['A','B'] = relentless.model.RDF(r=r, g=[2,9,5])
-        ens.rdf['A','A'] = relentless.model.RDF(r=r, g=[3,7,4])
-        ens.rdf['B','B'] = relentless.model.RDF(r=r, g=[1,9,3])
-        numpy.testing.assert_allclose(ens.rdf['A','B'].table, numpy.array([[1,2],
-                                                                           [2,9],
-                                                                           [3,5]]))
-        numpy.testing.assert_allclose(ens.rdf['A','A'].table, numpy.array([[1,3],
-                                                                           [2,7],
-                                                                           [3,4]]))
-        numpy.testing.assert_allclose(ens.rdf['B','B'].table, numpy.array([[1,1],
-                                                                           [2,9],
-                                                                           [3,3]]))
+        ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": 1, "B": 2})
+        r = [1, 2, 3]
+        ens.rdf["A", "B"] = relentless.model.RDF(r=r, g=[2, 9, 5])
+        ens.rdf["A", "A"] = relentless.model.RDF(r=r, g=[3, 7, 4])
+        ens.rdf["B", "B"] = relentless.model.RDF(r=r, g=[1, 9, 3])
+        numpy.testing.assert_allclose(
+            ens.rdf["A", "B"].table, numpy.array([[1, 2], [2, 9], [3, 5]])
+        )
+        numpy.testing.assert_allclose(
+            ens.rdf["A", "A"].table, numpy.array([[1, 3], [2, 7], [3, 4]])
+        )
+        numpy.testing.assert_allclose(
+            ens.rdf["B", "B"].table, numpy.array([[1, 1], [2, 9], [3, 3]])
+        )
 
         # test setting N with non-string type
         with self.assertRaises(TypeError):
-            ens = relentless.model.Ensemble(T=10, P=1.0, N={1:2})
+            ens = relentless.model.Ensemble(T=10, P=1.0, N={1: 2})
 
     def test_set_params(self):
         """Test setting constant and fluctuating parameter values."""
@@ -103,19 +103,19 @@ class test_Ensemble(unittest.TestCase):
         v_obj1 = relentless.model.Cube(L=4.0)
 
         # NVT ensemble
-        ens = relentless.model.Ensemble(T=10, V=v_obj, N={'A':1,'B':2})
+        ens = relentless.model.Ensemble(T=10, V=v_obj, N={"A": 1, "B": 2})
         self.assertEqual(ens.P, None)
-        self.assertIs(ens.V,v_obj)
+        self.assertIs(ens.V, v_obj)
         self.assertAlmostEqual(ens.V.extent, 27.0)
-        self.assertEqual(dict(ens.N), {'A':1,'B':2})
+        self.assertEqual(dict(ens.N), {"A": 1, "B": 2})
 
         # set values
         ens.V = v_obj1
-        self.assertIs(ens.V,v_obj1)
+        self.assertIs(ens.V, v_obj1)
         self.assertAlmostEqual(ens.V.extent, 64.0)
-        ens.N['A'] = 2
-        ens.N['B'] = 3
-        self.assertEqual(dict(ens.N), {'A':2,'B':3})
+        ens.N["A"] = 2
+        ens.N["B"] = 3
+        self.assertEqual(dict(ens.N), {"A": 2, "B": 3})
 
         # set other values
         ens.P = 2.0
@@ -123,14 +123,14 @@ class test_Ensemble(unittest.TestCase):
 
         # test invalid setting of N directly
         with self.assertRaises(AttributeError):
-            ens.N = {'A':3,'B':4}
+            ens.N = {"A": 3, "B": 4}
 
     def test_copy(self):
         """Test copy method"""
         v_obj = relentless.model.Cube(L=1.0)
 
         # P and mu set
-        ens = relentless.model.Ensemble(T=10, P=2.0, V=v_obj, N={'A':1,'B':2})
+        ens = relentless.model.Ensemble(T=10, P=2.0, V=v_obj, N={"A": 1, "B": 2})
         ens_ = ens.copy()
         self.assertIsNot(ens, ens_)
         self.assertCountEqual(ens.types, ens_.types)
@@ -142,24 +142,24 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(dict(ens_.N), dict(ens.N))
 
         # test copying rdf
-        ens = relentless.model.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
-        r = [1,2,3]
-        ens.rdf['A','B'] = relentless.model.RDF(r=r, g=[2,9,5])
-        ens.rdf['A','A'] = relentless.model.RDF(r=r, g=[3,7,4])
-        ens.rdf['B','B'] = relentless.model.RDF(r=r, g=[1,9,3])
+        ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": 1, "B": 2})
+        r = [1, 2, 3]
+        ens.rdf["A", "B"] = relentless.model.RDF(r=r, g=[2, 9, 5])
+        ens.rdf["A", "A"] = relentless.model.RDF(r=r, g=[3, 7, 4])
+        ens.rdf["B", "B"] = relentless.model.RDF(r=r, g=[1, 9, 3])
         ens_ = ens.copy()
         self.assertIsNot(ens_, ens)
         self.assertIsNot(ens_.rdf, ens.rdf)
-        numpy.testing.assert_allclose(ens.rdf['A','B'].table, ens_.rdf['A','B'].table)
-        numpy.testing.assert_allclose(ens.rdf['A','A'].table, ens_.rdf['A','A'].table)
-        numpy.testing.assert_allclose(ens.rdf['B','B'].table, ens_.rdf['B','B'].table)
+        numpy.testing.assert_allclose(ens.rdf["A", "B"].table, ens_.rdf["A", "B"].table)
+        numpy.testing.assert_allclose(ens.rdf["A", "A"].table, ens_.rdf["A", "A"].table)
+        numpy.testing.assert_allclose(ens.rdf["B", "B"].table, ens_.rdf["B", "B"].table)
 
     def test_save_from_file(self):
         """Test save and from_file methods"""
         temp = tempfile.NamedTemporaryFile()
 
         v_obj = relentless.model.Cube(L=1.0)
-        ens = relentless.model.Ensemble(T=20, V=v_obj, P=1.0, N={'A':1,'B':2})
+        ens = relentless.model.Ensemble(T=20, V=v_obj, P=1.0, N={"A": 1, "B": 2})
         ens.save(temp.name)
         ens_ = relentless.model.Ensemble.from_file(temp.name)
         self.assertIsNot(ens_, ens)
@@ -172,19 +172,20 @@ class test_Ensemble(unittest.TestCase):
         self.assertEqual(dict(ens_.N), dict(ens.N))
 
         # test saving/constructing rdf
-        ens = relentless.model.Ensemble(T=100, V=v_obj, N={'A':1,'B':2})
-        r = [1,2,3]
-        ens.rdf['A','B'] = relentless.model.RDF(r=r, g=[2,9,5])
-        ens.rdf['A','A'] = relentless.model.RDF(r=r, g=[3,7,4])
+        ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": 1, "B": 2})
+        r = [1, 2, 3]
+        ens.rdf["A", "B"] = relentless.model.RDF(r=r, g=[2, 9, 5])
+        ens.rdf["A", "A"] = relentless.model.RDF(r=r, g=[3, 7, 4])
         ens.save(temp.name)
         ens_ = relentless.model.Ensemble.from_file(temp.name)
         self.assertIsNot(ens_, ens)
         self.assertIsNot(ens_.rdf, ens.rdf)
-        numpy.testing.assert_allclose(ens.rdf['A','B'].table, ens_.rdf['A','B'].table)
-        numpy.testing.assert_allclose(ens.rdf['A','A'].table, ens_.rdf['A','A'].table)
-        self.assertEqual(ens.rdf['B','B'], ens_.rdf['B','B'])
+        numpy.testing.assert_allclose(ens.rdf["A", "B"].table, ens_.rdf["A", "B"].table)
+        numpy.testing.assert_allclose(ens.rdf["A", "A"].table, ens_.rdf["A", "A"].table)
+        self.assertEqual(ens.rdf["B", "B"], ens_.rdf["B", "B"])
 
         temp.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/model/test_extent.py
+++ b/tests/model/test_extent.py
@@ -5,69 +5,78 @@ import numpy
 
 import relentless
 
+
 class test_TriclinicBox(unittest.TestCase):
     """Unit tests for relentless.model.TriclinicBox"""
 
     def test_init(self):
         """Test creation from data."""
         # test valid construction, LAMMPS convention
-        t = relentless.model.TriclinicBox(Lx=1,Ly=2,Lz=3,xy=1,xz=0.75,yz=2.25,
-                                           convention='LAMMPS')
-        numpy.testing.assert_allclose(t.a, numpy.array([1,0,0]))
-        numpy.testing.assert_allclose(t.b, numpy.array([1,2,0]))
-        numpy.testing.assert_allclose(t.c, numpy.array([0.75,2.25,3]))
+        t = relentless.model.TriclinicBox(
+            Lx=1, Ly=2, Lz=3, xy=1, xz=0.75, yz=2.25, convention="LAMMPS"
+        )
+        numpy.testing.assert_allclose(t.a, numpy.array([1, 0, 0]))
+        numpy.testing.assert_allclose(t.b, numpy.array([1, 2, 0]))
+        numpy.testing.assert_allclose(t.c, numpy.array([0.75, 2.25, 3]))
         self.assertAlmostEqual(t.extent, 6)
 
         # test valid construction, HOOMD convention
-        t = relentless.model.TriclinicBox(Lx=1,Ly=2,Lz=3,xy=0.5,xz=0.25,yz=0.75,
-                                           convention='HOOMD')
-        numpy.testing.assert_allclose(t.a, numpy.array([1,0,0]))
-        numpy.testing.assert_allclose(t.b, numpy.array([1,2,0]))
-        numpy.testing.assert_allclose(t.c, numpy.array([0.75,2.25,3]))
+        t = relentless.model.TriclinicBox(
+            Lx=1, Ly=2, Lz=3, xy=0.5, xz=0.25, yz=0.75, convention="HOOMD"
+        )
+        numpy.testing.assert_allclose(t.a, numpy.array([1, 0, 0]))
+        numpy.testing.assert_allclose(t.b, numpy.array([1, 2, 0]))
+        numpy.testing.assert_allclose(t.c, numpy.array([0.75, 2.25, 3]))
         self.assertAlmostEqual(t.extent, 6)
 
         # test invalid constructions
         with self.assertRaises(ValueError):
-            t = relentless.model.TriclinicBox(Lx=1,Ly=2,Lz=3,xy=1,xz=0.75,yz=2.25,convention='not-real')
+            t = relentless.model.TriclinicBox(
+                Lx=1, Ly=2, Lz=3, xy=1, xz=0.75, yz=2.25, convention="not-real"
+            )
         with self.assertRaises(ValueError):
-            t = relentless.model.TriclinicBox(Lx=-1,Ly=2,Lz=3,xy=1,xz=0.75,yz=2.25,
-                                               convention='LAMMPS')
+            t = relentless.model.TriclinicBox(
+                Lx=-1, Ly=2, Lz=3, xy=1, xz=0.75, yz=2.25, convention="LAMMPS"
+            )
 
     def test_coordinate_transform(self):
         t = relentless.model.TriclinicBox(Lx=1, Ly=2, Lz=3, xy=1, xz=0.75, yz=2.25)
 
         # check upper/lower bounds
-        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.low), [0,0,0])
-        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.high), [1,1,1])
+        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.low), [0, 0, 0])
+        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.high), [1, 1, 1])
 
         # origin should be at center of box
-        x = t.coordinate_to_fraction([0,0,0])
-        numpy.testing.assert_allclose(x, [0.5,0.5,0.5])
+        x = t.coordinate_to_fraction([0, 0, 0])
+        numpy.testing.assert_allclose(x, [0.5, 0.5, 0.5])
         r = t.fraction_to_coordinate(x)
-        numpy.testing.assert_allclose(r, [0,0,0])
+        numpy.testing.assert_allclose(r, [0, 0, 0])
 
         # do a few made up coordinates, and ensure there & back works
-        r = [[-1,0.5,-0.25],[3,-2,1], [100,-200,300]]
+        r = [[-1, 0.5, -0.25], [3, -2, 1], [100, -200, 300]]
         r_2 = t.fraction_to_coordinate(t.coordinate_to_fraction(r))
         numpy.testing.assert_allclose(r_2, r)
 
         # go the other way
-        x = [[0.2,0.3,0.4],[0,1,0.9],[-1,100,-3]]
+        x = [[0.2, 0.3, 0.4], [0, 1, 0.9], [-1, 100, -3]]
         x_2 = t.fraction_to_coordinate(t.coordinate_to_fraction(x))
         numpy.testing.assert_allclose(x_2, x)
 
         # make some fractions and wrap them back in
-        x = [[0.1,0.2,0.3],[1.1,-0.1,1.2],[3.1,-1.1,-2.2]]
+        x = [[0.1, 0.2, 0.3], [1.1, -0.1, 1.2], [3.1, -1.1, -2.2]]
         r = t.fraction_to_coordinate(x)
         r = t.wrap(r)
         x = t.coordinate_to_fraction(r)
-        numpy.testing.assert_allclose(x, [[0.1,0.2,0.3],[0.1,0.9,0.2],[0.1,0.9,0.8]])
+        numpy.testing.assert_allclose(
+            x, [[0.1, 0.2, 0.3], [0.1, 0.9, 0.2], [0.1, 0.9, 0.8]]
+        )
 
     def test_to_from_json(self):
         """Test to_json and from_json methods."""
         # test LAMMPS convention
-        c = relentless.model.TriclinicBox(Lx=3,Ly=4,Lz=5,xy=2,xz=3,yz=4,
-                                           convention='LAMMPS')
+        c = relentless.model.TriclinicBox(
+            Lx=3, Ly=4, Lz=5, xy=2, xz=3, yz=4, convention="LAMMPS"
+        )
         data = c.to_json()
         c_ = relentless.model.TriclinicBox.from_json(data)
         self.assertIsInstance(c_, relentless.model.TriclinicBox)
@@ -77,8 +86,9 @@ class test_TriclinicBox(unittest.TestCase):
         self.assertAlmostEqual(c.extent, c_.extent)
 
         # test HOOMD convention
-        c = relentless.model.TriclinicBox(Lx=3,Ly=4,Lz=5,xy=2,xz=3,yz=4,
-                                           convention='HOOMD')
+        c = relentless.model.TriclinicBox(
+            Lx=3, Ly=4, Lz=5, xy=2, xz=3, yz=4, convention="HOOMD"
+        )
         data = c.to_json()
         c_ = relentless.model.TriclinicBox.from_json(data)
         self.assertIsInstance(c_, relentless.model.TriclinicBox)
@@ -87,25 +97,26 @@ class test_TriclinicBox(unittest.TestCase):
         numpy.testing.assert_allclose(c.c, c_.c)
         self.assertAlmostEqual(c.extent, c_.extent)
 
+
 class test_Cuboid(unittest.TestCase):
     """Unit tests for relentless.model.Cuboid"""
 
     def test_init(self):
         """Test creation from data."""
         # test valid construction
-        c = relentless.model.Cuboid(Lx=3,Ly=4,Lz=5)
-        numpy.testing.assert_allclose(c.a, numpy.array([3,0,0]))
-        numpy.testing.assert_allclose(c.b, numpy.array([0,4,0]))
-        numpy.testing.assert_allclose(c.c, numpy.array([0,0,5]))
+        c = relentless.model.Cuboid(Lx=3, Ly=4, Lz=5)
+        numpy.testing.assert_allclose(c.a, numpy.array([3, 0, 0]))
+        numpy.testing.assert_allclose(c.b, numpy.array([0, 4, 0]))
+        numpy.testing.assert_allclose(c.c, numpy.array([0, 0, 5]))
         self.assertAlmostEqual(c.extent, 60)
 
         # test invalid construction
         with self.assertRaises(ValueError):
-            c = relentless.model.Cuboid(Lx=-3,Ly=4,Lz=5)
+            c = relentless.model.Cuboid(Lx=-3, Ly=4, Lz=5)
 
     def test_to_from_json(self):
         """Test to_json and from_json methods."""
-        c = relentless.model.Cuboid(Lx=3,Ly=4,Lz=5)
+        c = relentless.model.Cuboid(Lx=3, Ly=4, Lz=5)
         data = c.to_json()
         c_ = relentless.model.Cuboid.from_json(data)
         self.assertIsInstance(c_, relentless.model.Cuboid)
@@ -114,6 +125,7 @@ class test_Cuboid(unittest.TestCase):
         numpy.testing.assert_allclose(c.c, c_.c)
         self.assertAlmostEqual(c.extent, c_.extent)
 
+
 class test_Cube(unittest.TestCase):
     """Unit tests for relentless.model.Cube"""
 
@@ -121,9 +133,9 @@ class test_Cube(unittest.TestCase):
         """Test creation from data."""
         # test valid construction
         c = relentless.model.Cube(L=3)
-        numpy.testing.assert_allclose(c.a, numpy.array([3,0,0]))
-        numpy.testing.assert_allclose(c.b, numpy.array([0,3,0]))
-        numpy.testing.assert_allclose(c.c, numpy.array([0,0,3]))
+        numpy.testing.assert_allclose(c.a, numpy.array([3, 0, 0]))
+        numpy.testing.assert_allclose(c.b, numpy.array([0, 3, 0]))
+        numpy.testing.assert_allclose(c.c, numpy.array([0, 0, 3]))
         self.assertAlmostEqual(c.extent, 27)
 
         # test invalid construction
@@ -141,66 +153,64 @@ class test_Cube(unittest.TestCase):
         numpy.testing.assert_allclose(c.c, c_.c)
         self.assertAlmostEqual(c.extent, c_.extent)
 
+
 class test_ObliqueArea(unittest.TestCase):
     """Unit tests for relentless.model.ObliqueArea"""
 
     def test_init(self):
         """Test creation from data."""
         # test valid construction, LAMMPS convention
-        t = relentless.model.ObliqueArea(Lx=1,Ly=2,xy=1, convention='LAMMPS')
-        numpy.testing.assert_allclose(t.a, numpy.array([1,0]))
-        numpy.testing.assert_allclose(t.b, numpy.array([1,2]))
+        t = relentless.model.ObliqueArea(Lx=1, Ly=2, xy=1, convention="LAMMPS")
+        numpy.testing.assert_allclose(t.a, numpy.array([1, 0]))
+        numpy.testing.assert_allclose(t.b, numpy.array([1, 2]))
         self.assertAlmostEqual(t.extent, 2)
 
         # test valid construction, HOOMD convention
-        t = relentless.model.ObliqueArea(Lx=1,Ly=2,xy=0.5,
-                                           convention='HOOMD')
-        numpy.testing.assert_allclose(t.a, numpy.array([1,0]))
-        numpy.testing.assert_allclose(t.b, numpy.array([1,2]))
-        self.assertAlmostEqual(t.extent, 2)    
+        t = relentless.model.ObliqueArea(Lx=1, Ly=2, xy=0.5, convention="HOOMD")
+        numpy.testing.assert_allclose(t.a, numpy.array([1, 0]))
+        numpy.testing.assert_allclose(t.b, numpy.array([1, 2]))
+        self.assertAlmostEqual(t.extent, 2)
 
         # test invalid constructions
         with self.assertRaises(ValueError):
-            t = relentless.model.ObliqueArea(Lx=1,Ly=2,xy=1,convention='not-real')
+            t = relentless.model.ObliqueArea(Lx=1, Ly=2, xy=1, convention="not-real")
         with self.assertRaises(ValueError):
-            t = relentless.model.ObliqueArea(Lx=-1,Ly=2,xy=1,
-                                               convention='LAMMPS')
+            t = relentless.model.ObliqueArea(Lx=-1, Ly=2, xy=1, convention="LAMMPS")
 
     def test_coordinate_transform(self):
         t = relentless.model.ObliqueArea(Lx=1, Ly=2, xy=1)
 
         # check upper/lower bounds
-        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.low), [0,0])
-        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.high), [1,1])
+        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.low), [0, 0])
+        numpy.testing.assert_allclose(t.coordinate_to_fraction(t.high), [1, 1])
 
         # origin should be at center of box
-        x = t.coordinate_to_fraction([0,0])
-        numpy.testing.assert_allclose(x, [0.5,0.5])
+        x = t.coordinate_to_fraction([0, 0])
+        numpy.testing.assert_allclose(x, [0.5, 0.5])
         r = t.fraction_to_coordinate(x)
-        numpy.testing.assert_allclose(r, [0,0])
+        numpy.testing.assert_allclose(r, [0, 0])
 
         # do a few made up coordinates, and ensure there & back works
-        r = [[-1,0.5],[3,-2], [100,-200]]
+        r = [[-1, 0.5], [3, -2], [100, -200]]
         r_2 = t.fraction_to_coordinate(t.coordinate_to_fraction(r))
         numpy.testing.assert_allclose(r_2, r)
 
         # go the other way
-        x = [[0.2,0.3],[0,1],[-1,100]]
+        x = [[0.2, 0.3], [0, 1], [-1, 100]]
         x_2 = t.fraction_to_coordinate(t.coordinate_to_fraction(x))
         numpy.testing.assert_allclose(x_2, x)
 
         # make some fractions and wrap them back in
-        x = [[0.1,0.2],[1.1,-0.1],[3.1,-2.2]]
+        x = [[0.1, 0.2], [1.1, -0.1], [3.1, -2.2]]
         r = t.fraction_to_coordinate(x)
         r = t.wrap(r)
         x = t.coordinate_to_fraction(r)
-        numpy.testing.assert_allclose(x, [[0.1,0.2],[0.1,0.9],[0.1,0.8]])
+        numpy.testing.assert_allclose(x, [[0.1, 0.2], [0.1, 0.9], [0.1, 0.8]])
 
     def test_to_from_json(self):
         """Test to_json and from_json methods."""
         # test LAMMPS convention
-        c = relentless.model.ObliqueArea(Lx=3,Ly=4,xy=2,
-                                           convention='LAMMPS')
+        c = relentless.model.ObliqueArea(Lx=3, Ly=4, xy=2, convention="LAMMPS")
         data = c.to_json()
         c_ = relentless.model.ObliqueArea.from_json(data)
         self.assertIsInstance(c_, relentless.model.ObliqueArea)
@@ -209,14 +219,14 @@ class test_ObliqueArea(unittest.TestCase):
         self.assertAlmostEqual(c.extent, c_.extent)
 
         # test HOOMD convention
-        c = relentless.model.ObliqueArea(Lx=3,Ly=4,xy=2,
-                                           convention='HOOMD')
+        c = relentless.model.ObliqueArea(Lx=3, Ly=4, xy=2, convention="HOOMD")
         data = c.to_json()
         c_ = relentless.model.ObliqueArea.from_json(data)
         self.assertIsInstance(c_, relentless.model.ObliqueArea)
         numpy.testing.assert_allclose(c.a, c_.a)
         numpy.testing.assert_allclose(c.b, c_.b)
-        self.assertAlmostEqual(c.extent, c_.extent) 
+        self.assertAlmostEqual(c.extent, c_.extent)
+
 
 class test_Rectangle(unittest.TestCase):
     """Unit tests for relentless.model.Rectangle"""
@@ -224,24 +234,25 @@ class test_Rectangle(unittest.TestCase):
     def test_init(self):
         """Test creation from data."""
         # test valid construction
-        c = relentless.model.Rectangle(Lx=3,Ly=4)
-        numpy.testing.assert_allclose(c.a, numpy.array([3,0]))
-        numpy.testing.assert_allclose(c.b, numpy.array([0,4]))
+        c = relentless.model.Rectangle(Lx=3, Ly=4)
+        numpy.testing.assert_allclose(c.a, numpy.array([3, 0]))
+        numpy.testing.assert_allclose(c.b, numpy.array([0, 4]))
         self.assertAlmostEqual(c.extent, 12)
 
         # test invalid construction
         with self.assertRaises(ValueError):
-            c = relentless.model.Rectangle(Lx=-3,Ly=4)
+            c = relentless.model.Rectangle(Lx=-3, Ly=4)
 
     def test_to_from_json(self):
         """Test to_json and from_json methods."""
-        c = relentless.model.Rectangle(Lx=3,Ly=4)
+        c = relentless.model.Rectangle(Lx=3, Ly=4)
         data = c.to_json()
         c_ = relentless.model.Rectangle.from_json(data)
         self.assertIsInstance(c_, relentless.model.Rectangle)
         numpy.testing.assert_allclose(c.a, c_.a)
         numpy.testing.assert_allclose(c.b, c_.b)
         self.assertAlmostEqual(c.extent, c_.extent)
+
 
 class test_Square(unittest.TestCase):
     """Unit tests for relentless.model.Square"""
@@ -250,8 +261,8 @@ class test_Square(unittest.TestCase):
         """Test creation from data."""
         # test valid construction
         c = relentless.model.Square(L=3)
-        numpy.testing.assert_allclose(c.a, numpy.array([3,0]))
-        numpy.testing.assert_allclose(c.b, numpy.array([0,3]))
+        numpy.testing.assert_allclose(c.a, numpy.array([3, 0]))
+        numpy.testing.assert_allclose(c.b, numpy.array([0, 3]))
         self.assertAlmostEqual(c.extent, 9)
 
         # test invalid construction
@@ -268,5 +279,6 @@ class test_Square(unittest.TestCase):
         numpy.testing.assert_allclose(c.b, c_.b)
         self.assertAlmostEqual(c.extent, c_.extent)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/model/test_variable.py
+++ b/tests/model/test_variable.py
@@ -1,30 +1,30 @@
 """Unit tests for core.variable module."""
-import re
 import unittest
 
 import numpy
 
 import relentless
 
+
 class test_Variable(unittest.TestCase):
     """Unit tests for relentless.model.Variable."""
 
     def test_name(self):
-        x = relentless.model.IndependentVariable(1.0, name='x')
-        self.assertEqual(x.name,'x')
+        x = relentless.model.IndependentVariable(1.0, name="x")
+        self.assertEqual(x.name, "x")
 
-        y = relentless.model.IndependentVariable(2.0, name='y')
-        self.assertEqual(y.name, 'y')
-        self.assertEqual(y.id, x.id+1)
+        y = relentless.model.IndependentVariable(2.0, name="y")
+        self.assertEqual(y.name, "y")
+        self.assertEqual(y.id, x.id + 1)
 
         # auto-create name
         z = relentless.model.IndependentVariable(3.0)
-        self.assertEqual(z.name[:3],'__x')
-        self.assertEqual(z.id, x.id+2)
+        self.assertEqual(z.name[:3], "__x")
+        self.assertEqual(z.id, x.id + 2)
 
         # try to create variable with same name (fail)
         with self.assertRaises(ValueError):
-            relentless.model.IndependentVariable(3.0, name='x')
+            relentless.model.IndependentVariable(3.0, name="x")
 
     def test_operations(self):
         """Test arithmetic operations on variables."""
@@ -33,35 +33,35 @@ class test_Variable(unittest.TestCase):
         w = relentless.model.IndependentVariable(value=4.0)
 
         # addition
-        x = v+w
+        x = v + w
         self.assertAlmostEqual(x.value, 6.0)
-        x = v+2.0
+        x = v + 2.0
         self.assertAlmostEqual(x.value, 4.0)
-        x = 2.0+w
+        x = 2.0 + w
         self.assertAlmostEqual(x.value, 6.0)
 
         # subtraction
-        x = v-w
+        x = v - w
         self.assertAlmostEqual(x.value, -2.0)
-        x = v-1.0
+        x = v - 1.0
         self.assertAlmostEqual(x.value, 1.0)
-        x = 1.0-w
+        x = 1.0 - w
         self.assertAlmostEqual(x.value, -3.0)
 
         # multiplication
-        x = v*w
+        x = v * w
         self.assertAlmostEqual(x.value, 8.0)
-        x = v*1.5
+        x = v * 1.5
         self.assertAlmostEqual(x.value, 3.0)
-        x = 1.5*w
+        x = 1.5 * w
         self.assertAlmostEqual(x.value, 6.0)
 
         # division
-        x = w/v
+        x = w / v
         self.assertAlmostEqual(x.value, 2.0)
-        x = v/2.0
+        x = v / 2.0
         self.assertAlmostEqual(x.value, 1.0)
-        x = 3.0/w
+        x = 3.0 / w
         self.assertAlmostEqual(x.value, 0.75)
 
         # exponentiation
@@ -75,7 +75,8 @@ class test_Variable(unittest.TestCase):
         self.assertAlmostEqual(x.value, -4.0)
 
         # string conversion
-        self.assertEqual(str(x), '-4.0')
+        self.assertEqual(str(x), "-4.0")
+
 
 class test_IndependentVariable(unittest.TestCase):
     """Unit tests for relentless.model.IndependentVariable."""
@@ -90,7 +91,7 @@ class test_IndependentVariable(unittest.TestCase):
         self.assertEqual(v.value, 1)
 
         with self.assertRaises(TypeError):
-            v = relentless.model.IndependentVariable('1.0')
+            v = relentless.model.IndependentVariable("1.0")
 
     def test_value(self):
         """Test value setting."""
@@ -129,6 +130,7 @@ class test_IndependentVariable(unittest.TestCase):
         self.assertAlmostEqual(v.value, 1.0)
         with self.assertRaises(TypeError):
             v /= w
+
 
 class test_DesignVariable(unittest.TestCase):
     """Unit tests for relentless.model.DesignVariable."""
@@ -194,50 +196,50 @@ class test_DesignVariable(unittest.TestCase):
         self.assertEqual(v.low, -1.5)
 
         with self.assertRaises(TypeError):
-            v.value = '4'
+            v.value = "4"
         # test invalid low initialization
         with self.assertRaises(TypeError):
-            v.low = '4'
+            v.low = "4"
         # test invalid high initialization
         with self.assertRaises(TypeError):
-            v.high = '4'
+            v.high = "4"
 
     def test_clamp(self):
         """Test methods for clamping values with bounds."""
         # construction with only low bound
         v = relentless.model.DesignVariable(value=0.0, low=2.0)
         # test below low
-        val,state = v.clamp(1.0)
+        val, state = v.clamp(1.0)
         self.assertAlmostEqual(val, 2.0)
         self.assertEqual(state, v.State.LOW)
         # test at low
-        val,state = v.clamp(2.0)
+        val, state = v.clamp(2.0)
         self.assertAlmostEqual(val, 2.0)
         self.assertEqual(state, v.State.LOW)
         # test above low
-        val,state = v.clamp(3.0)
+        val, state = v.clamp(3.0)
         self.assertAlmostEqual(val, 3.0)
         self.assertEqual(state, v.State.FREE)
 
         # construction with low and high bounds
         v = relentless.model.DesignVariable(value=0.0, low=0.0, high=2.0)
         # test below low
-        val,state = v.clamp(-1.0)
+        val, state = v.clamp(-1.0)
         self.assertAlmostEqual(val, 0.0)
         self.assertEqual(state, v.State.LOW)
         # test between bounds
-        val,state = v.clamp(1.0)
+        val, state = v.clamp(1.0)
         self.assertAlmostEqual(val, 1.0)
         self.assertEqual(state, v.State.FREE)
         # test above high
-        val,state = v.clamp(2.5)
+        val, state = v.clamp(2.5)
         self.assertAlmostEqual(val, 2.0)
         self.assertEqual(state, v.State.HIGH)
 
         # construction with no bounds
         v = relentless.model.DesignVariable(value=0.0)
         # test free variable
-        val,state = v.clamp(1.0)
+        val, state = v.clamp(1.0)
         self.assertAlmostEqual(val, 1.0)
         self.assertEqual(state, v.State.FREE)
 
@@ -260,7 +262,7 @@ class test_DesignVariable(unittest.TestCase):
 
         # test invalid value
         with self.assertRaises(TypeError):
-            v.value = '0'
+            v.value = "0"
 
     def test_bounds(self):
         """Test methods for setting bounds and checking value clamping."""
@@ -290,8 +292,10 @@ class test_DesignVariable(unittest.TestCase):
         with self.assertRaises(ValueError):
             v.high = -1.6
 
+
 class DepVar(relentless.model.DependentVariable):
     """Mock dependent variable to test relentless.model.DependentVariable"""
+
     def __init__(self, *a, **b):
         super().__init__(*a, **b)
 
@@ -308,7 +312,8 @@ class DepVar(relentless.model.DependentVariable):
             else:
                 return -0.5
         else:
-            raise ValueError('Unknown parameter')
+            raise ValueError("Unknown parameter")
+
 
 class test_DependentVariable(unittest.TestCase):
     """Unit tests for relentless.model.DependentVariable"""
@@ -320,7 +325,7 @@ class test_DependentVariable(unittest.TestCase):
         v = relentless.model.DesignVariable(value=3.0)
 
         # test creation with only vardicts
-        w = DepVar({'t':t, 'u':u, 'v':v})
+        w = DepVar({"t": t, "u": u, "v": v})
         self.assertAlmostEqual(w.value, 6.0)
 
         # test creation with only kwvars
@@ -328,15 +333,15 @@ class test_DependentVariable(unittest.TestCase):
         self.assertAlmostEqual(w.value, 6.0)
 
         # test creation with vardicts and kwvars
-        w = DepVar({'t':t, 'u':u}, v=v)
+        w = DepVar({"t": t, "u": u}, v=v)
         self.assertAlmostEqual(w.value, 6.0)
 
         # test creation with repeated attributes
-        w = DepVar({'t':t, 'u':u}, u=v)
+        w = DepVar({"t": t, "u": u}, u=v)
         self.assertAlmostEqual(w.value, 4.0)
 
         # test creation with multiple vardicts
-        w = DepVar({'t':t, 'u':u}, {'v':v})
+        w = DepVar({"t": t, "u": u}, {"v": v})
         self.assertAlmostEqual(w.value, 6.0)
 
         # test creation with scalar attributes
@@ -402,6 +407,7 @@ class test_DependentVariable(unittest.TestCase):
         dq = q.derivative(t)
         self.assertAlmostEqual(dq, 0.5)
 
+
 class test_SameAs(unittest.TestCase):
     """Unit tests for relentless.model.variable.SameAs"""
 
@@ -409,10 +415,10 @@ class test_SameAs(unittest.TestCase):
         """Test creation with data."""
         v = relentless.model.DesignVariable(value=1.0)
         w = relentless.model.variable.SameAs(v)
-        self.assertCountEqual(w.params, ('a',))
+        self.assertCountEqual(w.params, ("a",))
 
-        u = relentless.model.variable.SameAs(w)
-        z = relentless.model.variable.SameAs(2.0)
+        relentless.model.variable.SameAs(w)
+        relentless.model.variable.SameAs(2.0)
 
     def test_value(self):
         """Test compute method."""
@@ -425,10 +431,11 @@ class test_SameAs(unittest.TestCase):
         """Test compute_derivative method."""
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.SameAs(v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=1.0), 1.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=1.0), 1.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=1.0)
+            w.compute_derivative("x", a=1.0)
         self.assertAlmostEqual(w.derivative(v), 1.0)
+
 
 class test_Negation(unittest.TestCase):
     """Unit tests for relentless.model.variable.Negation"""
@@ -437,10 +444,10 @@ class test_Negation(unittest.TestCase):
         """Test creation with data."""
         v = relentless.model.DesignVariable(value=1.0)
         w = relentless.model.variable.Negation(v)
-        self.assertCountEqual(w.params, ('a',))
+        self.assertCountEqual(w.params, ("a",))
 
-        u = relentless.model.variable.Negation(w)
-        z = relentless.model.variable.Negation(2.0)
+        relentless.model.variable.Negation(w)
+        relentless.model.variable.Negation(2.0)
 
     def test_value(self):
         """Test compute method."""
@@ -453,10 +460,11 @@ class test_Negation(unittest.TestCase):
         """Test compute_derivative method."""
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Negation(v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=1.0), -1.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=1.0), -1.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=1.0)
+            w.compute_derivative("x", a=1.0)
         self.assertAlmostEqual(w.derivative(v), -1.0)
+
 
 class test_Sum(unittest.TestCase):
     """Unit tests for relentless.model.variable.Sum"""
@@ -466,12 +474,12 @@ class test_Sum(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Sum(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.variable.Sum(v, w)
-        y = relentless.model.variable.Sum(w, x)
-        w = relentless.model.variable.Sum(u, u)
-        z = relentless.model.variable.Sum(2.0, 1.0)
+        relentless.model.variable.Sum(w, x)
+        relentless.model.variable.Sum(u, u)
+        relentless.model.variable.Sum(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -486,12 +494,13 @@ class test_Sum(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Sum(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=3.0), 1.0)
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=3.0), 1.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=3.0), 1.0)
+        self.assertAlmostEqual(w.compute_derivative("b", a=4.0, b=3.0), 1.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=4.0, b=3.0)
+            w.compute_derivative("x", a=4.0, b=3.0)
         self.assertAlmostEqual(w.derivative(u), 1.0)
         self.assertAlmostEqual(w.derivative(v), 1.0)
+
 
 class test_Difference(unittest.TestCase):
     """Unit tests for relentless.model.variable.Difference"""
@@ -501,12 +510,12 @@ class test_Difference(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Difference(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.variable.Difference(v, w)
-        y = relentless.model.variable.Difference(w, x)
-        w = relentless.model.variable.Difference(u, u)
-        z = relentless.model.variable.Difference(2.0, 1.0)
+        relentless.model.variable.Difference(w, x)
+        relentless.model.variable.Difference(u, u)
+        relentless.model.variable.Difference(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -521,12 +530,13 @@ class test_Difference(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Difference(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=3.0), 1.0)
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=3.0), -1.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=3.0), 1.0)
+        self.assertAlmostEqual(w.compute_derivative("b", a=4.0, b=3.0), -1.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=4.0, b=3.0)
+            w.compute_derivative("x", a=4.0, b=3.0)
         self.assertAlmostEqual(w.derivative(u), 1.0)
         self.assertAlmostEqual(w.derivative(v), -1.0)
+
 
 class test_Product(unittest.TestCase):
     """Unit tests for relentless.model.variable.Power"""
@@ -536,12 +546,12 @@ class test_Product(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Product(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.variable.Product(v, w)
-        y = relentless.model.variable.Product(w, x)
-        w = relentless.model.variable.Product(u, u)
-        z = relentless.model.variable.Product(2.0, 1.0)
+        relentless.model.variable.Product(w, x)
+        relentless.model.variable.Product(u, u)
+        relentless.model.variable.Product(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -556,12 +566,13 @@ class test_Product(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Product(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=3.0), 3.0)
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=3.0), 4.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=3.0), 3.0)
+        self.assertAlmostEqual(w.compute_derivative("b", a=4.0, b=3.0), 4.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=4.0, b=3.0)
+            w.compute_derivative("x", a=4.0, b=3.0)
         self.assertAlmostEqual(w.derivative(u), 2.0)
         self.assertAlmostEqual(w.derivative(v), 1.0)
+
 
 class test_Quotient(unittest.TestCase):
     """Unit tests for relentless.model.variable.Quotient"""
@@ -571,12 +582,12 @@ class test_Quotient(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Quotient(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.variable.Quotient(v, w)
-        y = relentless.model.variable.Quotient(w, x)
-        w = relentless.model.variable.Quotient(u, u)
-        z = relentless.model.variable.Quotient(2.0, 1.0)
+        relentless.model.variable.Quotient(w, x)
+        relentless.model.variable.Quotient(u, u)
+        relentless.model.variable.Quotient(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -592,14 +603,15 @@ class test_Quotient(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Quotient(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=9.0, b=3.0), 1.0/3.0)
-        self.assertTrue(numpy.isnan(w.compute_derivative('a', a=1.0, b=0.0)))
-        self.assertAlmostEqual(w.compute_derivative('b', a=9.0, b=3.0), -1.0)
-        self.assertTrue(numpy.isnan(w.compute_derivative('b', a=1.0, b=0.0)))
+        self.assertAlmostEqual(w.compute_derivative("a", a=9.0, b=3.0), 1.0 / 3.0)
+        self.assertTrue(numpy.isnan(w.compute_derivative("a", a=1.0, b=0.0)))
+        self.assertAlmostEqual(w.compute_derivative("b", a=9.0, b=3.0), -1.0)
+        self.assertTrue(numpy.isnan(w.compute_derivative("b", a=1.0, b=0.0)))
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=4.0, b=3.0)
-        self.assertAlmostEqual(w.derivative(u), 1.0/2.0)
-        self.assertAlmostEqual(w.derivative(v), -1.0/4.0)
+            w.compute_derivative("x", a=4.0, b=3.0)
+        self.assertAlmostEqual(w.derivative(u), 1.0 / 2.0)
+        self.assertAlmostEqual(w.derivative(v), -1.0 / 4.0)
+
 
 class test_Power(unittest.TestCase):
     """Unit tests for relentless.model.variable.Power"""
@@ -609,12 +621,12 @@ class test_Power(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.variable.Power(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.variable.Power(v, w)
-        y = relentless.model.variable.Power(w, x)
-        w = relentless.model.variable.Power(u, u)
-        z = relentless.model.variable.Power(2.0, 1.0)
+        relentless.model.variable.Power(w, x)
+        relentless.model.variable.Power(u, u)
+        relentless.model.variable.Power(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -632,18 +644,23 @@ class test_Power(unittest.TestCase):
         u = relentless.model.DesignVariable(value=2.0)
         v = relentless.model.DesignVariable(value=3.0)
         w = relentless.model.variable.Power(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=0.5), 1./4.)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=0.0), 0.0)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=-0.5), -1./16)
-        self.assertAlmostEqual(w.compute_derivative('a', a=0.0, b=2), 0.0)
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=0.5), 2.0*numpy.log(4.0))
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=0.0), numpy.log(4.0))
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=-0.5), 0.5*numpy.log(4.0))
-        self.assertAlmostEqual(w.compute_derivative('a', a=0.0, b=2), 0.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=0.5), 1.0 / 4.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=0.0), 0.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=-0.5), -1.0 / 16)
+        self.assertAlmostEqual(w.compute_derivative("a", a=0.0, b=2), 0.0)
+        self.assertAlmostEqual(
+            w.compute_derivative("b", a=4.0, b=0.5), 2.0 * numpy.log(4.0)
+        )
+        self.assertAlmostEqual(w.compute_derivative("b", a=4.0, b=0.0), numpy.log(4.0))
+        self.assertAlmostEqual(
+            w.compute_derivative("b", a=4.0, b=-0.5), 0.5 * numpy.log(4.0)
+        )
+        self.assertAlmostEqual(w.compute_derivative("a", a=0.0, b=2), 0.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=4.0, b=3.0)
+            w.compute_derivative("x", a=4.0, b=3.0)
         self.assertAlmostEqual(w.derivative(u), 12)
-        self.assertAlmostEqual(w.derivative(v), 8.0*numpy.log(2.0))
+        self.assertAlmostEqual(w.derivative(v), 8.0 * numpy.log(2.0))
+
 
 class test_ArithmeticMean(unittest.TestCase):
     """Unit tests for relentless.model.ArithmeticMean"""
@@ -653,12 +670,12 @@ class test_ArithmeticMean(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.ArithmeticMean(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.ArithmeticMean(v, w)
-        y = relentless.model.ArithmeticMean(w, x)
-        w = relentless.model.ArithmeticMean(u, u)
-        z = relentless.model.ArithmeticMean(2.0, 1.0)
+        relentless.model.ArithmeticMean(w, x)
+        relentless.model.ArithmeticMean(u, u)
+        relentless.model.ArithmeticMean(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -673,12 +690,13 @@ class test_ArithmeticMean(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=2.0)
         w = relentless.model.ArithmeticMean(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=4.0, b=3.0), 0.5)
-        self.assertAlmostEqual(w.compute_derivative('b', a=4.0, b=3.0), 0.5)
+        self.assertAlmostEqual(w.compute_derivative("a", a=4.0, b=3.0), 0.5)
+        self.assertAlmostEqual(w.compute_derivative("b", a=4.0, b=3.0), 0.5)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=4.0, b=3.0)
+            w.compute_derivative("x", a=4.0, b=3.0)
         self.assertAlmostEqual(w.derivative(u), 0.5)
         self.assertAlmostEqual(w.derivative(v), 0.5)
+
 
 class test_GeometricMean(unittest.TestCase):
     """Unit tests for relentless.model.GeometricMean"""
@@ -688,12 +706,12 @@ class test_GeometricMean(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=16.0)
         w = relentless.model.GeometricMean(u, v)
-        self.assertCountEqual(w.params, ('a','b'))
+        self.assertCountEqual(w.params, ("a", "b"))
 
         x = relentless.model.GeometricMean(v, w)
-        y = relentless.model.GeometricMean(w, x)
-        w = relentless.model.GeometricMean(u, u)
-        z = relentless.model.GeometricMean(2.0, 1.0)
+        relentless.model.GeometricMean(w, x)
+        relentless.model.GeometricMean(u, u)
+        relentless.model.GeometricMean(2.0, 1.0)
 
     def test_value(self):
         """Test compute method."""
@@ -708,16 +726,17 @@ class test_GeometricMean(unittest.TestCase):
         u = relentless.model.DesignVariable(value=1.0)
         v = relentless.model.DesignVariable(value=16.0)
         w = relentless.model.GeometricMean(u, v)
-        self.assertAlmostEqual(w.compute_derivative('a', a=9.0, b=4.0), 0.5*2.0/3.0)
-        self.assertTrue(numpy.isnan(w.compute_derivative('a', a=0.0, b=4.0)))
-        self.assertAlmostEqual(w.compute_derivative('a', a=9.0, b=0.0),0.0)
-        self.assertAlmostEqual(w.compute_derivative('b', a=9.0, b=4.0), 0.5*3.0/2.0)
-        self.assertTrue(numpy.isnan(w.compute_derivative('b', a=9.0, b=0.0)))
-        self.assertAlmostEqual(w.compute_derivative('b', a=0.0, b=4.0),0.0)
+        self.assertAlmostEqual(w.compute_derivative("a", a=9.0, b=4.0), 0.5 * 2.0 / 3.0)
+        self.assertTrue(numpy.isnan(w.compute_derivative("a", a=0.0, b=4.0)))
+        self.assertAlmostEqual(w.compute_derivative("a", a=9.0, b=0.0), 0.0)
+        self.assertAlmostEqual(w.compute_derivative("b", a=9.0, b=4.0), 0.5 * 3.0 / 2.0)
+        self.assertTrue(numpy.isnan(w.compute_derivative("b", a=9.0, b=0.0)))
+        self.assertAlmostEqual(w.compute_derivative("b", a=0.0, b=4.0), 0.0)
         with self.assertRaises(ValueError):
-            w.compute_derivative('x', a=9.0, b=4.0)
-        self.assertAlmostEqual(w.derivative(u), 0.5*4.0/1.0)
-        self.assertAlmostEqual(w.derivative(v), 0.5*1.0/4.0)
+            w.compute_derivative("x", a=9.0, b=4.0)
+        self.assertAlmostEqual(w.derivative(u), 0.5 * 4.0 / 1.0)
+        self.assertAlmostEqual(w.derivative(v), 0.5 * 1.0 / 4.0)
+
 
 class test_VariableGraph(unittest.TestCase):
     def setUp(self):
@@ -815,12 +834,12 @@ class test_VariableGraph(unittest.TestCase):
     def test_evaluate_derivative(self):
         g = relentless.model.variable.graph
         x = relentless.model.IndependentVariable(1.0)
-        y = 2*x + 2.0
-        z = 3*y
+        y = 2 * x + 2.0
+        z = 3 * y
         w = relentless.model.IndependentVariable(2.0)
         self.assertEqual(g.evaluate_derivative(x, x), 1.0)
         self.assertEqual(g.evaluate_derivative(y, x), 2.0)
-        self.assertEqual(g.evaluate_derivative(x ,w), 0.0)
+        self.assertEqual(g.evaluate_derivative(x, w), 0.0)
         self.assertEqual(g.evaluate_derivative(z, y), 3.0)
         self.assertEqual(g.evaluate_derivative(z, x), 6.0)
 
@@ -837,13 +856,16 @@ class test_VariableGraph(unittest.TestCase):
         self.assertCountEqual(result, (x,))
 
         result = g.check_variables_and_types((x, y), relentless.model.Variable)
-        self.assertCountEqual(result, (x,y))
+        self.assertCountEqual(result, (x, y))
 
         with self.assertRaises(TypeError):
             g.check_variables_and_types(x, relentless.model.DesignVariable)
 
-        result = g.check_variables_and_types(x, (relentless.model.DesignVariable, relentless.model.IndependentVariable))
+        result = g.check_variables_and_types(
+            x, (relentless.model.DesignVariable, relentless.model.IndependentVariable)
+        )
         self.assertCountEqual(result, (x,))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/optimize/test_criteria.py
+++ b/tests/optimize/test_criteria.py
@@ -5,6 +5,7 @@ import relentless
 
 from .test_objective import QuadraticObjective
 
+
 class test_Tolerance(unittest.TestCase):
     """Unit tests for relentless.optimize.Tolerance"""
 
@@ -56,6 +57,7 @@ class test_Tolerance(unittest.TestCase):
             t = relentless.optimize.Tolerance(absolute=0.1, relative=1.1)
             t.isclose(x.value, 2.5)
 
+
 class test_GradientTest(unittest.TestCase):
     """Unit tests for relentless.optimize.GradientTest"""
 
@@ -99,13 +101,12 @@ class test_GradientTest(unittest.TestCase):
         x.low = 2.0
         self.assertTrue(t.converged(result=q.compute(x)))
 
+
 class test_ValueTest(unittest.TestCase):
     """Unit tests for relentless.optimize.ValueTest"""
 
     def test_init(self):
         """Test creation with data."""
-        x = relentless.model.DesignVariable(value=3.0)
-
         # test default values
         t = relentless.optimize.ValueTest(value=2.5)
         self.assertAlmostEqual(t.absolute, 1e-8)
@@ -141,6 +142,7 @@ class test_ValueTest(unittest.TestCase):
         x.value = 3.9999999999
         self.assertTrue(t.converged(result=q.compute(x)))
 
+
 class AnyTest(unittest.TestCase):
     """Unit tests for relentless.optimize.AnyTest"""
 
@@ -151,8 +153,8 @@ class AnyTest(unittest.TestCase):
         t2 = relentless.optimize.ValueTest(value=2.0)
         t3 = relentless.optimize.ValueTest(value=1.0)
 
-        t = relentless.optimize.AnyTest(t1,t2,t3)
-        self.assertCountEqual(t.tests, (t1,t2,t3))
+        t = relentless.optimize.AnyTest(t1, t2, t3)
+        self.assertCountEqual(t.tests, (t1, t2, t3))
 
     def test_converged(self):
         """Test converged method."""
@@ -162,7 +164,7 @@ class AnyTest(unittest.TestCase):
         t2 = relentless.optimize.ValueTest(value=1.0)
         t3 = relentless.optimize.ValueTest(value=0.0)
 
-        t = relentless.optimize.AnyTest(t1,t2,t3)
+        t = relentless.optimize.AnyTest(t1, t2, t3)
         self.assertFalse(t.converged(result=q.compute(x)))
 
         x.value = 2.00000001
@@ -170,6 +172,7 @@ class AnyTest(unittest.TestCase):
 
         x.value = 1.00000001
         self.assertTrue(t.converged(result=q.compute(x)))
+
 
 class AllTest(unittest.TestCase):
     """Unit tests for relentless.optimize.AllTest"""
@@ -181,8 +184,8 @@ class AllTest(unittest.TestCase):
         t2 = relentless.optimize.ValueTest(value=1.0)
         t3 = relentless.optimize.ValueTest(value=0.0)
 
-        t = relentless.optimize.AllTest(t1,t2,t3)
-        self.assertCountEqual(t.tests, (t1,t2,t3))
+        t = relentless.optimize.AllTest(t1, t2, t3)
+        self.assertCountEqual(t.tests, (t1, t2, t3))
 
     def test_converged(self):
         """Test converged method."""
@@ -192,7 +195,7 @@ class AllTest(unittest.TestCase):
         t2 = relentless.optimize.ValueTest(value=1.0)
         t3 = relentless.optimize.ValueTest(value=0.0)
 
-        t = relentless.optimize.AllTest(t1,t2,t3)
+        t = relentless.optimize.AllTest(t1, t2, t3)
         self.assertFalse(t.converged(result=q.compute(x)))
 
         x.value = 1.999999999
@@ -201,6 +204,7 @@ class AllTest(unittest.TestCase):
         t2.value = 0.0
         x.value = 0.999999999
         self.assertTrue(t.converged(result=q.compute(x)))
+
 
 class OrTest(unittest.TestCase):
     """Unit tests for relentless.optimize.OrTest"""
@@ -211,8 +215,8 @@ class OrTest(unittest.TestCase):
         t1 = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
         t2 = relentless.optimize.ValueTest(value=1.0)
 
-        t = relentless.optimize.OrTest(t1,t2)
-        self.assertCountEqual(t.tests, (t1,t2))
+        t = relentless.optimize.OrTest(t1, t2)
+        self.assertCountEqual(t.tests, (t1, t2))
 
     def test_converged(self):
         """Test converged method."""
@@ -221,7 +225,7 @@ class OrTest(unittest.TestCase):
         t1 = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
         t2 = relentless.optimize.ValueTest(value=1.0)
 
-        t = relentless.optimize.OrTest(t1,t2)
+        t = relentless.optimize.OrTest(t1, t2)
         self.assertFalse(t.converged(result=q.compute(x)))
 
         x.value = 1.9999999999
@@ -229,6 +233,7 @@ class OrTest(unittest.TestCase):
 
         x.value = 0.9999999999
         self.assertTrue(t.converged(result=q.compute(x)))
+
 
 class AndTest(unittest.TestCase):
     """Unit tests for relentless.optimize.AndTest"""
@@ -239,8 +244,8 @@ class AndTest(unittest.TestCase):
         t1 = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
         t2 = relentless.optimize.ValueTest(value=1.0)
 
-        t = relentless.optimize.AndTest(t1,t2)
-        self.assertCountEqual(t.tests, (t1,t2))
+        t = relentless.optimize.AndTest(t1, t2)
+        self.assertCountEqual(t.tests, (t1, t2))
 
     def test_converged(self):
         """Test converged method."""
@@ -249,7 +254,7 @@ class AndTest(unittest.TestCase):
         t1 = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
         t2 = relentless.optimize.ValueTest(value=1.0)
 
-        t = relentless.optimize.AndTest(t1,t2)
+        t = relentless.optimize.AndTest(t1, t2)
         self.assertFalse(t.converged(result=q.compute(x)))
 
         x.value = 1.999999999
@@ -259,5 +264,6 @@ class AndTest(unittest.TestCase):
         x.value = 0.999999999
         self.assertTrue(t.converged(result=q.compute(x)))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/optimize/test_method.py
+++ b/tests/optimize/test_method.py
@@ -7,6 +7,7 @@ import relentless
 
 from .test_objective import QuadraticObjective
 
+
 class test_LineSearch(unittest.TestCase):
     """Unit tests for relentless.optimize.LineSearch"""
 
@@ -21,22 +22,19 @@ class test_LineSearch(unittest.TestCase):
 
     def test_init(self):
         """Test creation with data."""
-        x = relentless.model.DesignVariable(value=3.0)
-        q = QuadraticObjective(x=x)
-
-        l = relentless.optimize.LineSearch(tolerance=1e-8, max_iter=1000)
-        self.assertAlmostEqual(l.tolerance, 1e-8)
-        self.assertEqual(l.max_iter, 1000)
+        ls = relentless.optimize.LineSearch(tolerance=1e-8, max_iter=1000)
+        self.assertAlmostEqual(ls.tolerance, 1e-8)
+        self.assertEqual(ls.max_iter, 1000)
 
         # test invalid parameters
         with self.assertRaises(ValueError):
-            l.max_iter = 0
+            ls.max_iter = 0
         with self.assertRaises(TypeError):
-            l.max_iter = 100.0
+            ls.max_iter = 100.0
 
     def test_find(self):
         """Test find method."""
-        l = relentless.optimize.LineSearch(tolerance=1e-8, max_iter=1000)
+        ls = relentless.optimize.LineSearch(tolerance=1e-8, max_iter=1000)
         x = relentless.model.DesignVariable(value=-3.0)
         q = QuadraticObjective(x=x)
         res_1 = q.compute(x)
@@ -45,56 +43,57 @@ class test_LineSearch(unittest.TestCase):
         x.value = 3.0
         res_2 = q.compute(x)
         x.value = -3.0
-        res_new = l.find(objective=q, start=res_1, end=res_2)
+        res_new = ls.find(objective=q, start=res_1, end=res_2)
         self.assertAlmostEqual(res_new.variables[x], 1.0)
         self.assertAlmostEqual(res_new.gradient[x], 0.0)
         self.assertEqual(q.x.value, -3.0)
 
         # use directory for output, check result of first iteration
         d = self.directory
-        res_new = l.find(q, res_1, res_2, d)
+        res_new = ls.find(q, res_1, res_2, d)
         self.assertAlmostEqual(res_new.variables[x], 1.0)
         self.assertAlmostEqual(res_new.gradient[x], 0.0)
         self.assertEqual(q.x.value, -3.0)
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0')))
-        self.assertTrue(os.path.isfile(os.path.join(d.path,'0','x.log')))
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0")))
+        self.assertTrue(os.path.isfile(os.path.join(d.path, "0", "x.log")))
 
         # not bracketing the minimum (accept "maximum" step size)
         x.value = -1.0
         res_3 = q.compute(x)
         x.value = -3.0
-        res_new = l.find(objective=q, start=res_1, end=res_3)
+        res_new = ls.find(objective=q, start=res_1, end=res_3)
         self.assertAlmostEqual(res_new.variables[x], -1.0)
         self.assertAlmostEqual(res_new.gradient[x], -4.0)
         self.assertEqual(q.x.value, -3.0)
 
         # bound does not include current objective value
-        res_new = l.find(objective=q, start=res_3, end=res_2)
+        res_new = ls.find(objective=q, start=res_3, end=res_2)
         self.assertAlmostEqual(res_new.variables[x], 1.0)
         self.assertAlmostEqual(res_new.gradient[x], 0.0)
         self.assertEqual(q.x.value, -3.0)
 
         # invalid search interval (not descent direction)
         with self.assertRaises(ValueError):
-            res_new = l.find(objective=q, start=res_3, end=res_1)
+            res_new = ls.find(objective=q, start=res_3, end=res_1)
 
         # invalid search interval (0 distance from start to end)
         with self.assertRaises(ValueError):
-            res_new = l.find(objective=q, start=res_3, end=res_3)
+            res_new = ls.find(objective=q, start=res_3, end=res_3)
 
         # invalid tolerance
         with self.assertRaises(ValueError):
-            l.tolerance = -1e-9
-            l.find(objective=q, start=res_1, end=res_3)
+            ls.tolerance = -1e-9
+            ls.find(objective=q, start=res_1, end=res_3)
         with self.assertRaises(ValueError):
-            l.tolerance = 1.1
-            l.find(objective=q, start=res_1, end=res_3)
+            ls.tolerance = 1.1
+            ls.find(objective=q, start=res_1, end=res_3)
 
     def tearDown(self):
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp
         del self.directory
+
 
 class test_SteepestDescent(unittest.TestCase):
     """Unit tests for relentless.optimize.SteepestDescent"""
@@ -130,21 +129,21 @@ class test_SteepestDescent(unittest.TestCase):
         self.assertIsNone(o.line_search)
 
         # test dictionary of scaling parameters
-        o.scale = {x:0.3}
+        o.scale = {x: 0.3}
         self.assertEqual(o.stop, t)
         self.assertEqual(o.max_iter, 1000)
         self.assertAlmostEqual(o.step_size, 0.25)
-        self.assertEqual(o.scale, {x:0.3})
+        self.assertEqual(o.scale, {x: 0.3})
         self.assertIsNone(o.line_search)
 
         # test using line search
-        l = relentless.optimize.LineSearch(tolerance=1e-9, max_iter=100)
-        o.line_search = l
+        ls = relentless.optimize.LineSearch(tolerance=1e-9, max_iter=100)
+        o.line_search = ls
         self.assertEqual(o.stop, t)
         self.assertEqual(o.max_iter, 1000)
         self.assertAlmostEqual(o.step_size, 0.25)
-        self.assertEqual(o.scale, {x:0.3})
-        self.assertEqual(o.line_search, l)
+        self.assertEqual(o.scale, {x: 0.3})
+        self.assertEqual(o.line_search, ls)
 
         # test invalid parameters
         with self.assertRaises(TypeError):
@@ -158,7 +157,7 @@ class test_SteepestDescent(unittest.TestCase):
         with self.assertRaises(ValueError):
             o.scale = -0.5
         with self.assertRaises(ValueError):
-            o.scale = {x:-0.5}
+            o.scale = {x: -0.5}
         with self.assertRaises(TypeError):
             o.line_search = q
 
@@ -186,7 +185,7 @@ class test_SteepestDescent(unittest.TestCase):
 
         # test with nontrivial dictionary of scaling parameters
         x.value = -35
-        o.scale = {x:1.5}
+        o.scale = {x: 1.5}
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
@@ -207,26 +206,26 @@ class test_SteepestDescent(unittest.TestCase):
         o.optimize(q, x, d)
 
         # 0/ holds the initial value
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0')))
-        self.assertTrue(os.path.isfile(os.path.join(d.path,'0','x.log')))
-        with open(d.directory('0').file('x.log')) as f:
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0")))
+        self.assertTrue(os.path.isfile(os.path.join(d.path, "0", "x.log")))
+        with open(d.directory("0").file("x.log")) as f:
             self.assertAlmostEqual(float(f.readline()), 1.5)
 
         # 0/.next should be empty because it has been accepted to 1/
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0','.next')))
-        self.assertEqual(len(os.listdir(d.directory('0/.next').path)), 0)
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0", ".next")))
+        self.assertEqual(len(os.listdir(d.directory("0/.next").path)), 0)
 
         # 1/ holds the next output
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'1')))
-        self.assertTrue(os.path.isfile(os.path.join(d.path,'1','x.log')))
-        with open(d.directory('1').file('x.log')) as f:
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "1")))
+        self.assertTrue(os.path.isfile(os.path.join(d.path, "1", "x.log")))
+        with open(d.directory("1").file("x.log")) as f:
             self.assertAlmostEqual(float(f.readline()), 1.25)
 
     def test_directory_line_search(self):
         x = relentless.model.DesignVariable(value=0.5)
         q = QuadraticObjective(x=x)
         t = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
-        o = relentless.optimize.SteepestDescent(stop=t, max_iter=1, step_size=2.)
+        o = relentless.optimize.SteepestDescent(stop=t, max_iter=1, step_size=2.0)
         o.line_search = relentless.optimize.LineSearch(tolerance=1e-5, max_iter=1)
 
         # optimize with output
@@ -234,27 +233,27 @@ class test_SteepestDescent(unittest.TestCase):
         o.optimize(q, x, d)
 
         # 0/ holds the initial value
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0')))
-        with open(d.directory('0').file('x.log')) as f:
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0")))
+        with open(d.directory("0").file("x.log")) as f:
             self.assertAlmostEqual(float(f.readline()), 0.5)
 
         # 0/.next/ holds the overshoot
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0','.next')))
-        with open(d.directory('0/.next').file('x.log')) as f:
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0", ".next")))
+        with open(d.directory("0/.next").file("x.log")) as f:
             self.assertAlmostEqual(float(f.readline()), 2.5)
 
         # 0/.line/ should exist, but it should have only one entry (0/) because
         # line search is exact for this function
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0','.line')))
-        self.assertEqual(len(os.listdir(d.directory('0/.line').path)), 1)
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0", ".line")))
+        self.assertEqual(len(os.listdir(d.directory("0/.line").path)), 1)
 
         # .line/0 should be empty because it has been accepted to 1/
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'0','.line','0')))
-        self.assertEqual(len(os.listdir(d.directory('0/.line/0').path)), 0)
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "0", ".line", "0")))
+        self.assertEqual(len(os.listdir(d.directory("0/.line/0").path)), 0)
 
         # 1/ holds the solved value
-        self.assertTrue(os.path.isdir(os.path.join(d.path,'1')))
-        with open(d.directory('1').file('x.log')) as f:
+        self.assertTrue(os.path.isdir(os.path.join(d.path, "1")))
+        with open(d.directory("1").file("x.log")) as f:
             self.assertAlmostEqual(float(f.readline()), 1.0)
 
     def tearDown(self):
@@ -262,6 +261,7 @@ class test_SteepestDescent(unittest.TestCase):
             self._tmp.cleanup()
             del self._tmp
         del self.directory
+
 
 class test_FixedStepDescent(unittest.TestCase):
     """Unit tests for relentless.optimize.FixedStepDescent"""
@@ -296,7 +296,7 @@ class test_FixedStepDescent(unittest.TestCase):
 
         # test with nontrivial dictionary of scaling parameters
         x.value = -35
-        o.scale = {x:1.5}
+        o.scale = {x: 1.5}
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
@@ -306,5 +306,6 @@ class test_FixedStepDescent(unittest.TestCase):
         self.assertTrue(o.optimize(objective=q, design_variables=x))
         self.assertAlmostEqual(x.value, 1.0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -1,5 +1,4 @@
 """Unit tests for objective module."""
-import json
 import tempfile
 import unittest
 
@@ -8,6 +7,7 @@ import scipy.integrate
 
 import relentless
 
+
 class QuadraticObjective(relentless.optimize.ObjectiveFunction):
     """Mock objective function used to test relentless.optimize.ObjectiveFunction"""
 
@@ -15,22 +15,27 @@ class QuadraticObjective(relentless.optimize.ObjectiveFunction):
         self.x = x
 
     def compute(self, variables, directory=None):
-        val = (self.x.value-1)**2
-        variables = relentless.model.variable.graph.check_variables_and_types(variables, relentless.model.Variable)
+        val = (self.x.value - 1) ** 2
+        variables = relentless.model.variable.graph.check_variables_and_types(
+            variables, relentless.model.Variable
+        )
         grad = {}
         for x in variables:
             if x is self.x:
-                grad[x] = 2*(self.x.value-1)
+                grad[x] = 2 * (self.x.value - 1)
             else:
-                grad[x] = 0.
+                grad[x] = 0.0
 
         # optionally write output
         if relentless.mpi.world.rank_is_root and directory is not None:
-            with open(directory.file('x.log'),'w') as f:
-                f.write(str(self.x.value) + '\n')
+            with open(directory.file("x.log"), "w") as f:
+                f.write(str(self.x.value) + "\n")
         relentless.mpi.world.barrier()
 
-        return relentless.optimize.ObjectiveFunctionResult(variables, val, grad, directory)
+        return relentless.optimize.ObjectiveFunctionResult(
+            variables, val, grad, directory
+        )
+
 
 class test_ObjectiveFunction(unittest.TestCase):
     """Unit tests for relentless.optimize.ObjectiveFunction"""
@@ -55,27 +60,30 @@ class test_ObjectiveFunction(unittest.TestCase):
         self.assertAlmostEqual(res.variables[x], 4.0)
 
         x.value = 3.0
-        self.assertAlmostEqual(res.variables[x], 4.0) # maintains the value at time of construction
+        self.assertAlmostEqual(
+            res.variables[x], 4.0
+        )  # maintains the value at time of construction
 
         # test "invalid" variable
         with self.assertRaises(KeyError):
-            m = res.gradient[relentless.model.variable.SameAs(x)]
+            res.gradient[relentless.model.variable.SameAs(x)]
 
     def test_directory(self):
         x = relentless.model.DesignVariable(value=1.0)
         q = QuadraticObjective(x=x)
         d = self.directory
-        res = q.compute(x, d)
+        q.compute(x, d)
 
-        with open(d.file('x.log')) as f:
+        with open(d.file("x.log")) as f:
             x = float(f.readline())
-        self.assertAlmostEqual(x,1.0)
+        self.assertAlmostEqual(x, 1.0)
 
     def tearDown(self):
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp
         del self.directory
+
 
 class test_RelativeEntropy(unittest.TestCase):
     """Unit tests for relentless.optimize.RelativeEntropy"""
@@ -89,63 +97,75 @@ class test_RelativeEntropy(unittest.TestCase):
         directory = relentless.mpi.world.bcast(directory)
         self.directory = relentless.data.Directory(directory)
 
-        lj = relentless.model.potential.LennardJones(types=('1',))
+        lj = relentless.model.potential.LennardJones(types=("1",))
         self.epsilon = relentless.model.DesignVariable(value=1.0)
         self.sigma = relentless.model.DesignVariable(value=0.9)
-        lj.coeff['1','1'].update({'epsilon':self.epsilon, 'sigma':self.sigma, 'rmax':2.7})
+        lj.coeff["1", "1"].update(
+            {"epsilon": self.epsilon, "sigma": self.sigma, "rmax": 2.7}
+        )
         self.potentials = relentless.simulate.Potentials(pair_potentials=lj)
         self.potentials.pair.rmax = 3.6
         self.potentials.pair.num = 1000
-        self.potentials.pair.fmax = 100.
+        self.potentials.pair.fmax = 100.0
         self.potentials.pair.neighbor_buffer = 0.4
 
-        v_obj = relentless.model.Cube(L=10.)
-        self.target = relentless.model.Ensemble(T=1.5, V=v_obj, N={'1':50})
-        rs = numpy.arange(0.05,5.0,0.1)
-        gs = numpy.exp(-lj.energy(('1','1'),rs))
-        self.target.rdf['1','1'] = relentless.model.RDF(r=rs, g=gs)
+        v_obj = relentless.model.Cube(L=10.0)
+        self.target = relentless.model.Ensemble(T=1.5, V=v_obj, N={"1": 50})
+        rs = numpy.arange(0.05, 5.0, 0.1)
+        gs = numpy.exp(-lj.energy(("1", "1"), rs))
+        self.target.rdf["1", "1"] = relentless.model.RDF(r=rs, g=gs)
 
-        init = relentless.simulate.InitializeRandomly(seed=42, N=self.target.N, V=self.target.V, T=self.target.T)
+        init = relentless.simulate.InitializeRandomly(
+            seed=42, N=self.target.N, V=self.target.V, T=self.target.T
+        )
         self.thermo = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1)
-        md = relentless.simulate.RunMolecularDynamics(steps=100, timestep=1e-3, analyzers=self.thermo)
+            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+        )
+        md = relentless.simulate.RunMolecularDynamics(
+            steps=100, timestep=1e-3, analyzers=self.thermo
+        )
         self.simulation = relentless.simulate.dilute.Dilute(init, operations=md)
 
     def relent_grad(self, var, ext=False):
-        rs = numpy.linspace(0,3.6,1001)[1:]
-        r6_inv = numpy.power(0.9/rs, 6)
-        gs = numpy.exp(-(1/1.5)*4.*1.0*(r6_inv**2 - r6_inv))
-        sim_rdf = relentless.math.Interpolator(rs,gs)
+        rs = numpy.linspace(0, 3.6, 1001)[1:]
+        r6_inv = numpy.power(0.9 / rs, 6)
+        gs = numpy.exp(-(1 / 1.5) * 4.0 * 1.0 * (r6_inv**2 - r6_inv))
+        sim_rdf = relentless.math.Interpolator(rs, gs)
 
-        rs = numpy.arange(0.05,5.0,0.1)
-        r6_inv = numpy.power(0.9/rs, 6)
-        gs = numpy.exp(-4.*1.0*(r6_inv**2 - r6_inv))
-        tgt_rdf = relentless.math.Interpolator(rs,gs)
+        rs = numpy.arange(0.05, 5.0, 0.1)
+        r6_inv = numpy.power(0.9 / rs, 6)
+        gs = numpy.exp(-4.0 * 1.0 * (r6_inv**2 - r6_inv))
+        tgt_rdf = relentless.math.Interpolator(rs, gs)
 
-        rs = numpy.linspace(0,3.6,1001)[1:]
-        r6_inv = numpy.power(0.9/rs, 6)
+        rs = numpy.linspace(0, 3.6, 1001)[1:]
+        r6_inv = numpy.power(0.9 / rs, 6)
         if var is self.epsilon:
-            dus = 4*(r6_inv**2 - r6_inv)
+            dus = 4 * (r6_inv**2 - r6_inv)
         elif var is self.sigma:
-            dus = (48.*1.0/0.9)*(r6_inv**2 - 0.5*r6_inv)
-        dudvar = relentless.math.Interpolator(rs,dus)
+            dus = (48.0 * 1.0 / 0.9) * (r6_inv**2 - 0.5 * r6_inv)
+        dudvar = relentless.math.Interpolator(rs, dus)
 
         if ext:
-            norm_factor = 1.
+            norm_factor = 1.0
         else:
-            norm_factor = 1000.
-        sim_factor = 50**2*(1/1.5)/(1000*norm_factor)
-        tgt_factor = 50**2*(1/1.5)/(1000*norm_factor)
+            norm_factor = 1000.0
+        sim_factor = 50**2 * (1 / 1.5) / (1000 * norm_factor)
+        tgt_factor = 50**2 * (1 / 1.5) / (1000 * norm_factor)
 
         r = numpy.linspace(0.05, 3.55, 1001)
-        y = -2*numpy.pi*r**2*(sim_factor*sim_rdf(r)-tgt_factor*tgt_rdf(r))*dudvar(r)
+        y = (
+            -2
+            * numpy.pi
+            * r**2
+            * (sim_factor * sim_rdf(r) - tgt_factor * tgt_rdf(r))
+            * dudvar(r)
+        )
         return scipy.integrate.trapz(x=r, y=y)
 
     def test_init(self):
-        relent = relentless.optimize.RelativeEntropy(self.target,
-                                                     self.simulation,
-                                                     self.potentials,
-                                                     self.thermo)
+        relent = relentless.optimize.RelativeEntropy(
+            self.target, self.simulation, self.potentials, self.thermo
+        )
         self.assertEqual(relent.target, self.target)
         self.assertEqual(relent.simulation, self.simulation)
         self.assertEqual(relent.potentials, self.potentials)
@@ -153,14 +173,13 @@ class test_RelativeEntropy(unittest.TestCase):
 
         # test invalid target ensemble
         with self.assertRaises(ValueError):
-            relent.target = relentless.model.Ensemble(T=1.5, P=1, N={'1':50})
+            relent.target = relentless.model.Ensemble(T=1.5, P=1, N={"1": 50})
 
     def test_compute(self):
         """Test compute and compute_gradient methods"""
-        relent = relentless.optimize.RelativeEntropy(self.target,
-                                                     self.simulation,
-                                                     self.potentials,
-                                                     self.thermo)
+        relent = relentless.optimize.RelativeEntropy(
+            self.target, self.simulation, self.potentials, self.thermo
+        )
 
         res = relent.compute((self.epsilon, self.sigma))
 
@@ -178,13 +197,11 @@ class test_RelativeEntropy(unittest.TestCase):
         numpy.testing.assert_allclose(res_grad[self.sigma], grad_sig, atol=1e-4)
 
         # test extensive option
-        relent = relentless.optimize.RelativeEntropy(self.target,
-                                                     self.simulation,
-                                                     self.potentials,
-                                                     self.thermo,
-                                                     extensive=True)
+        relent = relentless.optimize.RelativeEntropy(
+            self.target, self.simulation, self.potentials, self.thermo, extensive=True
+        )
 
-        res = relent.compute((self.epsilon,self.sigma))
+        res = relent.compute((self.epsilon, self.sigma))
 
         sim = self.simulation.run(self.potentials, self.directory)
         ensemble = sim[self.thermo].ensemble
@@ -200,32 +217,42 @@ class test_RelativeEntropy(unittest.TestCase):
         numpy.testing.assert_allclose(res_grad[self.sigma], grad_sig, atol=1e-1)
 
     def test_directory(self):
-        relent = relentless.optimize.RelativeEntropy(self.target,
-                                                     self.simulation,
-                                                     self.potentials,
-                                                     self.thermo)
+        relent = relentless.optimize.RelativeEntropy(
+            self.target, self.simulation, self.potentials, self.thermo
+        )
 
-        res = relent.compute((self.epsilon,self.sigma), self.directory)
+        res = relent.compute((self.epsilon, self.sigma), self.directory)
 
-        x = relentless.mpi.world.load_json(self.directory.file('pair_potential.0.json'))
-        self.assertAlmostEqual(x["('1', '1')"]['epsilon'], self.epsilon.value)
-        self.assertAlmostEqual(x["('1', '1')"]['sigma'], self.sigma.value)
-        self.assertAlmostEqual(x["('1', '1')"]['rmax'], 2.7)
+        x = relentless.mpi.world.load_json(self.directory.file("pair_potential.0.json"))
+        self.assertAlmostEqual(x["('1', '1')"]["epsilon"], self.epsilon.value)
+        self.assertAlmostEqual(x["('1', '1')"]["sigma"], self.sigma.value)
+        self.assertAlmostEqual(x["('1', '1')"]["rmax"], 2.7)
 
-        z = relentless.mpi.world.load_json(self.directory.file('result.json'))
-        self.assertDictEqual(z['variables'], {self.epsilon.name: self.epsilon.value, self.sigma.name: self.sigma.value})
-        self.assertIsNone(z['value'])
-        self.assertDictEqual(z['gradient'], {self.epsilon.name: res.gradient[self.epsilon], self.sigma.name: res.gradient[self.sigma]})
-        self.assertEqual(z['directory'], self.directory.path)
+        z = relentless.mpi.world.load_json(self.directory.file("result.json"))
+        self.assertDictEqual(
+            z["variables"],
+            {self.epsilon.name: self.epsilon.value, self.sigma.name: self.sigma.value},
+        )
+        self.assertIsNone(z["value"])
+        self.assertDictEqual(
+            z["gradient"],
+            {
+                self.epsilon.name: res.gradient[self.epsilon],
+                self.sigma.name: res.gradient[self.sigma],
+            },
+        )
+        self.assertEqual(z["directory"], self.directory.path)
 
-        y = relentless.mpi.world.load_json(self.directory.file('ensemble.json'))
+        y = relentless.mpi.world.load_json(self.directory.file("ensemble.json"))
         sim = self.simulation.run(self.potentials, self.directory)
         sim_ens = sim[self.thermo].ensemble
-        self.assertAlmostEqual(y['T'], 1.5)
-        self.assertAlmostEqual(y['N'], {'1':50})
-        self.assertAlmostEqual(y['V']['data'], {'L':10.})
-        self.assertAlmostEqual(y['P'], sim_ens.P)
-        numpy.testing.assert_allclose(y['rdf']["('1', '1')"], sim_ens.rdf['1','1'].table.tolist())
+        self.assertAlmostEqual(y["T"], 1.5)
+        self.assertAlmostEqual(y["N"], {"1": 50})
+        self.assertAlmostEqual(y["V"]["data"], {"L": 10.0})
+        self.assertAlmostEqual(y["P"], sim_ens.P)
+        numpy.testing.assert_allclose(
+            y["rdf"]["('1', '1')"], sim_ens.rdf["1", "1"].table.tolist()
+        )
 
     def tearDown(self):
         if relentless.mpi.world.rank_is_root:
@@ -233,5 +260,6 @@ class test_RelativeEntropy(unittest.TestCase):
             del self._tmp
         del self.directory
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -3,8 +3,8 @@ import tempfile
 import unittest
 
 import relentless
-
 from tests.model.potential.test_pair import LinPot
+
 
 class test_Dilute(unittest.TestCase):
     """Unit tests for relentless.simulate.Dilute"""
@@ -21,18 +21,19 @@ class test_Dilute(unittest.TestCase):
     def test_run(self):
         """Test run method."""
         init = relentless.simulate.InitializeRandomly(
-                seed=42,
-                N={'A':2,'B':3},
-                V=relentless.model.Cube(L=2.0),
-                T=1.0)
+            seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
+        )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1)
-        md = relentless.simulate.RunMolecularDynamics(steps=100, timestep=1e-3, analyzers=analyzer)
+            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+        )
+        md = relentless.simulate.RunMolecularDynamics(
+            steps=100, timestep=1e-3, analyzers=analyzer
+        )
 
         # set up potentials
-        pot = LinPot(('A','B'),params=('m',))
+        pot = LinPot(("A", "B"), params=("m",))
         for pair in pot.coeff:
-            pot.coeff[pair]['m'] = 2.0
+            pot.coeff[pair]["m"] = 2.0
         pots = relentless.simulate.Potentials()
         pots.pair.potentials.append(pot)
         pots.pair.rmax = 3.0
@@ -46,18 +47,21 @@ class test_Dilute(unittest.TestCase):
     def test_inf_potential(self):
         """Test potential with infinite value."""
         init = relentless.simulate.InitializeRandomly(
-                seed=42,
-                N={'A':2,'B':3},
-                V=relentless.model.Cube(L=2.0),
-                T=1.0)
+            seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
+        )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1)
-        md = relentless.simulate.RunMolecularDynamics(steps=100, timestep=1e-3, analyzers=analyzer)
+            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+        )
+        md = relentless.simulate.RunMolecularDynamics(
+            steps=100, timestep=1e-3, analyzers=analyzer
+        )
 
         # test with potential that has infinite potential at low r
-        pot = relentless.model.potential.LennardJones(types=('A','B'))
+        pot = relentless.model.potential.LennardJones(types=("A", "B"))
         for pair in pot.coeff:
-            pot.coeff[pair].update({'epsilon':1.0, 'sigma':1.0, 'rmax':3.0, 'shift':True})
+            pot.coeff[pair].update(
+                {"epsilon": 1.0, "sigma": 1.0, "rmax": 3.0, "shift": True}
+            )
         pots = relentless.simulate.Potentials()
         pots.pair.potentials.append(pot)
         pots.pair.rmax = 3.0
@@ -69,7 +73,7 @@ class test_Dilute(unittest.TestCase):
             sim = d.run(potentials=pots, directory=self.directory)
         except RuntimeWarning:
             warned = True
-        self.assertFalse(warned)   # no warning should be raised
+        self.assertFalse(warned)  # no warning should be raised
         ens_ = sim[analyzer].ensemble
         self.assertAlmostEqual(ens_.P, -1.1987890)
 
@@ -79,5 +83,6 @@ class test_Dilute(unittest.TestCase):
             del self._tmp
         del self.directory
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -1,14 +1,12 @@
 """Unit tests for relentless.simulate.hoomd."""
-from parameterized import parameterized_class
 import tempfile
 import unittest
 
-try:
-    import hoomd
-except ImportError:
-    pass
+from parameterized import parameterized_class
+
 try:
     import gsd.hoomd
+
     _found_gsd = True
 except ImportError:
     _found_gsd = False
@@ -17,15 +15,23 @@ import numpy
 import relentless
 from tests.model.potential.test_pair import LinPot
 
-_has_modules = (relentless.simulate.hoomd._hoomd_found and
-                relentless.simulate.hoomd._freud_found and
-                _found_gsd)
+_has_modules = (
+    relentless.simulate.hoomd._hoomd_found
+    and relentless.simulate.hoomd._freud_found
+    and _found_gsd
+)
+
 
 @unittest.skipIf(not _has_modules, "HOOMD, freud, and/or GSD not installed")
-@parameterized_class([{'dim': 2}, {'dim': 3}],
-    class_name_func=lambda cls, num, params_dict: "{}_{}d".format(cls.__name__,params_dict['dim']))
+@parameterized_class(
+    [{"dim": 2}, {"dim": 3}],
+    class_name_func=lambda cls, num, params_dict: "{}_{}d".format(
+        cls.__name__, params_dict["dim"]
+    ),
+)
 class test_HOOMD(unittest.TestCase):
     """Unit tests for relentless.HOOMD"""
+
     def setUp(self):
         if relentless.mpi.world.rank_is_root:
             self._tmp = tempfile.TemporaryDirectory()
@@ -38,146 +44,159 @@ class test_HOOMD(unittest.TestCase):
     # mock (NVT) ensemble and potential for testing
     def ens_pot(self):
         if self.dim == 3:
-            ens = relentless.model.Ensemble(T=2.0, V=relentless.model.Cube(L=20.0), N={'A':2,'B':3})
+            ens = relentless.model.Ensemble(
+                T=2.0, V=relentless.model.Cube(L=20.0), N={"A": 2, "B": 3}
+            )
         elif self.dim == 2:
-            ens = relentless.model.Ensemble(T=2.0, V=relentless.model.Square(L=20.0), N={'A':2,'B':3})
+            ens = relentless.model.Ensemble(
+                T=2.0, V=relentless.model.Square(L=20.0), N={"A": 2, "B": 3}
+            )
         else:
-            raise ValueError('HOOMD supports 2d and 3d simulations')
+            raise ValueError("HOOMD supports 2d and 3d simulations")
 
         # setup potentials
-        pot = LinPot(ens.types,params=('m',))
+        pot = LinPot(ens.types, params=("m",))
         for pair in pot.coeff:
-            pot.coeff[pair].update({'m': -2.0, 'rmax': 1.0})
+            pot.coeff[pair].update({"m": -2.0, "rmax": 1.0})
         pots = relentless.simulate.Potentials()
         pots.pair.potentials.append(pot)
         pots.pair.rmax = 2.0
         pots.pair.num = 3
 
-        return (ens,pots)
+        return (ens, pots)
 
     # mock gsd file for testing
     def create_gsd(self):
-        filename = self.directory.file('test.gsd')
+        filename = self.directory.file("test.gsd")
         if relentless.mpi.world.rank_is_root:
-            with gsd.hoomd.open(name=filename, mode='wb') as f:
+            with gsd.hoomd.open(name=filename, mode="wb") as f:
                 s = gsd.hoomd.Snapshot()
                 s.particles.N = 5
-                s.particles.types = ['A','B']
-                s.particles.typeid = [0,0,1,1,1]
+                s.particles.types = ["A", "B"]
+                s.particles.typeid = [0, 0, 1, 1, 1]
                 if self.dim == 3:
-                    s.particles.position = numpy.random.uniform(low=-5.0,high=5.0,size=(5,3))
-                    s.configuration.box = [20,20,20,0,0,0]
+                    s.particles.position = numpy.random.uniform(
+                        low=-5.0, high=5.0, size=(5, 3)
+                    )
+                    s.configuration.box = [20, 20, 20, 0, 0, 0]
                 elif self.dim == 2:
-                    s.particles.position = numpy.random.uniform(low=-5.0,high=5.0,size=(5,3))
+                    s.particles.position = numpy.random.uniform(
+                        low=-5.0, high=5.0, size=(5, 3)
+                    )
                     s.particles.position[:, 2] = 0
-                    s.configuration.box = [20,20,0,0,0,0]
+                    s.configuration.box = [20, 20, 0, 0, 0, 0]
                 else:
-                    raise ValueError('HOOMD supports 2d and 3d simulations')
+                    raise ValueError("HOOMD supports 2d and 3d simulations")
                 f.append(s)
         relentless.mpi.world.barrier()
         return filename
 
     def test_initialize_from_file(self):
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         f = self.create_gsd()
         op = relentless.simulate.InitializeFromFile(filename=f)
         h = relentless.simulate.HOOMD(op)
         h.run(pot, self.directory)
 
     def test_initialize_randomly(self):
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
         h = relentless.simulate.HOOMD(op)
         h.run(pot, self.directory)
 
         # no T
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         h.initializer = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V)
         h.run(pot, self.directory)
 
         # T + diameters
-        h.initializer = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, diameters={'A': 1., 'B': 2.})
+        h.initializer = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, diameters={"A": 1.0, "B": 2.0}
+        )
         h.run(pot, self.directory)
 
         # no T + mass
-        m = {i: idx+1 for idx,i in enumerate(ens.N)}
-        h.initializer = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, masses=m)
+        m = {i: idx + 1 for idx, i in enumerate(ens.N)}
+        h.initializer = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, masses=m
+        )
         h.run(pot, self.directory)
 
         # T + mass
-        h.initializer = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, masses=m)
+        h.initializer = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, T=ens.T, masses=m
+        )
         h.run(pot, self.directory)
 
     def test_minimization(self):
         """Test running energy minimization simulation operation."""
         # MinimizeEnergy
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
 
-        emin = relentless.simulate.MinimizeEnergy(energy_tolerance=1e-7,
-                                                  force_tolerance=1e-7,
-                                                  max_iterations=1000,
-                                                  options={'max_displacement':0.5,
-                                                           'steps_per_iteration':50})
+        emin = relentless.simulate.MinimizeEnergy(
+            energy_tolerance=1e-7,
+            force_tolerance=1e-7,
+            max_iterations=1000,
+            options={"max_displacement": 0.5, "steps_per_iteration": 50},
+        )
         h = relentless.simulate.HOOMD(init, emin)
         h.run(pot, self.directory)
-        self.assertEqual(emin.options['max_displacement'],0.5)
-        self.assertEqual(emin.options['steps_per_iteration'],50)
+        self.assertEqual(emin.options["max_displacement"], 0.5)
+        self.assertEqual(emin.options["steps_per_iteration"], 50)
 
         # error check for missing max_displacement
         with self.assertRaises(KeyError):
-            emin = relentless.simulate.MinimizeEnergy(energy_tolerance=1e-7,
-                                                      force_tolerance=1e-7,
-                                                      max_iterations=1000,
-                                                      options={})
+            emin = relentless.simulate.MinimizeEnergy(
+                energy_tolerance=1e-7,
+                force_tolerance=1e-7,
+                max_iterations=1000,
+                options={},
+            )
             h = relentless.simulate.HOOMD(init, emin)
             h.run(pot, self.directory)
 
-        #check default value for max_evaluations
-        emin = relentless.simulate.MinimizeEnergy(energy_tolerance=1e-7,
-                                                  force_tolerance=1e-7,
-                                                  max_iterations=1000,
-                                                  options={'max_displacement':0.5})
+        # check default value for max_evaluations
+        emin = relentless.simulate.MinimizeEnergy(
+            energy_tolerance=1e-7,
+            force_tolerance=1e-7,
+            max_iterations=1000,
+            options={"max_displacement": 0.5},
+        )
         h = relentless.simulate.HOOMD(init, emin)
         h.run(pot, self.directory)
-        self.assertEqual(emin.options['steps_per_iteration'], 100)
+        self.assertEqual(emin.options["steps_per_iteration"], 100)
 
     def test_brownian_dynamics(self):
         """Test adding and removing integrator operations."""
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
         brn = relentless.simulate.RunBrownianDynamics(
-                steps=1,
-                timestep=1.e-3,
-                T=ens.T,
-                friction=1.0,
-                seed=2)
+            steps=1, timestep=1.0e-3, T=ens.T, friction=1.0, seed=2
+        )
         h = relentless.simulate.HOOMD(init, brn)
         h.run(pot, self.directory)
 
-        brn.friction = {'A': 1.5, 'B': 2.5}
+        brn.friction = {"A": 1.5, "B": 2.5}
         h.run(pot, self.directory)
 
     def test_langevin_dynamics(self):
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
         lgv = relentless.simulate.RunLangevinDynamics(
-                steps=1,
-                timestep=1.e-3,
-                T=ens.T,
-                friction=1.0,
-                seed=2)
+            steps=1, timestep=1.0e-3, T=ens.T, friction=1.0, seed=2
+        )
         h = relentless.simulate.HOOMD(init, lgv)
         h.run(pot, self.directory)
 
-        lgv.friction = {'A': 1.5, 'B': 2.5}
+        lgv.friction = {"A": 1.5, "B": 2.5}
         h.run(pot, self.directory)
 
     def test_molecular_dynamics(self):
         # VerletIntegrator - NVE
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        vrl = relentless.simulate.RunMolecularDynamics(steps=1, timestep=1.e-3)
+        vrl = relentless.simulate.RunMolecularDynamics(steps=1, timestep=1.0e-3)
         h = relentless.simulate.HOOMD(init, vrl)
         h.run(pot, self.directory)
 
@@ -189,7 +208,7 @@ class test_HOOMD(unittest.TestCase):
         vrl.barostat = relentless.simulate.MTKBarostat(P=1, tau=0.5)
         h.run(pot, self.directory)
 
-        #VerletIntegrator - NPH
+        # VerletIntegrator - NPH
         vrl.thermostat = None
         h.run(pot, self.directory)
 
@@ -206,18 +225,16 @@ class test_HOOMD(unittest.TestCase):
 
     def test_analyzer(self):
         """Test ensemble analyzer simulation operation."""
-        ens,pot = self.ens_pot()
-        init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={'A': 1, 'B': 1})
-        analyzer = relentless.simulate.EnsembleAverage(check_thermo_every=5,
-                                                       check_rdf_every=10,
-                                                       rdf_dr=1.0)
+        ens, pot = self.ens_pot()
+        init = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"A": 1, "B": 1}
+        )
+        analyzer = relentless.simulate.EnsembleAverage(
+            check_thermo_every=5, check_rdf_every=10, rdf_dr=1.0
+        )
         lgv = relentless.simulate.RunLangevinDynamics(
-                steps=500,
-                timestep=0.001,
-                T=ens.T,
-                friction=1.0,
-                seed=1,
-                analyzers=analyzer)
+            steps=500, timestep=0.001, T=ens.T, friction=1.0, seed=1, analyzers=analyzer
+        )
         h = relentless.simulate.HOOMD(init, lgv)
         sim = h.run(pot, self.directory)
 
@@ -229,50 +246,54 @@ class test_HOOMD(unittest.TestCase):
         self.assertNotEqual(ens_.P, 0)
         self.assertIsNotNone(ens_.V)
         self.assertNotEqual(ens_.V.extent, 0)
-        for i,j in ens_.rdf:
-            self.assertEqual(ens_.rdf[i,j].table.shape, (len(pot.pair.r)-1,2))
+        for i, j in ens_.rdf:
+            self.assertEqual(ens_.rdf[i, j].table.shape, (len(pot.pair.r) - 1, 2))
         self.assertEqual(sim[analyzer].num_thermo_samples, 100)
         self.assertEqual(sim[analyzer].num_rdf_samples, 50)
 
     def test_self_interactions(self):
         """Test if self-interactions are excluded from rdf computation."""
         if self.dim == 3:
-            Lz = 20.
-            z = 1.
-            box_type = relentless.model.Cube
+            Lz = 20.0
+            z = 1.0
         elif self.dim == 2:
-            Lz = 1.
-            z = 0.
-            box_type = relentless.model.Square   
+            Lz = 1.0
+            z = 0.0
         else:
-            raise ValueError('HOOMD supports 2d and 3d simulations')
- 
-        filename = self.directory.file('mock.gsd')
+            raise ValueError("HOOMD supports 2d and 3d simulations")
+
+        filename = self.directory.file("mock.gsd")
         if relentless.mpi.world.rank_is_root:
-            with gsd.hoomd.open(name=filename, mode='wb') as f:
+            with gsd.hoomd.open(name=filename, mode="wb") as f:
                 s = gsd.hoomd.Snapshot()
                 s.particles.N = 4
-                s.particles.types = ['A','B']
-                s.particles.typeid = [0,1,0,1]
-                s.particles.position = [[-1,-1,-z],[1,1,z],[1,-1,z],[-1,1,-z]]
-                s.configuration.box = [20,20,Lz,0,0,0]
+                s.particles.types = ["A", "B"]
+                s.particles.typeid = [0, 1, 0, 1]
+                s.particles.position = [
+                    [-1, -1, -z],
+                    [1, 1, z],
+                    [1, -1, z],
+                    [-1, 1, -z],
+                ]
+                s.configuration.box = [20, 20, Lz, 0, 0, 0]
                 s.configuration.dimensions = self.dim
                 f.append(s)
         relentless.mpi.world.barrier()
 
-        ens = relentless.model.Ensemble(T=2.0, V=box_type(L=20), N={'A':2,'B':2})
-        _,pot = self.ens_pot()
+        _, pot = self.ens_pot()
         init = relentless.simulate.InitializeFromFile(filename=filename)
-        analyzer = relentless.simulate.EnsembleAverage(check_thermo_every=1,
-                                                       check_rdf_every=1,
-                                                       rdf_dr=0.1)
-        ig = relentless.simulate.RunMolecularDynamics(steps=1, timestep=0.0, analyzers=analyzer)
+        analyzer = relentless.simulate.EnsembleAverage(
+            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+        )
+        ig = relentless.simulate.RunMolecularDynamics(
+            steps=1, timestep=0.0, analyzers=analyzer
+        )
         h = relentless.simulate.HOOMD(init, ig)
         sim = h.run(pot, self.directory)
 
         ens_ = sim[analyzer].ensemble
-        for i,j in ens_.rdf:
-            self.assertEqual(ens_.rdf[i,j].table[0,1], 0.0)
+        for i, j in ens_.rdf:
+            self.assertEqual(ens_.rdf[i, j].table[0, 1], 0.0)
 
     def tearDown(self):
         if relentless.mpi.world.rank_is_root:
@@ -280,5 +301,6 @@ class test_HOOMD(unittest.TestCase):
             del self._tmp
         del self.directory
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -1,25 +1,28 @@
 """Unit tests for relentless.simulate.lammps."""
-import contextlib
-import io
-import sys
-from parameterized import parameterized_class
 import tempfile
 import unittest
+
+from parameterized import parameterized_class
 
 try:
     import lammps
 except ImportError:
     pass
 import lammpsio
-import numpy
 
 import relentless
 from tests.model.potential.test_pair import LinPot
 
-@unittest.skipIf(not relentless.simulate.lammps._lammps_found,
-                "Compatible LAMMPS not installed")
-@parameterized_class([{'dim': 2}, {'dim': 3}],
-    class_name_func=lambda cls, num, params_dict: "{}_{}d".format(cls.__name__,params_dict['dim']))
+
+@unittest.skipIf(
+    not relentless.simulate.lammps._lammps_found, "Compatible LAMMPS not installed"
+)
+@parameterized_class(
+    [{"dim": 2}, {"dim": 3}],
+    class_name_func=lambda cls, num, params_dict: "{}_{}d".format(
+        cls.__name__, params_dict["dim"]
+    ),
+)
 class test_LAMMPS(unittest.TestCase):
     """Unit tests for relentless.LAMMPS"""
 
@@ -35,35 +38,39 @@ class test_LAMMPS(unittest.TestCase):
     # mock (NVT) ensemble and potential for testing
     def ens_pot(self):
         if self.dim == 3:
-            ens = relentless.model.Ensemble(T=2.0, V=relentless.model.Cube(L=10.0), N={'1':2,'2':3})
+            ens = relentless.model.Ensemble(
+                T=2.0, V=relentless.model.Cube(L=10.0), N={"1": 2, "2": 3}
+            )
         elif self.dim == 2:
-            ens = relentless.model.Ensemble(T=2.0, V=relentless.model.Square(L=10.0), N={'1':2,'2':3})
+            ens = relentless.model.Ensemble(
+                T=2.0, V=relentless.model.Square(L=10.0), N={"1": 2, "2": 3}
+            )
         else:
-            raise ValueError('LAMMPS supports 2d and 3d simulations')
+            raise ValueError("LAMMPS supports 2d and 3d simulations")
         ens.P = 2.5
         # setup potentials
-        pot = LinPot(ens.types,params=('m',))
+        pot = LinPot(ens.types, params=("m",))
         for pair in pot.coeff:
-            pot.coeff[pair].update({'m': -2.0, 'rmax': 1.0})
+            pot.coeff[pair].update({"m": -2.0, "rmax": 1.0})
         pots = relentless.simulate.Potentials()
         pots.pair.potentials.append(pot)
         pots.pair.rmin = 1e-6
         pots.pair.rmax = 2.0
         pots.pair.num = 3
 
-        return (ens,pots)
+        return (ens, pots)
 
     def create_file(self):
-        file_ = self.directory.file('test.data')
+        file_ = self.directory.file("test.data")
 
         if relentless.mpi.world.rank_is_root:
             low = [-5, -5, -5 if self.dim == 3 else -0.1]
             high = [5, 5, 5 if self.dim == 3 else 0.1]
             snap = lammpsio.Snapshot(N=5, box=lammpsio.Box(low, high))
-            snap.position[:,:2] = [[-4,-4],[-2,-2],[0,0],[2,2],[4,4]]
+            snap.position[:, :2] = [[-4, -4], [-2, -2], [0, 0], [2, 2], [4, 4]]
             if self.dim == 3:
-                snap.position[:,2] = [-4, -2, 0, 2, 4]
-            snap.typeid = [1,1,2,2,2]
+                snap.position[:, 2] = [-4, -2, 0, 2, 4]
+            snap.typeid = [1, 1, 2, 2, 2]
             snap.mass = [0.3, 0.3, 0.1, 0.1, 0.1]
             lammpsio.DataFile.create(file_, snap)
         relentless.mpi.world.barrier()
@@ -73,169 +80,172 @@ class test_LAMMPS(unittest.TestCase):
     def test_initialize(self):
         """Test running initialization simulation operations."""
         # InitializeFromFile
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         file_ = self.create_file()
         op = relentless.simulate.InitializeFromFile(filename=file_)
-        op.lammps_types = {'1': 1, '2': 2}
-        l = relentless.simulate.LAMMPS(op, dimension=self.dim)
-        sim = l.run(potentials=pot, directory=self.directory)
+        op.lammps_types = {"1": 1, "2": 2}
+        lmp = relentless.simulate.LAMMPS(op, dimension=self.dim)
+        sim = lmp.run(potentials=pot, directory=self.directory)
         self.assertIsInstance(sim.lammps, lammps.lammps)
         self.assertEqual(sim.lammps.get_natoms(), 5)
 
-        #InitializeRandomly
+        # InitializeRandomly
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        l = relentless.simulate.LAMMPS(op, dimension=self.dim)
-        sim = l.run(potentials=pot, directory=self.directory)
+        lmp = relentless.simulate.LAMMPS(op, dimension=self.dim)
+        sim = lmp.run(potentials=pot, directory=self.directory)
         self.assertIsInstance(sim.lammps, lammps.lammps)
         self.assertEqual(sim.lammps.get_natoms(), 5)
 
     def test_random_initialize_options(self):
         # no T
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V)
         h = relentless.simulate.LAMMPS(op, dimension=self.dim)
         h.run(potentials=pot, directory=self.directory)
 
         # T + diameters
-        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, diameters={'1': 1., '2': 2.})
+        op = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, diameters={"1": 1.0, "2": 2.0}
+        )
         h = relentless.simulate.LAMMPS(op, dimension=self.dim)
         h.run(potentials=pot, directory=self.directory)
 
         # no T + mass
-        m = {i: idx+1 for idx,i in enumerate(ens.N)}
+        m = {i: idx + 1 for idx, i in enumerate(ens.N)}
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, masses=m)
         h = relentless.simulate.LAMMPS(op, dimension=self.dim)
         h.run(potentials=pot, directory=self.directory)
 
         # T + mass
-        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, masses=m)
+        op = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, T=ens.T, masses=m
+        )
         h = relentless.simulate.LAMMPS(op, dimension=self.dim)
         h.run(potentials=pot, directory=self.directory)
 
     def test_minimization(self):
         """Test running energy minimization simulation operation."""
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         file_ = self.create_file()
         init = relentless.simulate.InitializeFromFile(filename=file_)
-        init.lammps_types = {'1': 1, '2': 2}
+        init.lammps_types = {"1": 1, "2": 2}
 
-        #MinimizeEnergy
-        emin = relentless.simulate.MinimizeEnergy(energy_tolerance=1e-7,
-                                                  force_tolerance=1e-7,
-                                                  max_iterations=1000,
-                                                  options={'max_evaluations': 10000})
-        l = relentless.simulate.LAMMPS(init, operations=[emin], dimension=self.dim)
-        sim = l.run(potentials=pot, directory=self.directory)
-        self.assertEqual(emin.options['max_evaluations'], 10000)
+        # MinimizeEnergy
+        emin = relentless.simulate.MinimizeEnergy(
+            energy_tolerance=1e-7,
+            force_tolerance=1e-7,
+            max_iterations=1000,
+            options={"max_evaluations": 10000},
+        )
+        lmp = relentless.simulate.LAMMPS(init, operations=[emin], dimension=self.dim)
+        lmp.run(potentials=pot, directory=self.directory)
+        self.assertEqual(emin.options["max_evaluations"], 10000)
 
-        #check default value of max_evaluations
-        emin = relentless.simulate.MinimizeEnergy(energy_tolerance=1e-7,
-                                                  force_tolerance=1e-7,
-                                                  max_iterations=1000,
-                                                  options={})
-        l = relentless.simulate.LAMMPS(init, operations=[emin], dimension=self.dim)
-        sim = l.run(potentials=pot, directory=self.directory)
-        self.assertEqual(emin.options['max_evaluations'], 100*emin.max_iterations)
+        # check default value of max_evaluations
+        emin = relentless.simulate.MinimizeEnergy(
+            energy_tolerance=1e-7, force_tolerance=1e-7, max_iterations=1000, options={}
+        )
+        lmp = relentless.simulate.LAMMPS(init, operations=[emin], dimension=self.dim)
+        lmp.run(potentials=pot, directory=self.directory)
+        self.assertEqual(emin.options["max_evaluations"], 100 * emin.max_iterations)
 
     def test_langevin_dynamics(self):
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        l = relentless.simulate.LAMMPS(init, dimension=self.dim)
+        lmp = relentless.simulate.LAMMPS(init, dimension=self.dim)
 
         # float friction
         lgv = relentless.simulate.RunLangevinDynamics(
-                steps=1,
-                timestep=0.5,
-                T=ens.T,
-                friction=1.5,
-                seed=2)
-        l.operations = lgv
-        l.run(pot, self.directory)
+            steps=1, timestep=0.5, T=ens.T, friction=1.5, seed=2
+        )
+        lmp.operations = lgv
+        lmp.run(pot, self.directory)
 
         # dictionary friction
-        lgv.friction = {'1':2.0,'2':5.0}
-        l.run(pot, self.directory)
+        lgv.friction = {"1": 2.0, "2": 5.0}
+        lmp.run(pot, self.directory)
 
         # single-type friction
-        init_1 = relentless.simulate.InitializeRandomly(seed=1, N={'1':2}, V=ens.V, T=ens.T)
+        init_1 = relentless.simulate.InitializeRandomly(
+            seed=1, N={"1": 2}, V=ens.V, T=ens.T
+        )
         lgv = relentless.simulate.RunLangevinDynamics(
-                steps=1,
-                timestep=0.5,
-                T=ens.T,
-                friction={'1':3.0},
-                seed=2)
-        l.initializer = init_1
-        l.operations = lgv
-        l.run(pot, self.directory)
+            steps=1, timestep=0.5, T=ens.T, friction={"1": 3.0}, seed=2
+        )
+        lmp.initializer = init_1
+        lmp.operations = lgv
+        lmp.run(pot, self.directory)
 
-        #invalid-type friction
-        lgv.friction = {'2':5.0,'3':2.0}
-        l.initializer = init
-        l.operations = lgv
+        # invalid-type friction
+        lgv.friction = {"2": 5.0, "3": 2.0}
+        lmp.initializer = init
+        lmp.operations = lgv
         with self.assertRaises(KeyError):
-            l.run(pot, self.directory)
+            lmp.run(pot, self.directory)
 
     def test_molecular_dynamics(self):
-        ens,pot = self.ens_pot()
+        ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        l = relentless.simulate.LAMMPS(init, dimension=self.dim)
+        lmp = relentless.simulate.LAMMPS(init, dimension=self.dim)
 
         # VerletIntegrator - NVE
         vrl = relentless.simulate.RunMolecularDynamics(steps=1, timestep=1e-3)
-        l.operations = vrl
-        l.run(pot, self.directory)
+        lmp.operations = vrl
+        lmp.run(pot, self.directory)
 
         # NVT - Berendesen
         vrl.thermostat = relentless.simulate.BerendsenThermostat(T=1, tau=0.5)
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NPT - Berendsen
         vrl.barostat = relentless.simulate.BerendsenBarostat(P=1, tau=0.5)
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NPH - Berendsen
         vrl.thermostat = None
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NVT - Nose Hoover
         vrl.thermostat = relentless.simulate.NoseHooverThermostat(T=1, tau=0.5)
         vrl.barostat = None
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NPT - Nose Hoover + Berendsen
         vrl.barostat = relentless.simulate.BerendsenBarostat(P=1, tau=0.5)
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NPT - Nose Hoover + MTK
         vrl.barostat = relentless.simulate.MTKBarostat(P=1, tau=0.5)
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NPT - Berendsen + MTK
         vrl.thermostat = relentless.simulate.BerendsenThermostat(T=1, tau=0.5)
-        l.run(pot, self.directory)
+        lmp.run(pot, self.directory)
 
         # NPH - MTK
         vrl.thermostat = None
-        l.run(pot, self.directory)
-
+        lmp.run(pot, self.directory)
 
     def test_analyzer(self):
         """Test ensemble analyzer simulation operation."""
-        ens,pot = self.ens_pot()
-        init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={'1': 1, '2': 1})
-        analyzer = relentless.simulate.EnsembleAverage(check_thermo_every=5,
-                                                       check_rdf_every=5,
-                                                       rdf_dr=1.0)
-        analyzer2 = relentless.simulate.EnsembleAverage(check_thermo_every=10,
-                                                        check_rdf_every=10,
-                                                        rdf_dr=0.5)
+        ens, pot = self.ens_pot()
+        init = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"1": 1, "2": 1}
+        )
+        analyzer = relentless.simulate.EnsembleAverage(
+            check_thermo_every=5, check_rdf_every=5, rdf_dr=1.0
+        )
+        analyzer2 = relentless.simulate.EnsembleAverage(
+            check_thermo_every=10, check_rdf_every=10, rdf_dr=0.5
+        )
         lgv = relentless.simulate.RunLangevinDynamics(
-                steps=500,
-                timestep=0.001,
-                T=ens.T,
-                friction=1.0,
-                seed=1,
-                analyzers=[analyzer,analyzer2])
+            steps=500,
+            timestep=0.001,
+            T=ens.T,
+            friction=1.0,
+            seed=1,
+            analyzers=[analyzer, analyzer2],
+        )
         h = relentless.simulate.LAMMPS(init, operations=lgv, dimension=self.dim)
         sim = h.run(potentials=pot, directory=self.directory)
 
@@ -247,9 +257,9 @@ class test_LAMMPS(unittest.TestCase):
         self.assertNotEqual(ens_.P, 0)
         self.assertIsNotNone(ens_.V)
         self.assertNotEqual(ens_.V.extent, 0)
-        for i,j in ens_.rdf:
+        for i, j in ens_.rdf:
             # shape is determined by rmax for potential and rdf_dr
-            self.assertEqual(ens_.rdf[i,j].table.shape, (2,2))
+            self.assertEqual(ens_.rdf[i, j].table.shape, (2, 2))
 
         # extract ensemble from second analyzer, answers should be slightly different
         # for any quantities that fluctuate
@@ -263,8 +273,8 @@ class test_LAMMPS(unittest.TestCase):
         self.assertIsNotNone(ens2_.V)
         self.assertNotEqual(ens2_.V.extent, 0)
         self.assertEqual(ens2_.V.extent, ens_.V.extent)
-        for i,j in ens2_.rdf:
-            self.assertEqual(ens2_.rdf[i,j].table.shape, (4,2))
+        for i, j in ens2_.rdf:
+            self.assertEqual(ens2_.rdf[i, j].table.shape, (4, 2))
 
     def tearDown(self):
         if relentless.mpi.world.rank_is_root:
@@ -272,5 +282,6 @@ class test_LAMMPS(unittest.TestCase):
             del self._tmp
         del self.directory
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -1,66 +1,69 @@
 """Unit tests for simulate module."""
-from parameterized import parameterized_class
-import tempfile
 import unittest
 
 import numpy
+from parameterized import parameterized_class
 
 import relentless
 
+
 class QuadPot(relentless.model.potential.Potential):
-    """Quadratic potential function used to test relentless.simulate.PotentialTabulator"""
+    """Quadratic potential function"""
 
     def __init__(self, types, params):
         super().__init__(types, params)
 
     def energy(self, key, x):
-        x,u,s = self._zeros(x)
-        m = self.coeff[key]['m']
+        x, u, s = self._zeros(x)
+        m = self.coeff[key]["m"]
         if isinstance(m, relentless.model.DesignVariable):
             m = m.value
-        u = m*(3-x)**2
+        u = m * (3 - x) ** 2
         if s:
             u = u.item()
         return u
 
     def force(self, key, x):
-        x,f,s = self._zeros(x)
-        m = self.coeff[key]['m']
+        x, f, s = self._zeros(x)
+        m = self.coeff[key]["m"]
         if isinstance(m, relentless.model.DesignVariable):
             m = m.value
-        f = 2*m*(3-x)
+        f = 2 * m * (3 - x)
         if s:
             f = f.item()
         return f
 
     def derivative(self, key, var, x):
-        x,d,s = self._zeros(x)
+        x, d, s = self._zeros(x)
         if isinstance(var, relentless.model.DesignVariable):
-            if self.coeff[key]['m'] is var:
-                d = (3-x)**2
+            if self.coeff[key]["m"] is var:
+                d = (3 - x) ** 2
         if s:
             d = d.item()
         return d
+
 
 class test_PotentialTabulator(unittest.TestCase):
     """Unit tests for relentless.simulate.PotentialTabulator"""
 
     def test_init(self):
         """Test creation with data."""
-        xs = numpy.array([0.0,0.5,1,1.5])
-        p1 = QuadPot(types=('1',), params=('m',))
+        xs = numpy.array([0.0, 0.5, 1, 1.5])
+        p1 = QuadPot(types=("1",), params=("m",))
 
         # test creation with no potential
-        t = relentless.simulate.PotentialTabulator(start=0.0,stop=1.5,num=4)
-        numpy.testing.assert_allclose(t.x,xs)
+        t = relentless.simulate.PotentialTabulator(start=0.0, stop=1.5, num=4)
+        numpy.testing.assert_allclose(t.x, xs)
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
         self.assertEqual(t.potentials, [])
 
         # test creation with defined potential
-        t = relentless.simulate.PotentialTabulator(start=0.0,stop=1.5,num=4,potentials=p1)
-        numpy.testing.assert_allclose(t.x,xs)
+        t = relentless.simulate.PotentialTabulator(
+            start=0.0, stop=1.5, num=4, potentials=p1
+        )
+        numpy.testing.assert_allclose(t.x, xs)
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
@@ -68,73 +71,79 @@ class test_PotentialTabulator(unittest.TestCase):
 
     def test_potential(self):
         """Test energy, force, and derivative methods"""
-        p1 = QuadPot(types=('1',), params=('m',))
-        p1.coeff['1']['m'] = relentless.model.DesignVariable(2.0)
-        p2 = QuadPot(types=('1','2'), params=('m',))
+        p1 = QuadPot(types=("1",), params=("m",))
+        p1.coeff["1"]["m"] = relentless.model.DesignVariable(2.0)
+        p2 = QuadPot(types=("1", "2"), params=("m",))
         for key in p2.coeff.types:
-            p2.coeff[key]['m'] = 1.0
-        t = relentless.simulate.PotentialTabulator(start=0.0,stop=5.0,num=6,potentials=[p1,p2])
+            p2.coeff[key]["m"] = 1.0
+        t = relentless.simulate.PotentialTabulator(
+            start=0.0, stop=5.0, num=6, potentials=[p1, p2]
+        )
 
         # test energy method
-        u = t.energy('1')
-        numpy.testing.assert_allclose(u, numpy.array([27,12,3,0,3,12]))
+        u = t.energy("1")
+        numpy.testing.assert_allclose(u, numpy.array([27, 12, 3, 0, 3, 12]))
 
-        u = t.energy('2')
-        numpy.testing.assert_allclose(u, numpy.array([9,4,1,0,1,4]))
+        u = t.energy("2")
+        numpy.testing.assert_allclose(u, numpy.array([9, 4, 1, 0, 1, 4]))
 
         # test force method
-        f = t.force('1')
-        numpy.testing.assert_allclose(f, numpy.array([18,12,6,0,-6,-12]))
+        f = t.force("1")
+        numpy.testing.assert_allclose(f, numpy.array([18, 12, 6, 0, -6, -12]))
 
-        f = t.force('2')
-        numpy.testing.assert_allclose(f, numpy.array([6,4,2,0,-2,-4]))
+        f = t.force("2")
+        numpy.testing.assert_allclose(f, numpy.array([6, 4, 2, 0, -2, -4]))
 
         # test derivative method
-        var = p1.coeff['1']['m']
-        d = t.derivative('1',var)
-        numpy.testing.assert_allclose(d, numpy.array([9,4,1,0,1,4]))
+        var = p1.coeff["1"]["m"]
+        d = t.derivative("1", var)
+        numpy.testing.assert_allclose(d, numpy.array([9, 4, 1, 0, 1, 4]))
 
-        d = t.derivative('2',var)
-        numpy.testing.assert_allclose(d, numpy.array([0,0,0,0,0,0]))
+        d = t.derivative("2", var)
+        numpy.testing.assert_allclose(d, numpy.array([0, 0, 0, 0, 0, 0]))
+
 
 class QuadPairPot(relentless.model.potential.PairPotential):
-    """Quadratic pair potential function used to test relentless.simulate.PairPotentialTabulator"""
+    """Quadratic pair potential function"""
 
     def __init__(self, types, params):
         super().__init__(types, params)
 
     def _energy(self, r, m, **params):
-        r,u,s = self._zeros(r)
-        u = m*(3-r)**2
+        r, u, s = self._zeros(r)
+        u = m * (3 - r) ** 2
         if s:
             u = u.item()
         return u
 
     def _force(self, r, m, **params):
-        r,f,s = self._zeros(r)
-        f = 2*m*(3-r)
+        r, f, s = self._zeros(r)
+        f = 2 * m * (3 - r)
         if s:
             f = f.item()
         return f
 
     def _derivative(self, param, r, **params):
-        r,d,s = self._zeros(r)
-        if param == 'm':
-            d = (3-r)**2
+        r, d, s = self._zeros(r)
+        if param == "m":
+            d = (3 - r) ** 2
         if s:
             d = d.item()
         return d
+
 
 class test_PairPotentialTabulator(unittest.TestCase):
     """Unit tests for relentless.simulate.PairPotentialTabulator"""
 
     def test_init(self):
         """Test creation with data."""
-        rs = numpy.array([0.0,0.5,1,1.5])
+        rs = numpy.array([0.0, 0.5, 1, 1.5])
 
         # test creation with only required parameters
-        t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=1.5,num=4,neighbor_buffer=0.4)
-        numpy.testing.assert_allclose(t.r,rs)
+        t = relentless.simulate.PairPotentialTabulator(
+            rmin=0.0, rmax=1.5, num=4, neighbor_buffer=0.4
+        )
+        numpy.testing.assert_allclose(t.r, rs)
         self.assertAlmostEqual(t.rmin, 0.0)
         self.assertAlmostEqual(t.rmax, 1.5)
         self.assertEqual(t.num, 4)
@@ -142,7 +151,9 @@ class test_PairPotentialTabulator(unittest.TestCase):
         self.assertEqual(t.fmax, None)
 
         # test creation with required parameters and fmax
-        t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=1.5,num=4,neighbor_buffer=0.4,fmax=1.5)
+        t = relentless.simulate.PairPotentialTabulator(
+            rmin=0.0, rmax=1.5, num=4, neighbor_buffer=0.4, fmax=1.5
+        )
         numpy.testing.assert_allclose(t.r, rs)
         self.assertAlmostEqual(t.rmin, 0.0)
         self.assertAlmostEqual(t.rmax, 1.5)
@@ -152,122 +163,139 @@ class test_PairPotentialTabulator(unittest.TestCase):
 
     def test_potential(self):
         """Test energy, force, and derivative methods"""
-        p1 = QuadPairPot(types=('1',), params=('m',))
-        p1.coeff['1','1']['m'] = relentless.model.DesignVariable(2.0)
-        p2 = QuadPairPot(types=('1','2'), params=('m',))
+        p1 = QuadPairPot(types=("1",), params=("m",))
+        p1.coeff["1", "1"]["m"] = relentless.model.DesignVariable(2.0)
+        p2 = QuadPairPot(types=("1", "2"), params=("m",))
         for pair in p2.coeff.pairs:
-            p2.coeff[pair]['m'] = 1.0
-        t = relentless.simulate.PairPotentialTabulator(rmin=0,rmax=5,num=6,neighbor_buffer=0.4,potentials=[p1,p2])
+            p2.coeff[pair]["m"] = 1.0
+        t = relentless.simulate.PairPotentialTabulator(
+            rmin=0, rmax=5, num=6, neighbor_buffer=0.4, potentials=[p1, p2]
+        )
 
         # test energy method
-        u = t.energy(('1','1'))
-        numpy.testing.assert_allclose(u, numpy.array([27,12,3,0,3,12])-12)
+        u = t.energy(("1", "1"))
+        numpy.testing.assert_allclose(u, numpy.array([27, 12, 3, 0, 3, 12]) - 12)
 
-        u = t.energy(('1','2'))
-        numpy.testing.assert_allclose(u, numpy.array([9,4,1,0,1,4])-4)
+        u = t.energy(("1", "2"))
+        numpy.testing.assert_allclose(u, numpy.array([9, 4, 1, 0, 1, 4]) - 4)
 
         # test force method
-        f = t.force(('1','1'))
-        numpy.testing.assert_allclose(f, numpy.array([18,12,6,0,-6,-12]))
+        f = t.force(("1", "1"))
+        numpy.testing.assert_allclose(f, numpy.array([18, 12, 6, 0, -6, -12]))
 
-        f = t.force(('1','2'))
-        numpy.testing.assert_allclose(f, numpy.array([6,4,2,0,-2,-4]))
+        f = t.force(("1", "2"))
+        numpy.testing.assert_allclose(f, numpy.array([6, 4, 2, 0, -2, -4]))
 
         # test derivative method
-        var = p1.coeff['1','1']['m']
-        d = t.derivative(('1','1'),var)
-        numpy.testing.assert_allclose(d, numpy.array([9,4,1,0,1,4])-4)
+        var = p1.coeff["1", "1"]["m"]
+        d = t.derivative(("1", "1"), var)
+        numpy.testing.assert_allclose(d, numpy.array([9, 4, 1, 0, 1, 4]) - 4)
 
-        d = t.derivative(('1','2'),var)
-        numpy.testing.assert_allclose(d, numpy.array([0,0,0,0,0,0]))
+        d = t.derivative(("1", "2"), var)
+        numpy.testing.assert_allclose(d, numpy.array([0, 0, 0, 0, 0, 0]))
 
     def test_fmax(self):
         """Test setting and changing fmax."""
-        p1 = QuadPairPot(types=('1',), params=('m',))
-        p1.coeff['1','1']['m'] = 3.0
+        p1 = QuadPairPot(types=("1",), params=("m",))
+        p1.coeff["1", "1"]["m"] = 3.0
 
-        t = relentless.simulate.PairPotentialTabulator(rmin=0.0,rmax=6.0,num=7,neighbor_buffer=0.4,potentials=p1,fmax=4)
-        f = t.force(('1','1'))
-        numpy.testing.assert_allclose(f, numpy.array([4,4,4,0,-4,-4,-4]))
+        t = relentless.simulate.PairPotentialTabulator(
+            rmin=0.0, rmax=6.0, num=7, neighbor_buffer=0.4, potentials=p1, fmax=4
+        )
+        f = t.force(("1", "1"))
+        numpy.testing.assert_allclose(f, numpy.array([4, 4, 4, 0, -4, -4, -4]))
 
         t.fmax = 12
-        f = t.force(('1','1'))
-        numpy.testing.assert_allclose(f, numpy.array([12,12,6,0,-6,-12,-12]))
+        f = t.force(("1", "1"))
+        numpy.testing.assert_allclose(f, numpy.array([12, 12, 6, 0, -6, -12, -12]))
 
         t.fmax = 20
-        f = t.force(('1','1'))
-        numpy.testing.assert_allclose(f, numpy.array([18,12,6,0,-6,-12,-18]))
+        f = t.force(("1", "1"))
+        numpy.testing.assert_allclose(f, numpy.array([18, 12, 6, 0, -6, -12, -18]))
 
-@parameterized_class([
-    {'box_geom': 'orthorhombic', 'dim': 3},
-    {'box_geom': 'triclinic', 'dim': 3},
-    {'box_geom': 'orthorhombic', 'dim': 2},
-    {'box_geom': 'triclinic', 'dim': 2}],
-    class_name_func=lambda cls, num, params_dict: "{}_{}_{}d".format(cls.__name__,params_dict['box_geom'],params_dict['dim']))
+
+@parameterized_class(
+    [
+        {"box_geom": "orthorhombic", "dim": 3},
+        {"box_geom": "triclinic", "dim": 3},
+        {"box_geom": "orthorhombic", "dim": 2},
+        {"box_geom": "triclinic", "dim": 2},
+    ],
+    class_name_func=lambda cls, num, params_dict: "{}_{}_{}d".format(
+        cls.__name__, params_dict["box_geom"], params_dict["dim"]
+    ),
+)
 class test_InitializeRandomly(unittest.TestCase):
     def setUp(self):
-        if self.box_geom == 'orthorhombic':
+        if self.box_geom == "orthorhombic":
             if self.dim == 3:
                 self.V = relentless.model.Cuboid(Lx=10, Ly=20, Lz=30)
             elif self.dim == 2:
                 self.V = relentless.model.Rectangle(Lx=20, Ly=30)
-        elif self.box_geom == 'triclinic':
+        elif self.box_geom == "triclinic":
             if self.dim == 3:
-                self.V = relentless.model.TriclinicBox(Lx=10, Ly=20, Lz=30, xy=1, xz=2, yz=-1)
+                self.V = relentless.model.TriclinicBox(
+                    Lx=10, Ly=20, Lz=30, xy=1, xz=2, yz=-1
+                )
             elif self.dim == 2:
                 self.V = relentless.model.ObliqueArea(Lx=20, Ly=30, xy=3)
-        self.tol = 1.e-8
+        self.tol = 1.0e-8
 
     def test_packing_one_type(self):
         if self.dim == 3:
-            N = {'A': 150}
+            N = {"A": 150}
         else:
-            N = {'A': 50}
-        d = {'A': 1.2}
-        rs, types = relentless.simulate.InitializeRandomly._pack_particles(42, N, self.V, d)
+            N = {"A": 50}
+        d = {"A": 1.2}
+        rs, types = relentless.simulate.InitializeRandomly._pack_particles(
+            42, N, self.V, d
+        )
 
-        self.assertTrue(all(typei == 'A' for typei in types))
+        self.assertTrue(all(typei == "A" for typei in types))
 
         xs = self.V.coordinate_to_fraction(rs)
         self.assertTrue(numpy.all(xs >= 0))
         self.assertTrue(numpy.all(xs < 1))
 
-        for i,r in enumerate(rs):
-            dr = numpy.linalg.norm(rs[i+1:]-r, axis=1)
-            self.assertTrue(numpy.all(dr > d['A']-self.tol))
+        for i, r in enumerate(rs):
+            dr = numpy.linalg.norm(rs[i + 1 :] - r, axis=1)
+            self.assertTrue(numpy.all(dr > d["A"] - self.tol))
 
     def test_packing_two_types(self):
         if self.dim == 3:
-            N = {'A': 100, 'B': 25}
+            N = {"A": 100, "B": 25}
         else:
-            N = {'A': 20, 'B': 5}
-        d = {'A': 1.0, 'B': relentless.model.DesignVariable(3.0)}
-        rs, types = relentless.simulate.InitializeRandomly._pack_particles(42, N, self.V, d)
+            N = {"A": 20, "B": 5}
+        d = {"A": 1.0, "B": relentless.model.DesignVariable(3.0)}
+        rs, types = relentless.simulate.InitializeRandomly._pack_particles(
+            42, N, self.V, d
+        )
 
-        mask = numpy.array([typei == 'A' for typei in types])
-        self.assertEqual(numpy.sum(mask), N['A'])
-        self.assertEqual(numpy.sum(~mask), N['B'])
+        mask = numpy.array([typei == "A" for typei in types])
+        self.assertEqual(numpy.sum(mask), N["A"])
+        self.assertEqual(numpy.sum(~mask), N["B"])
 
         xs = self.V.coordinate_to_fraction(rs)
         self.assertTrue(numpy.all(xs > -self.tol))
-        self.assertTrue(numpy.all(xs < 1.+self.tol))
+        self.assertTrue(numpy.all(xs < 1.0 + self.tol))
 
         rAs = rs[mask]
         rBs = rs[~mask]
-        for i,rB in enumerate(rBs):
-            dr = numpy.linalg.norm(rBs[i+1:]-rB, axis=1)
-            self.assertTrue(numpy.all(dr > d['B'].value-self.tol))
+        for i, rB in enumerate(rBs):
+            dr = numpy.linalg.norm(rBs[i + 1 :] - rB, axis=1)
+            self.assertTrue(numpy.all(dr > d["B"].value - self.tol))
 
-        for i,rA in enumerate(rAs):
-            dr = numpy.linalg.norm(rAs[i+1:]-rA, axis=1)
-            self.assertTrue(numpy.all(dr > d['A']-self.tol))
+        for i, rA in enumerate(rAs):
+            dr = numpy.linalg.norm(rAs[i + 1 :] - rA, axis=1)
+            self.assertTrue(numpy.all(dr > d["A"] - self.tol))
 
-        for i,rA in enumerate(rAs):
-            dr = numpy.linalg.norm(rBs-rA,axis=1)
-            dAB = 0.5*(d['A']+d['B'].value)
+        for i, rA in enumerate(rAs):
+            dr = numpy.linalg.norm(rBs - rA, axis=1)
+            dAB = 0.5 * (d["A"] + d["B"].value)
             if numpy.any(dr < dAB):
-                print(dr[dr<dAB])
-            self.assertTrue(numpy.all(dr > dAB-self.tol))
+                print(dr[dr < dAB])
+            self.assertTrue(numpy.all(dr > dAB - self.tol))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -3,81 +3,81 @@ import unittest
 
 import relentless
 
+
 class test_FixedKeyDict(unittest.TestCase):
     """Unit tests for relentless.collections.FixedKeyDict."""
 
     def test_init(self):
         """Test construction with different list keys."""
-        keys = ('A','B')
-        default = {'A':1.0, 'B':1.0}
+        keys = ("A", "B")
 
         # test construction with tuple input
-        d = relentless.collections.FixedKeyDict(keys=('A','B'))
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"))
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         # test construction with list input
-        d = relentless.collections.FixedKeyDict(keys=['A','B'])
+        d = relentless.collections.FixedKeyDict(keys=["A", "B"])
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         # test construction with defined default input
-        d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"), default=1.0)
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         # test construction with single-key tuple input
-        keys = ('A',)
-        d = relentless.collections.FixedKeyDict(keys=('A',))
+        keys = ("A",)
+        d = relentless.collections.FixedKeyDict(keys=("A",))
         self.assertCountEqual(d.keys(), keys)
         self.assertEqual([d[k] for k in d.keys()], [None])
 
     def test_accessors(self):
         """Test get and set methods on keys."""
-        d = relentless.collections.FixedKeyDict(keys=('A','B'))
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"))
 
         # test setting and getting values
-        d['A'] = 1.0
+        d["A"] = 1.0
         self.assertEqual([d[k] for k in d.keys()], [1.0, None])
-        d['B'] = 1.0
+        d["B"] = 1.0
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         # test re-setting and getting values
-        d['A'] = 2.0
+        d["A"] = 2.0
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
-        d['B'] = 1.5
+        d["B"] = 1.5
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
         # test getting invalid key
         with self.assertRaises(KeyError):
-            x = d['C']
+            d["C"]
 
     def test_update(self):
         """Test update method to get and set keys."""
-        d = relentless.collections.FixedKeyDict(keys=('A','B'))
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"))
 
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         # test updating both keys
-        d.update({'A':1.0, 'B':2.0}) # using dict
+        d.update({"A": 1.0, "B": 2.0})  # using dict
         self.assertEqual([d[k] for k in d.keys()], [1.0, 2.0])
 
-        d.update(A=1.5, B=2.5) # using kwargs
+        d.update(A=1.5, B=2.5)  # using kwargs
         self.assertEqual([d[k] for k in d.keys()], [1.5, 2.5])
 
         # test updating only one key at a time
-        d.update({'A':1.1}) # using dict
+        d.update({"A": 1.1})  # using dict
         self.assertEqual([d[k] for k in d.keys()], [1.1, 2.5])
 
-        d.update(B=2.2) # using kwargs
+        d.update(B=2.2)  # using kwargs
         self.assertEqual([d[k] for k in d.keys()], [1.1, 2.2])
 
         # test using *args length > 1
         with self.assertRaises(TypeError):
-            d.update({'A':3.0}, {'B':4.0})
+            d.update({"A": 3.0}, {"B": 4.0})
 
         # test using both *args and **kwargs
-        d.update({'A':3.0, 'B':2.0}, B=2.2)
+        d.update({"A": 3.0, "B": 2.0}, B=2.2)
         self.assertEqual([d[k] for k in d.keys()], [3.0, 2.2])
 
         # test using invalid kwarg
@@ -87,7 +87,7 @@ class test_FixedKeyDict(unittest.TestCase):
     def test_clear(self):
         """Test clear method to reset keys to default."""
         # test clear with no default set
-        d = relentless.collections.FixedKeyDict(keys=('A','B'))
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"))
         self.assertEqual([d[k] for k in d.keys()], [None, None])
         d.update(A=2, B=3)
         self.assertEqual([d[k] for k in d.keys()], [2.0, 3.0])
@@ -95,7 +95,7 @@ class test_FixedKeyDict(unittest.TestCase):
         self.assertEqual([d[k] for k in d.keys()], [None, None])
 
         # test clear with set default
-        d = relentless.collections.FixedKeyDict(keys=('A','B'), default=1.0)
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"), default=1.0)
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
         d.update(A=2, B=3)
         self.assertEqual([d[k] for k in d.keys()], [2.0, 3.0])
@@ -104,7 +104,7 @@ class test_FixedKeyDict(unittest.TestCase):
 
     def test_iteration(self):
         """Test iteration on the dictionary."""
-        d = relentless.collections.FixedKeyDict(keys=('A','B'))
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"))
 
         # test iteration for setting values
         for k in d:
@@ -112,9 +112,9 @@ class test_FixedKeyDict(unittest.TestCase):
         self.assertEqual([d[k] for k in d.keys()], [1.0, 1.0])
 
         # test manual re-setting of values
-        d['A'] = 2.0
+        d["A"] = 2.0
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.0])
-        d['B'] = 1.5
+        d["B"] = 1.5
         self.assertEqual([d[k] for k in d.keys()], [2.0, 1.5])
 
         # test iteration for re-setting values
@@ -124,142 +124,144 @@ class test_FixedKeyDict(unittest.TestCase):
 
     def test_copy(self):
         """Test copying custom dict to standard dict."""
-        d = relentless.collections.FixedKeyDict(keys=('A','B'))
+        d = relentless.collections.FixedKeyDict(keys=("A", "B"))
 
         # test copying for empty dict
-        dict_var = {'A':None, 'B':None}
+        dict_var = {"A": None, "B": None}
         self.assertEqual(dict(d), dict_var)
 
         # test copying for partially filled dict
-        dict_var = {'A':None, 'B':1.0}
-        d['B'] = 1.0
+        dict_var = {"A": None, "B": 1.0}
+        d["B"] = 1.0
         self.assertEqual(dict(d), dict_var)
 
         # test copying for full dict
-        dict_var = {'A':1.0, 'B':1.0}
-        d['A'] = 1.0
+        dict_var = {"A": 1.0, "B": 1.0}
+        d["A"] = 1.0
         self.assertEqual(dict(d), dict_var)
+
 
 class test_PairMatrix(unittest.TestCase):
     """Unit tests for relentless.collections.PairMatrix."""
 
     def test_init(self):
         """Test construction with different list types."""
-        types = ('A','B')
-        pairs  = (('A','B'), ('B','B'), ('A','A'))
+        types = ("A", "B")
+        pairs = (("A", "B"), ("B", "B"), ("A", "A"))
 
         # test construction with tuple input
-        m = relentless.collections.PairMatrix(types=('A','B'))
+        m = relentless.collections.PairMatrix(types=("A", "B"))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
         # test construction with list input
-        m = relentless.collections.PairMatrix(types=['A','B'])
+        m = relentless.collections.PairMatrix(types=["A", "B"])
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
-        types = ('A',)
-        pairs = (('A','A'),)
+        types = ("A",)
+        pairs = (("A", "A"),)
 
         # test construction with single type tuple
-        m = relentless.collections.PairMatrix(types=('A',))
+        m = relentless.collections.PairMatrix(types=("A",))
         self.assertEqual(m.types, types)
         self.assertCountEqual(m.pairs, pairs)
 
         # test construction with int type input
         with self.assertRaises(TypeError):
-            m = relentless.collections.PairMatrix(types=(1,2))
+            m = relentless.collections.PairMatrix(types=(1, 2))
 
         # test construction with mixed type input
         with self.assertRaises(TypeError):
-            m = relentless.collections.PairMatrix(types=('1',2))
+            m = relentless.collections.PairMatrix(types=("1", 2))
 
     def test_accessors(self):
         """Test get and set methods on pairs."""
-        m = relentless.collections.PairMatrix(types=('A','B'))
+        m = relentless.collections.PairMatrix(types=("A", "B"))
 
         # test set and get for each pair type
-        m['A','A']['energy'] = 1.0
-        self.assertEqual(m['A','A']['energy'], 1.0)
-        self.assertEqual(m['A','B'], {})
-        self.assertEqual(m['B','B'], {})
+        m["A", "A"]["energy"] = 1.0
+        self.assertEqual(m["A", "A"]["energy"], 1.0)
+        self.assertEqual(m["A", "B"], {})
+        self.assertEqual(m["B", "B"], {})
 
-        m['A','B']['energy'] = -1.0
-        self.assertEqual(m['A','A']['energy'], 1.0)
-        self.assertEqual(m['A','B']['energy'], -1.0)
-        self.assertEqual(m['B','B'], {})
+        m["A", "B"]["energy"] = -1.0
+        self.assertEqual(m["A", "A"]["energy"], 1.0)
+        self.assertEqual(m["A", "B"]["energy"], -1.0)
+        self.assertEqual(m["B", "B"], {})
 
-        m['B','B']['energy'] = 1.0
-        self.assertEqual(m['A','A']['energy'], 1.0)
-        self.assertEqual(m['A','B']['energy'], -1.0)
-        self.assertEqual(m['B','B']['energy'], 1.0)
+        m["B", "B"]["energy"] = 1.0
+        self.assertEqual(m["A", "A"]["energy"], 1.0)
+        self.assertEqual(m["A", "B"]["energy"], -1.0)
+        self.assertEqual(m["B", "B"]["energy"], 1.0)
 
         # test key order equality
-        self.assertEqual(m['A','B'], m['B','A'])
+        self.assertEqual(m["A", "B"], m["B", "A"])
 
         # test re-set and get
-        m['A','A']['energy'] = 2.0
-        self.assertEqual(m['A','A']['energy'], 2.0)
-        self.assertEqual(m['A','B']['energy'], -1.0)
-        self.assertEqual(m['B','B']['energy'], 1.0)
+        m["A", "A"]["energy"] = 2.0
+        self.assertEqual(m["A", "A"]["energy"], 2.0)
+        self.assertEqual(m["A", "B"]["energy"], -1.0)
+        self.assertEqual(m["B", "B"]["energy"], 1.0)
 
-        m['A','B']['energy'] = -1.5
-        self.assertEqual(m['A','A']['energy'], 2.0)
-        self.assertEqual(m['A','B']['energy'], -1.5)
-        self.assertEqual(m['B','B']['energy'], 1.0)
+        m["A", "B"]["energy"] = -1.5
+        self.assertEqual(m["A", "A"]["energy"], 2.0)
+        self.assertEqual(m["A", "B"]["energy"], -1.5)
+        self.assertEqual(m["B", "B"]["energy"], 1.0)
 
-        m['B','B']['energy'] = 0.0
-        self.assertEqual(m['A','A']['energy'], 2.0)
-        self.assertEqual(m['A','B']['energy'], -1.5)
-        self.assertEqual(m['B','B']['energy'], 0.0)
+        m["B", "B"]["energy"] = 0.0
+        self.assertEqual(m["A", "A"]["energy"], 2.0)
+        self.assertEqual(m["A", "B"]["energy"], -1.5)
+        self.assertEqual(m["B", "B"]["energy"], 0.0)
 
         # test setting multiple parameters and get
-        m['A','A']['mass'] = 1.0
-        self.assertEqual(m['A','A']['mass'], 1.0)
-        self.assertEqual(m['A','A']['energy'], 2.0)
-        self.assertEqual(m['A','A'], {'energy':2.0, 'mass':1.0})
+        m["A", "A"]["mass"] = 1.0
+        self.assertEqual(m["A", "A"]["mass"], 1.0)
+        self.assertEqual(m["A", "A"]["energy"], 2.0)
+        self.assertEqual(m["A", "A"], {"energy": 2.0, "mass": 1.0})
 
-        m['A','B']['mass'] = 3.0
-        self.assertEqual(m['A','B']['mass'], 3.0)
-        self.assertEqual(m['A','B']['energy'], -1.5)
-        self.assertEqual(m['A','B'], {'energy':-1.5, 'mass':3.0})
+        m["A", "B"]["mass"] = 3.0
+        self.assertEqual(m["A", "B"]["mass"], 3.0)
+        self.assertEqual(m["A", "B"]["energy"], -1.5)
+        self.assertEqual(m["A", "B"], {"energy": -1.5, "mass": 3.0})
 
-        m['B','B']['mass'] = 5.0
-        self.assertEqual(m['B','B']['mass'], 5.0)
-        self.assertEqual(m['B','B']['energy'], 0.0)
-        self.assertEqual(m['B','B'], {'energy':0.0, 'mass':5.0})
+        m["B", "B"]["mass"] = 5.0
+        self.assertEqual(m["B", "B"]["mass"], 5.0)
+        self.assertEqual(m["B", "B"]["energy"], 0.0)
+        self.assertEqual(m["B", "B"], {"energy": 0.0, "mass": 5.0})
 
         # test setting paramters for invalid keys
         with self.assertRaises(KeyError):
-            x = m['C','C']
+            m["C", "C"]
         with self.assertRaises(KeyError):
-            x = m['A','C']
+            m["A", "C"]
 
     def test_iteration(self):
         """Test iteration on the matrix."""
-        m = relentless.collections.PairMatrix(types=('A','B'))
+        m = relentless.collections.PairMatrix(types=("A", "B"))
 
         # test iteration for initialization
         for pair in m:
-            m[pair]['mass'] = 2.0
-            m[pair]['energy'] = 1.0
-        self.assertEqual(m['A','B'], {'energy':1.0, 'mass':2.0})
-        self.assertEqual(m['A','A'], {'energy':1.0, 'mass':2.0})
-        self.assertEqual(m['B','B'], {'energy':1.0, 'mass':2.0})
+            m[pair]["mass"] = 2.0
+            m[pair]["energy"] = 1.0
+        self.assertEqual(m["A", "B"], {"energy": 1.0, "mass": 2.0})
+        self.assertEqual(m["A", "A"], {"energy": 1.0, "mass": 2.0})
+        self.assertEqual(m["B", "B"], {"energy": 1.0, "mass": 2.0})
 
         # test resetting values manually
-        m['A','B']['mass'] = 2.5
-        m['A','A']['energy'] = 1.5
-        self.assertEqual(m['A','B'], {'energy':1.0, 'mass':2.5})
-        self.assertEqual(m['A','A'], {'energy':1.5, 'mass':2.0})
-        self.assertEqual(m['B','B'], {'energy':1.0, 'mass':2.0})
+        m["A", "B"]["mass"] = 2.5
+        m["A", "A"]["energy"] = 1.5
+        self.assertEqual(m["A", "B"], {"energy": 1.0, "mass": 2.5})
+        self.assertEqual(m["A", "A"], {"energy": 1.5, "mass": 2.0})
+        self.assertEqual(m["B", "B"], {"energy": 1.0, "mass": 2.0})
 
         # test re-iteration for setting values
         for pair in m:
-            m[pair]['energy'] = 3.0
-        self.assertEqual(m['A','B'], {'energy':3.0, 'mass':2.5})
-        self.assertEqual(m['A','A'], {'energy':3.0, 'mass':2.0})
-        self.assertEqual(m['B','B'], {'energy':3.0, 'mass':2.0})
+            m[pair]["energy"] = 3.0
+        self.assertEqual(m["A", "B"], {"energy": 3.0, "mass": 2.5})
+        self.assertEqual(m["A", "A"], {"energy": 3.0, "mass": 2.0})
+        self.assertEqual(m["B", "B"], {"energy": 3.0, "mass": 2.0})
+
 
 class test_DefaultDict(unittest.TestCase):
     """Unit tests for relentless.collections.DefaultDict"""
@@ -269,31 +271,32 @@ class test_DefaultDict(unittest.TestCase):
         # instantiation
         d = relentless.collections.DefaultDict(default=1.0)
         self.assertAlmostEqual(d.default, 1.0)
-        self.assertAlmostEqual(d['A'], 1.0)
-        self.assertAlmostEqual(d['B'], 1.0)
+        self.assertAlmostEqual(d["A"], 1.0)
+        self.assertAlmostEqual(d["B"], 1.0)
         self.assertEqual(len(d), 0)
 
         # set individually
-        d['A'] = 2.0
+        d["A"] = 2.0
         self.assertAlmostEqual(d.default, 1.0)
-        self.assertAlmostEqual(d['A'], 2.0)
-        self.assertAlmostEqual(d['B'], 1.0)
+        self.assertAlmostEqual(d["A"], 2.0)
+        self.assertAlmostEqual(d["B"], 1.0)
         self.assertEqual(len(d), 1)
 
         # delete
-        del d['A']
+        del d["A"]
         self.assertAlmostEqual(d.default, 1.0)
-        self.assertAlmostEqual(d['A'], 1.0)
-        self.assertAlmostEqual(d['B'], 1.0)
+        self.assertAlmostEqual(d["A"], 1.0)
+        self.assertAlmostEqual(d["B"], 1.0)
         self.assertEqual(len(d), 0)
 
         # iterate
-        for key in ('A','B'):
+        for key in ("A", "B"):
             d[key] = 2.5
         self.assertAlmostEqual(d.default, 1.0)
-        self.assertAlmostEqual(d['A'], 2.5)
-        self.assertAlmostEqual(d['B'], 2.5)
+        self.assertAlmostEqual(d["A"], 2.5)
+        self.assertAlmostEqual(d["B"], 2.5)
         self.assertEqual(len(d), 2)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,6 +6,7 @@ import unittest
 
 import relentless
 
+
 class test_Directory(unittest.TestCase):
     def setUp(self):
         if relentless.mpi.world.rank_is_root:
@@ -17,6 +18,7 @@ class test_Directory(unittest.TestCase):
         self.real_f = os.path.realpath(self.f)
 
     """Unit tests for core.data.Directory."""
+
     def test_init(self):
         """Test basic creation and methods of Directory."""
         cwd = os.getcwd()
@@ -32,7 +34,7 @@ class test_Directory(unittest.TestCase):
         self.assertEqual(d._start, [])
 
         # test creation with non-existent path (absolute)
-        foo = os.path.join(self.f,'foo')
+        foo = os.path.join(self.f, "foo")
         real_foo = os.path.realpath(foo)
         d1 = relentless.data.Directory(foo)
         self.assertEqual(d1.path, real_foo)
@@ -44,7 +46,7 @@ class test_Directory(unittest.TestCase):
         self.assertEqual(d1._start, [])
 
         # test creation with non-existent path (recursive)
-        foobar = os.path.join(self.f,'bar','foobar')
+        foobar = os.path.join(self.f, "bar", "foobar")
         real_foobar = os.path.realpath(foobar)
         d2 = relentless.data.Directory(foobar)
         self.assertEqual(d2.path, real_foobar)
@@ -64,7 +66,7 @@ class test_Directory(unittest.TestCase):
             x_name = None
         x_name = relentless.mpi.world.bcast(x_name)
         with self.assertRaises(OSError):
-            d3 = relentless.data.Directory(x_name)
+            relentless.data.Directory(x_name)
         if x is not None:
             x.close()
 
@@ -74,12 +76,12 @@ class test_Directory(unittest.TestCase):
             with d1:
                 self.assertEqual(d1._start, [d.path])
                 with d1:
-                    self.assertEqual(d1._start, [d.path,d1.path])
+                    self.assertEqual(d1._start, [d.path, d1.path])
                 self.assertEqual(d1._start, [d.path])
                 with d2:
                     self.assertEqual(d2._start, [d1.path])
                     with d2:
-                        self.assertEqual(d2._start, [d1.path,d2.path])
+                        self.assertEqual(d2._start, [d1.path, d2.path])
                     self.assertEqual(d2._start, [d1.path])
                 self.assertEqual(d2._start, [])
             self.assertEqual(d1._start, [])
@@ -94,123 +96,123 @@ class test_Directory(unittest.TestCase):
                     shutil.rmtree(foobar)
                 relentless.mpi.world.barrier()
             self.assertEqual(d1._start, [])
-            self.assertEqual(os.getcwd(), d1.path) # no exit
+            self.assertEqual(os.getcwd(), d1.path)  # no exit
 
     def test_context(self):
         """Test context methods for Directory."""
         # create nested directory structure
         d = relentless.data.Directory(self.f)
-        d1 = d.directory('foo')
-        d2 = d.directory('bar')
-        d3 = d1.directory(os.path.join('bar','foobar'))
+        d1 = d.directory("foo")
+        d2 = d.directory("bar")
+        d3 = d1.directory(os.path.join("bar", "foobar"))
         self.assertEqual(d.path, self.real_f)
-        self.assertEqual(d1.path, os.path.join(self.real_f,'foo'))
-        self.assertEqual(d2.path, os.path.join(self.real_f,'bar'))
-        self.assertEqual(d3.path, os.path.join(self.real_f,'foo','bar','foobar'))
+        self.assertEqual(d1.path, os.path.join(self.real_f, "foo"))
+        self.assertEqual(d2.path, os.path.join(self.real_f, "bar"))
+        self.assertEqual(d3.path, os.path.join(self.real_f, "foo", "bar", "foobar"))
 
         # test creating files
-        x = d.file('spam.txt')
-        x1 = d1.file('ham.txt')
-        x2 = d1.file('eggs.txt')
-        x3 = d3.file('baz.txt')
+        x = d.file("spam.txt")
+        x1 = d1.file("ham.txt")
+        x2 = d1.file("eggs.txt")
+        x3 = d3.file("baz.txt")
         if relentless.mpi.world.rank_is_root:
-            open(x,'w').close()
-            open(x1,'w').close()
-            open(x2,'w').close()
-            open(x3,'w').close()
+            open(x, "w").close()
+            open(x1, "w").close()
+            open(x2, "w").close()
+            open(x3, "w").close()
         relentless.mpi.world.barrier()
-        self.assertEqual(os.path.abspath(x), os.path.join(d.path,'spam.txt'))
-        self.assertEqual(os.path.abspath(x1), os.path.join(d1.path,'ham.txt'))
-        self.assertEqual(os.path.abspath(x2), os.path.join(d1.path,'eggs.txt'))
-        self.assertEqual(os.path.abspath(x3), os.path.join(d3.path,'baz.txt'))
+        self.assertEqual(os.path.abspath(x), os.path.join(d.path, "spam.txt"))
+        self.assertEqual(os.path.abspath(x1), os.path.join(d1.path, "ham.txt"))
+        self.assertEqual(os.path.abspath(x2), os.path.join(d1.path, "eggs.txt"))
+        self.assertEqual(os.path.abspath(x3), os.path.join(d3.path, "baz.txt"))
 
         # test clearing directory structure
         # delete sub-directory
-        self.assertCountEqual(os.listdir(d1.path), ['bar','ham.txt','eggs.txt'])
-        self.assertCountEqual(os.listdir(d3.path), ['baz.txt'])
+        self.assertCountEqual(os.listdir(d1.path), ["bar", "ham.txt", "eggs.txt"])
+        self.assertCountEqual(os.listdir(d3.path), ["baz.txt"])
         d3.clear_contents()
-        self.assertCountEqual(os.listdir(d1.path), ['bar','ham.txt','eggs.txt'])
+        self.assertCountEqual(os.listdir(d1.path), ["bar", "ham.txt", "eggs.txt"])
         self.assertCountEqual(os.listdir(d3.path), [])
         # delete parent directory
-        self.assertCountEqual(os.listdir(d.path), ['foo','bar','spam.txt'])
+        self.assertCountEqual(os.listdir(d.path), ["foo", "bar", "spam.txt"])
         d.clear_contents()
         self.assertCountEqual(os.listdir(d.path), [])
 
     def test_path(self):
         # set path by constructor
-        foo = os.path.join(self.f,'foo')
+        foo = os.path.join(self.f, "foo")
         real_foo = os.path.realpath(foo)
         d = relentless.data.Directory(foo)
         self.assertEqual(d.path, real_foo)
         self.assertTrue(os.path.exists(foo))
 
     def test_move_contents(self):
-        foo = os.path.join(self.f,'foo')
-        bar = os.path.join(self.f,'bar')
-        baz = os.path.join(self.f,'baz')
+        foo = os.path.join(self.f, "foo")
+        bar = os.path.join(self.f, "bar")
+        baz = os.path.join(self.f, "baz")
 
         dfoo = relentless.data.Directory(foo)
         dbar = relentless.data.Directory(bar)
 
         # create a file and directory in foo, it is not yet in bar
         if relentless.mpi.world.rank_is_root:
-            open(dfoo.file('spam.txt'),'w').close()
+            open(dfoo.file("spam.txt"), "w").close()
         relentless.mpi.world.barrier()
-        dfoo.directory('fizz')
-        self.assertTrue(os.path.isfile(os.path.join(foo,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(foo,'fizz')))
-        self.assertFalse(os.path.isfile(os.path.join(bar,'spam.txt')))
-        self.assertFalse(os.path.isdir(os.path.join(bar,'fizz')))
+        dfoo.directory("fizz")
+        self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertFalse(os.path.isfile(os.path.join(bar, "spam.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(bar, "fizz")))
 
         # move to bar
         dfoo.move_contents(dbar)
-        self.assertFalse(os.path.isfile(os.path.join(foo,'spam.txt')))
-        self.assertFalse(os.path.isdir(os.path.join(foo,'fizz')))
-        self.assertTrue(os.path.isfile(os.path.join(bar,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(bar,'fizz')))
+        self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(bar, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(bar, "fizz")))
 
         # move to baz (doesn't exist as Directory yet)
         dbar.move_contents(baz)
-        self.assertFalse(os.path.isfile(os.path.join(foo,'spam.txt')))
-        self.assertFalse(os.path.isdir(os.path.join(foo,'fizz')))
-        self.assertFalse(os.path.isfile(os.path.join(bar,'spam.txt')))
-        self.assertFalse(os.path.isdir(os.path.join(bar,'fizz')))
-        self.assertTrue(os.path.isfile(os.path.join(baz,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(baz,'fizz')))
+        self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertFalse(os.path.isfile(os.path.join(bar, "spam.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(bar, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
 
     def test_copy_contents(self):
-        foo = os.path.join(self.f,'foo')
-        bar = os.path.join(self.f,'bar')
-        baz = os.path.join(self.f,'baz')
+        foo = os.path.join(self.f, "foo")
+        bar = os.path.join(self.f, "bar")
+        baz = os.path.join(self.f, "baz")
 
         dfoo = relentless.data.Directory(foo)
         dbar = relentless.data.Directory(bar)
 
         # create a file and directory in foo, it is not yet in bar
         if relentless.mpi.world.rank_is_root:
-            open(dfoo.file('spam.txt'),'w').close()
+            open(dfoo.file("spam.txt"), "w").close()
         relentless.mpi.world.barrier()
-        dfoo.directory('fizz')
-        self.assertTrue(os.path.isfile(os.path.join(foo,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(foo,'fizz')))
-        self.assertFalse(os.path.isfile(os.path.join(bar,'spam.txt')))
-        self.assertFalse(os.path.isdir(os.path.join(bar,'fizz')))
+        dfoo.directory("fizz")
+        self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertFalse(os.path.isfile(os.path.join(bar, "spam.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(bar, "fizz")))
 
         # copy to bar
         dfoo.copy_contents(dbar)
-        self.assertTrue(os.path.isfile(os.path.join(foo,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(foo,'fizz')))
-        self.assertTrue(os.path.isfile(os.path.join(bar,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(bar,'fizz')))
+        self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(bar, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(bar, "fizz")))
 
         # copy to baz (doesn't exist as Directory yet)
         dfoo.copy_contents(baz)
-        self.assertTrue(os.path.isfile(os.path.join(foo,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(foo,'fizz')))
-        self.assertTrue(os.path.isfile(os.path.join(bar,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(bar,'fizz')))
-        self.assertTrue(os.path.isfile(os.path.join(baz,'spam.txt')))
-        self.assertTrue(os.path.isdir(os.path.join(baz,'fizz')))
+        self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(bar, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(bar, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
 
     def tearDown(self):
         if relentless.mpi.world.rank_is_root:
@@ -218,5 +220,6 @@ class test_Directory(unittest.TestCase):
             del self._tmp
         self.real_f = None
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -5,27 +5,29 @@ import numpy
 
 import relentless
 
+
 class test_Interpolator(unittest.TestCase):
     """Unit tests for relentless.math.Interpolator."""
 
     def test_init(self):
         """Test creation from data."""
         # test construction with tuple input
-        f = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
-        self.assertEqual(f.domain, (-1,1))
+        f = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
+        self.assertEqual(f.domain, (-1, 1))
 
         # test construction with list input
-        f = relentless.math.Interpolator(x=[-1,0,1], y=[-2,0,2])
-        self.assertEqual(f.domain, (-1,1))
+        f = relentless.math.Interpolator(x=[-1, 0, 1], y=[-2, 0, 2])
+        self.assertEqual(f.domain, (-1, 1))
 
         # test construction with numpy array input
-        f = relentless.math.Interpolator(x=numpy.array([-1,0,1]),
-                                         y=numpy.array([-2,0,2]))
-        self.assertEqual(f.domain, (-1,1))
+        f = relentless.math.Interpolator(
+            x=numpy.array([-1, 0, 1]), y=numpy.array([-2, 0, 2])
+        )
+        self.assertEqual(f.domain, (-1, 1))
 
         # test construction with mixed input
-        f = relentless.math.Interpolator(x=[-1,0,1], y=(-2,0,2))
-        self.assertEqual(f.domain, (-1,1))
+        f = relentless.math.Interpolator(x=[-1, 0, 1], y=(-2, 0, 2))
+        self.assertEqual(f.domain, (-1, 1))
 
         # test construction with scalar input
         with self.assertRaises(ValueError):
@@ -33,43 +35,45 @@ class test_Interpolator(unittest.TestCase):
 
         # test construction with 2d-array input
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(x=numpy.array([[-1,0,1], [-2,2,4]]),
-                                             y=numpy.array([[-1,0,1], [-2,2,4]]))
+            f = relentless.math.Interpolator(
+                x=numpy.array([[-1, 0, 1], [-2, 2, 4]]),
+                y=numpy.array([[-1, 0, 1], [-2, 2, 4]]),
+            )
 
         # test construction with x and y having different lengths
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(x=[-1,0], y=[-2,0,2])
+            f = relentless.math.Interpolator(x=[-1, 0], y=[-2, 0, 2])
 
         # test construction with non-strictly-increasing domain
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(x=(0,1,-1), y=(0,2,-2))
+            f = relentless.math.Interpolator(x=(0, 1, -1), y=(0, 2, -2))
 
     def test_call(self):
         """Test calls, both scalar and array."""
-        f = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        f = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
 
         # test scalar call
         self.assertAlmostEqual(f(-0.5), -1.0)
         self.assertAlmostEqual(f(0.5), 1.0)
 
         # test array call
-        numpy.testing.assert_allclose(f([-0.5,0.5]), [-1.0,1.0])
+        numpy.testing.assert_allclose(f([-0.5, 0.5]), [-1.0, 1.0])
 
     def test_derivative(self):
         """Test derivative function, both scalar and array."""
-        f = relentless.math.Interpolator(x=(-2,-1,0,1,2), y=(4,1,0,1,4))
+        f = relentless.math.Interpolator(x=(-2, -1, 0, 1, 2), y=(4, 1, 0, 1, 4))
 
         # test scalar call
         d = f.derivative(x=1.5, n=1)
         self.assertAlmostEqual(d, 3.0)
 
         # test array call
-        d = f.derivative(x=numpy.array([-3.0,-0.5,0.5,3.0]), n=1)
-        numpy.testing.assert_allclose(d, numpy.array([0.0,-1.0,1.0,0.0]))
+        d = f.derivative(x=numpy.array([-3.0, -0.5, 0.5, 3.0]), n=1)
+        numpy.testing.assert_allclose(d, numpy.array([0.0, -1.0, 1.0, 0.0]))
 
     def test_extrap(self):
         """Test extrapolation calls."""
-        f = relentless.math.Interpolator(x=(-1,0,1), y=(-2,0,2))
+        f = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
 
         # test extrap below lo
         self.assertAlmostEqual(f(-2), -2.0)
@@ -78,46 +82,47 @@ class test_Interpolator(unittest.TestCase):
         self.assertAlmostEqual(f(2), 2.0)
 
         # test extrap below low and above hi
-        numpy.testing.assert_allclose(f([-2,2]), [-2.0,2.0])
+        numpy.testing.assert_allclose(f([-2, 2]), [-2.0, 2.0])
 
         # test combined extrapolation and interpolation
-        numpy.testing.assert_allclose(f([-2,0.5,2]), [-2.0,1.0,2.0])
+        numpy.testing.assert_allclose(f([-2, 0.5, 2]), [-2.0, 1.0, 2.0])
+
 
 class test_KeyedArray(unittest.TestCase):
     """Unit tests for relentless.math.KeyedArray."""
 
     def test_init(self):
         """Test construction with data."""
-        k = relentless.math.KeyedArray(keys=('A','B'))
-        self.assertEqual(dict(k), {'A':None, 'B':None})
+        k = relentless.math.KeyedArray(keys=("A", "B"))
+        self.assertEqual(dict(k), {"A": None, "B": None})
 
-        k = relentless.math.KeyedArray(keys=('A','B'), default=2.0)
-        self.assertEqual(dict(k), {'A':2.0, 'B':2.0})
+        k = relentless.math.KeyedArray(keys=("A", "B"), default=2.0)
+        self.assertEqual(dict(k), {"A": 2.0, "B": 2.0})
 
         # invalid key
         with self.assertRaises(KeyError):
-            x = k['C']
+            k["C"]
 
     def test_arithmetic_ops(self):
         """Test arithmetic operations."""
-        k1 = relentless.math.KeyedArray(keys=('A','B'))
-        k1.update({'A':1.0, 'B':2.0})
-        k2 = relentless.math.KeyedArray(keys=('A','B'))
-        k2.update({'A':2.0, 'B':3.0})
-        k3 = relentless.math.KeyedArray(keys=('A','B','C'))
-        k3.update({'A':3.0, 'B':4.0, 'C':5.0})
+        k1 = relentless.math.KeyedArray(keys=("A", "B"))
+        k1.update({"A": 1.0, "B": 2.0})
+        k2 = relentless.math.KeyedArray(keys=("A", "B"))
+        k2.update({"A": 2.0, "B": 3.0})
+        k3 = relentless.math.KeyedArray(keys=("A", "B", "C"))
+        k3.update({"A": 3.0, "B": 4.0, "C": 5.0})
 
         # addition
         k4 = k1 + k2
-        self.assertEqual(dict(k4), {'A':3.0, 'B':5.0})
+        self.assertEqual(dict(k4), {"A": 3.0, "B": 5.0})
         k4 += k2
-        self.assertEqual(dict(k4), {'A':5.0, 'B':8.0})
+        self.assertEqual(dict(k4), {"A": 5.0, "B": 8.0})
         k4 = k1 + 1
-        self.assertEqual(dict(k4), {'A':2.0, 'B':3.0})
+        self.assertEqual(dict(k4), {"A": 2.0, "B": 3.0})
         k4 = 2 + k1
-        self.assertEqual(dict(k4), {'A':3.0, 'B':4.0})
+        self.assertEqual(dict(k4), {"A": 3.0, "B": 4.0})
         k4 += 1
-        self.assertEqual(dict(k4), {'A':4.0, 'B':5.0})
+        self.assertEqual(dict(k4), {"A": 4.0, "B": 5.0})
         with self.assertRaises(KeyError):
             k4 = k1 + k3
         with self.assertRaises(KeyError):
@@ -125,66 +130,66 @@ class test_KeyedArray(unittest.TestCase):
 
         # subtraction
         k4 = k1 - k2
-        self.assertEqual(dict(k4), {'A':-1.0, 'B':-1.0})
+        self.assertEqual(dict(k4), {"A": -1.0, "B": -1.0})
         k4 -= k2
-        self.assertEqual(dict(k4), {'A':-3.0, 'B':-4.0})
+        self.assertEqual(dict(k4), {"A": -3.0, "B": -4.0})
         k4 = k1 - 1
-        self.assertEqual(dict(k4), {'A':0.0, 'B':1.0})
+        self.assertEqual(dict(k4), {"A": 0.0, "B": 1.0})
         k4 = 2 - k1
-        self.assertEqual(dict(k4), {'A':1.0, 'B':0.0})
+        self.assertEqual(dict(k4), {"A": 1.0, "B": 0.0})
         k4 -= 1
-        self.assertEqual(dict(k4), {'A':0.0, 'B':-1.0})
+        self.assertEqual(dict(k4), {"A": 0.0, "B": -1.0})
         with self.assertRaises(KeyError):
             k4 = k1 - k3
         with self.assertRaises(KeyError):
             k3 -= k2
 
         # multiplication
-        k4 = k1*k2
-        self.assertEqual(dict(k4), {'A':2.0, 'B':6.0})
+        k4 = k1 * k2
+        self.assertEqual(dict(k4), {"A": 2.0, "B": 6.0})
         k4 *= k2
-        self.assertEqual(dict(k4), {'A':4.0, 'B':18.0})
-        k4 = 3*k1
-        self.assertEqual(dict(k4), {'A':3.0, 'B':6.0})
-        k4 = k2*3
-        self.assertEqual(dict(k4), {'A':6.0, 'B':9.0})
+        self.assertEqual(dict(k4), {"A": 4.0, "B": 18.0})
+        k4 = 3 * k1
+        self.assertEqual(dict(k4), {"A": 3.0, "B": 6.0})
+        k4 = k2 * 3
+        self.assertEqual(dict(k4), {"A": 6.0, "B": 9.0})
         k4 *= 3
-        self.assertEqual(dict(k4), {'A':18.0, 'B':27.0})
+        self.assertEqual(dict(k4), {"A": 18.0, "B": 27.0})
         with self.assertRaises(KeyError):
-            k4 = k1*k3
+            k4 = k1 * k3
 
         # division
-        k4 = k1/k2
-        self.assertEqual(dict(k4), {'A':0.5, 'B':0.6666666666666666})
+        k4 = k1 / k2
+        self.assertEqual(dict(k4), {"A": 0.5, "B": 0.6666666666666666})
         k4 /= k2
-        self.assertEqual(dict(k4), {'A':0.25, 'B':0.2222222222222222})
-        k4 = 2/k2
-        self.assertEqual(dict(k4), {'A':1.0, 'B':0.6666666666666666})
-        k4 = k2/2
-        self.assertEqual(dict(k4), {'A':1.0, 'B':1.5})
+        self.assertEqual(dict(k4), {"A": 0.25, "B": 0.2222222222222222})
+        k4 = 2 / k2
+        self.assertEqual(dict(k4), {"A": 1.0, "B": 0.6666666666666666})
+        k4 = k2 / 2
+        self.assertEqual(dict(k4), {"A": 1.0, "B": 1.5})
         k4 /= 2
-        self.assertEqual(dict(k4), {'A':0.5, 'B':0.75})
+        self.assertEqual(dict(k4), {"A": 0.5, "B": 0.75})
         with self.assertRaises(KeyError):
-            k4 = k1/k3
+            k4 = k1 / k3
 
         # exponentiation
         k4 = k1**k2
-        self.assertEqual(dict(k4), {'A':1.0, 'B':8.0})
+        self.assertEqual(dict(k4), {"A": 1.0, "B": 8.0})
         k4 = k2**2
-        self.assertEqual(dict(k4), {'A':4.0, 'B':9.0})
+        self.assertEqual(dict(k4), {"A": 4.0, "B": 9.0})
 
         # negation
         k4 = -k1
-        self.assertEqual(dict(k4), {'A':-1.0, 'B':-2.0})
+        self.assertEqual(dict(k4), {"A": -1.0, "B": -2.0})
 
     def test_vector_ops(self):
         """Test vector operations."""
-        k1 = relentless.math.KeyedArray(keys=('A','B'))
-        k1.update({'A':1.0, 'B':2.0})
-        k2 = relentless.math.KeyedArray(keys=('A','B'))
-        k2.update({'A':2.0, 'B':3.0})
-        k3 = relentless.math.KeyedArray(keys=('A','B','C'))
-        k3.update({'A':3.0, 'B':4.0, 'C':5.0})
+        k1 = relentless.math.KeyedArray(keys=("A", "B"))
+        k1.update({"A": 1.0, "B": 2.0})
+        k2 = relentless.math.KeyedArray(keys=("A", "B"))
+        k2.update({"A": 2.0, "B": 3.0})
+        k3 = relentless.math.KeyedArray(keys=("A", "B", "C"))
+        k3.update({"A": 3.0, "B": 4.0, "C": 5.0})
 
         # norm
         self.assertAlmostEqual(k1.norm(), numpy.sqrt(5))
@@ -194,7 +199,8 @@ class test_KeyedArray(unittest.TestCase):
         self.assertAlmostEqual(k1.dot(k2), 8.0)
         self.assertAlmostEqual(k1.dot(k2), k2.dot(k1))
         with self.assertRaises(KeyError):
-            k4 = k2.dot(k3)
+            k2.dot(k3)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,17 +1,19 @@
 """Unit tests for mpi module."""
-import unittest
-
 import os
 import tempfile
+import unittest
+
 import numpy
 
 import relentless
+
 try:
     from mpi4py import MPI
 except ImportError:
     pass
 
 has_mpi = relentless.mpi._mpi_running()
+
 
 class test_Communicator(unittest.TestCase):
     def setUp(self):
@@ -23,15 +25,15 @@ class test_Communicator(unittest.TestCase):
             self.assertTrue(self.comm.enabled)
             self.assertEqual(self.comm.size, MPI.COMM_WORLD.Get_size())
             self.assertEqual(self.comm.rank, MPI.COMM_WORLD.Get_rank())
-            self.assertEqual(self.comm.root,0)
+            self.assertEqual(self.comm.root, 0)
         else:
             self.assertTrue(self.comm.comm is None)
             self.assertFalse(self.comm.enabled)
-            self.assertEqual(self.comm.size,1)
-            self.assertEqual(self.comm.rank,0)
-            self.assertEqual(self.comm.root,0)
+            self.assertEqual(self.comm.size, 1)
+            self.assertEqual(self.comm.rank, 0)
+            self.assertEqual(self.comm.root, 0)
 
-    @unittest.skipUnless(has_mpi,"Needs MPI")
+    @unittest.skipUnless(has_mpi, "Needs MPI")
     def test_split(self):
         world = MPI.COMM_WORLD.Dup()
         self.assertTrue(world is not MPI.COMM_WORLD)
@@ -55,62 +57,62 @@ class test_Communicator(unittest.TestCase):
                 x = 7
             else:
                 x = None
-            x = self.comm.bcast(x,root=root)
+            x = self.comm.bcast(x, root=root)
             self.assertEqual(x, 7)
 
     def test_bcast_numpy(self):
         # float array
         if self.comm.rank_is_root:
-            x = numpy.array([1.,2.],dtype=numpy.float64)
+            x = numpy.array([1.0, 2.0], dtype=numpy.float64)
         else:
             x = None
         x = self.comm.bcast_numpy(x)
-        self.assertEqual(x.shape,(2,))
-        self.assertEqual(x.dtype,numpy.float64)
-        numpy.testing.assert_allclose(x,[1.,2.])
+        self.assertEqual(x.shape, (2,))
+        self.assertEqual(x.dtype, numpy.float64)
+        numpy.testing.assert_allclose(x, [1.0, 2.0])
 
         # float array from specified root
         if self.comm.size >= 2:
             root = 1
             if self.comm.rank == root:
-                x = numpy.array([3.,4.],dtype=numpy.float64)
+                x = numpy.array([3.0, 4.0], dtype=numpy.float64)
             else:
                 x = None
-            x = self.comm.bcast_numpy(x,root=root)
-            self.assertEqual(x.shape,(2,))
-            self.assertEqual(x.dtype,numpy.float64)
-            numpy.testing.assert_allclose(x,[3.,4.])
+            x = self.comm.bcast_numpy(x, root=root)
+            self.assertEqual(x.shape, (2,))
+            self.assertEqual(x.dtype, numpy.float64)
+            numpy.testing.assert_allclose(x, [3.0, 4.0])
 
         # prealloc'd float array
         if self.comm.rank_is_root:
-            x = numpy.array([5.,6.],dtype=numpy.float64)
+            x = numpy.array([5.0, 6.0], dtype=numpy.float64)
         else:
-            x = numpy.zeros((2,),dtype=numpy.float64)
+            x = numpy.zeros((2,), dtype=numpy.float64)
         y = self.comm.bcast_numpy(x)
         self.assertTrue(y is x)
-        self.assertEqual(y.shape,(2,))
-        self.assertEqual(y.dtype,numpy.float64)
-        numpy.testing.assert_allclose(y,[5.,6.])
+        self.assertEqual(y.shape, (2,))
+        self.assertEqual(y.dtype, numpy.float64)
+        numpy.testing.assert_allclose(y, [5.0, 6.0])
 
         # incorrectly alloc'd float array
         if self.comm.rank_is_root:
-            x = numpy.array([5.,6.],dtype=numpy.float64)
+            x = numpy.array([5.0, 6.0], dtype=numpy.float64)
         else:
-            x = numpy.zeros((2,),dtype=numpy.int32)
+            x = numpy.zeros((2,), dtype=numpy.int32)
         y = self.comm.bcast_numpy(x)
         if self.comm.rank_is_root:
             self.assertTrue(y is x)
         else:
             self.assertTrue(y is not x)
-        self.assertEqual(y.shape,(2,))
-        self.assertEqual(y.dtype,numpy.float64)
-        numpy.testing.assert_allclose(y,[5.,6.])
+        self.assertEqual(y.shape, (2,))
+        self.assertEqual(y.dtype, numpy.float64)
+        numpy.testing.assert_allclose(y, [5.0, 6.0])
 
     def test_loadtxt(self):
         # create file
         if self.comm.rank_is_root:
             tmp = tempfile.NamedTemporaryFile(delete=False)
-            tmp.write(b'1 2\n 3 4\n')
+            tmp.write(b"1 2\n 3 4\n")
             tmp.close()
             filename = tmp.name
         else:
@@ -124,7 +126,8 @@ class test_Communicator(unittest.TestCase):
         if self.comm.rank_is_root:
             os.unlink(tmp.name)
 
-        numpy.testing.assert_allclose(dat, [[1.,2.],[3.,4.]])
+        numpy.testing.assert_allclose(dat, [[1.0, 2.0], [3.0, 4.0]])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds `pre-commit` to implement automatic code formatting and linting. Once merged, developers can install precommit from `requirements-dev.txt`, then run `pre-commit install` _once_ for the project. This will automatically format code on commits, and it will also run `flake8` linting.

I ran `pre-commit` on all of our files, then resolved all `flake8` errors.

Resolves #98