### PR TITLE
Expand random filling size

### DIFF
--- a/src/relentless/simulate/initialize.py
+++ b/src/relentless/simulate/initialize.py
@@ -88,18 +88,11 @@ class InitializeRandomly(simulate.DelegatedSimulationOperation):
     @staticmethod
     def _make_orthorhombic(V):
         # get the orthorhombic bounding box
+        box_array = V.as_array()
         if isinstance(V, extent.TriclinicBox):
-            Lx, Ly, Lz, xy, xz, yz = V.as_array("HOOMD")
-            aabb = numpy.array(
-                [
-                    Lx / numpy.sqrt(1.0 + xy**2 + (xy * yz - xz) ** 2),
-                    Ly / numpy.sqrt(1.0 + yz**2),
-                    Lz,
-                ]
-            )
+            aabb = box_array[:3]
         elif isinstance(V, extent.ObliqueArea):
-            Lx, Ly, xy = V.as_array("HOOMD")
-            aabb = numpy.array([Lx / numpy.sqrt(1.0 + xy**2), Ly])
+            aabb = box_array[:2]
         else:
             raise TypeError(
                 "Random initialization currently only supported in"


### PR DESCRIPTION
The equivalent orthorhombic box _should_ be given by the diagonal of the matrix of lattice vectors because the tilt factors make the lattice vectors longer.

Fixes #130 