### PR TITLE
Fix lammpsio to only raise import error when using LAMMPS.

### DIFF
--- a/relentless/simulate/lammps.py
+++ b/relentless/simulate/lammps.py
@@ -19,7 +19,6 @@ To implement your own LAMMPS operation, create an operation that derives from
 import abc
 import uuid
 
-import lammpsio
 import numpy
 
 from relentless import mpi
@@ -33,6 +32,13 @@ try:
     _lammps_found = True
 except ImportError:
     _lammps_found = False
+
+try:
+    import lammpsio
+
+    _lammpsio_found = True
+except ImportError:
+    _lammpsio_found = False
 
 
 class LAMMPSOperation(simulate.SimulationOperation):
@@ -846,6 +852,9 @@ class LAMMPS(simulate.Simulation):
     def __init__(self, initializer, operations=None, dimension=3, quiet=True):
         if not _lammps_found:
             raise ImportError("LAMMPS not found.")
+
+        if not _lammpsio_found:
+            raise ImportError("lammpsio not found.")
 
         super().__init__(initializer, operations)
         self.dimension = dimension

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -8,15 +8,22 @@ try:
     import lammps
 except ImportError:
     pass
-import lammpsio
+
+try:
+    import lammpsio
+except ImportError:
+    pass
 
 import relentless
 from tests.model.potential.test_pair import LinPot
 
-
-@unittest.skipIf(
-    not relentless.simulate.lammps._lammps_found, "Compatible LAMMPS not installed"
+_has_modules = (
+    relentless.simulate.lammps._lammps_found
+    and relentless.simulate.lammps._lammpsio_found
 )
+
+
+@unittest.skipIf(not _has_modules, "Compatible LAMMPS and/or lammpsio not installed")
 @parameterized_class(
     [{"dim": 2}, {"dim": 3}],
     class_name_func=lambda cls, num, params_dict: "{}_{}d".format(


### PR DESCRIPTION
An import error triggers if lammpsio is not installed, even if LAMMPS is not installed. The lammpsio import statement needs to be changed to only try to import lammpsio if LAMMPS is installed.