### PR TITLE
Run tests with MPI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: 'openmpi'
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -37,6 +41,12 @@ jobs:
       - name: Test
         run: |
           python -m unittest discover -v -s ./tests -p 'test_*.py'
+      - name: Install mpi4py
+        run: |
+          pip install --no-cache-dir mpi4py
+      - name: Test MPI
+        run: |
+          mpiexec -n 2 --timeout 300 python -m unittest discover -v -s ./tests -p 'test_*.py'
 
   test-hoomd:
     name: unit test [python-${{ matrix.python-version }}, hoomd-2.9.7]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,10 +116,10 @@ jobs:
           python -m unittest -v tests/simulate/test_lammps.py
       - name: Install mpi4py
         run: |
-          pip install --no-cache-dir mpi4py
+          env MPICC=/usr/bin/mpicc pip install --no-cache-dir mpi4py
       - name: Test MPI
         run: |
-          mpirun -n 2 --timeout 300 python -m unittest -v tests/simulate/test_lammps.py
+          /usr/bin/mpirun -n 2 --timeout 300 python -m unittest -v tests/simulate/test_lammps.py
 
   # final exit point for unit tests on PRs, which can be a required check
   test-exit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: unit test [python-${{ matrix.python-version }}]
     runs-on: ubuntu-latest
+    env:
+      MPIEXEC_TIMEOUT: 300
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +48,7 @@ jobs:
           pip install --no-cache-dir mpi4py
       - name: Test MPI
         run: |
-          mpiexec -n 2 --timeout 300 python -m unittest discover -v -s ./tests -p 'test_*.py'
+          mpiexec -n 2 python -m unittest discover -v -s ./tests -p 'test_*.py'
 
   test-hoomd:
     name: unit test [python-${{ matrix.python-version }}, hoomd-2.9.7]
@@ -83,6 +85,8 @@ jobs:
     name: unit test [python-${{ matrix.python-version }}, lammps-${{ matrix.lammps-version }}]
     needs: test
     runs-on: ubuntu-latest
+    env:
+      MPIEXEC_TIMEOUT: 300
     defaults:
       run:
         shell: bash -el {0}
@@ -112,7 +116,7 @@ jobs:
           python -m unittest -v tests/simulate/test_lammps.py
       - name: Test MPI
         run: |
-          mpirun -n 2 --timeout 300 python -m unittest -v tests/simulate/test_lammps.py
+          mpiexec -n 2 python -m unittest -v tests/simulate/test_lammps.py
 
   # final exit point for unit tests on PRs, which can be a required check
   test-exit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: 'openmpi'
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -110,6 +114,12 @@ jobs:
       - name: Test
         run: |
           python -m unittest -v tests/simulate/test_lammps.py
+      - name: Install mpi4py
+        run: |
+          pip install --no-cache-dir mpi4py
+      - name: Test MPI
+        run: |
+          mpirun -n 2 --timeout 300 python -m unittest -v tests/simulate/test_lammps.py
 
   # final exit point for unit tests on PRs, which can be a required check
   test-exit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: 'openmpi'
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -105,7 +101,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge lammps=${{ matrix.lammps-version }}
+          conda install -c conda-forge lammps=${{ matrix.lammps-version }} mpi4py
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install
@@ -114,12 +110,9 @@ jobs:
       - name: Test
         run: |
           python -m unittest -v tests/simulate/test_lammps.py
-      - name: Install mpi4py
-        run: |
-          env MPICC=/usr/bin/mpicc pip install --no-cache-dir mpi4py
       - name: Test MPI
         run: |
-          /usr/bin/mpirun -n 2 --timeout 300 python -m unittest -v tests/simulate/test_lammps.py
+          mpirun -n 2 --timeout 300 python -m unittest -v tests/simulate/test_lammps.py
 
   # final exit point for unit tests on PRs, which can be a required check
   test-exit:

--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -56,7 +56,7 @@ class Directory:
     def __init__(self, path):
         self._start = []
 
-        # ensure path exists at time directory is created (synchronizing)
+        # ensure path exists at time directory is created
         path = os.path.realpath(path)
         if mpi.world.rank_is_root:
             if not os.path.exists(path):
@@ -189,13 +189,11 @@ class Directory:
 
         """
         # delete on root rank and wait
-        if mpi.world.rank_is_root:
-            for entry in os.scandir(self.path):
-                if entry.is_file():
-                    os.remove(entry.path)
-                elif entry.is_dir():
-                    shutil.rmtree(entry.path)
-        mpi.world.barrier()
+        for entry in os.scandir(self.path):
+            if entry.is_file():
+                os.remove(entry.path)
+            elif entry.is_dir():
+                shutil.rmtree(entry.path)
 
     def move_contents(self, dest):
         """Move the contents of the directory.
@@ -207,11 +205,8 @@ class Directory:
 
         """
         dest = Directory.cast(dest)
-        # move on root rank and wait
-        if mpi.world.rank_is_root:
-            for entry in os.scandir(self.path):
-                shutil.move(entry.path, dest.path)
-        mpi.world.barrier()
+        for entry in os.scandir(self.path):
+            shutil.move(entry.path, dest.path)
 
     def copy_contents(self, dest):
         """Copy the contents of the directory.
@@ -223,11 +218,8 @@ class Directory:
 
         """
         dest = Directory.cast(dest)
-        # copy using root rank and wait
-        if mpi.world.rank_is_root:
-            for entry in os.scandir(self.path):
-                if entry.is_file():
-                    shutil.copy2(entry.path, dest.path)
-                elif entry.is_dir():
-                    shutil.copytree(entry.path, os.path.join(dest.path, entry.name))
-        mpi.world.barrier()
+        for entry in os.scandir(self.path):
+            if entry.is_file():
+                shutil.copy2(entry.path, dest.path)
+            elif entry.is_dir():
+                shutil.copytree(entry.path, os.path.join(dest.path, entry.name))

--- a/src/relentless/optimize/method.py
+++ b/src/relentless/optimize/method.py
@@ -136,7 +136,8 @@ class LineSearch:
 
         """
         if directory is not None:
-            directory = data.Directory.cast(directory)
+            directory = data.Directory.cast(directory, create=mpi.world.rank_is_root)
+            mpi.world.barrier()
         ovars = {x: x.value for x in start.variables}
 
         # compute search direction
@@ -172,10 +173,11 @@ class LineSearch:
                 for x in start.variables:
                     x.value = start.variables[x] + new_step * d[x]
                 new_dir = (
-                    directory.directory(str(iter_num))
+                    directory.directory(str(iter_num), create=mpi.world.rank_is_root)
                     if directory is not None
                     else None
                 )
+                mpi.world.barrier()
                 new_res = objective.compute(start.variables, new_dir)
                 new_target = -d.dot(new_res.gradient)
 
@@ -347,7 +349,8 @@ class SteepestDescent(Optimizer):
             return None
 
         if directory is not None:
-            directory = data.Directory.cast(directory)
+            directory = data.Directory.cast(directory, create=mpi.world.rank_is_root)
+            mpi.world.barrier()
 
         # fix scaling parameters
         scale = math.KeyedArray(keys=design_variables)
@@ -361,7 +364,12 @@ class SteepestDescent(Optimizer):
                     scale[x] = 1.0
 
         iter_num = 0
-        cur_dir = directory.directory(str(iter_num)) if directory is not None else None
+        cur_dir = (
+            directory.directory(str(iter_num), create=mpi.world.rank_is_root)
+            if directory is not None
+            else None
+        )
+        mpi.world.barrier()
         cur_res = objective.compute(design_variables, cur_dir)
         while not self.stop.converged(cur_res) and iter_num < self.max_iter:
             grad_y = scale * cur_res.gradient
@@ -370,12 +378,22 @@ class SteepestDescent(Optimizer):
             # steepest descent update
             for x in design_variables:
                 x.value = cur_res.variables[x] - update[x]
-            next_dir = cur_dir.directory(".next") if cur_dir is not None else None
+            next_dir = (
+                cur_dir.directory(".next", create=mpi.world.rank_is_root)
+                if cur_dir is not None
+                else None
+            )
+            mpi.world.barrier()
             next_res = objective.compute(design_variables, next_dir)
 
             # if line search, attempt backtracking in interval
             if self.line_search is not None:
-                line_dir = cur_dir.directory(".line") if cur_dir is not None else None
+                line_dir = (
+                    cur_dir.directory(".line", create=mpi.world.rank_is_root)
+                    if cur_dir is not None
+                    else None
+                )
+                mpi.world.barrier()
                 line_res = self.line_search.find(
                     objective=objective, start=cur_res, end=next_res, directory=line_dir
                 )
@@ -387,12 +405,12 @@ class SteepestDescent(Optimizer):
 
             # move the contents of the "next" result to the new "current" result
             cur_dir = (
-                directory.directory(str(iter_num + 1))
+                directory.directory(str(iter_num + 1), create=mpi.world.rank_is_root)
                 if directory is not None
                 else None
             )
+            mpi.world.barrier()
             if next_res.directory is not None:
-                mpi.world.barrier()
                 if mpi.world.rank_is_root:
                     next_res.directory.move_contents(cur_dir)
                 mpi.world.barrier()

--- a/src/relentless/optimize/method.py
+++ b/src/relentless/optimize/method.py
@@ -2,7 +2,7 @@ import abc
 
 import numpy
 
-from relentless import data, math
+from relentless import data, math, mpi
 from relentless.model import variable
 
 from .criteria import ConvergenceTest, Tolerance
@@ -392,7 +392,10 @@ class SteepestDescent(Optimizer):
                 else None
             )
             if next_res.directory is not None:
-                next_res.directory.move_contents(cur_dir)
+                mpi.world.barrier()
+                if mpi.world.rank_is_root:
+                    next_res.directory.move_contents(cur_dir)
+                mpi.world.barrier()
 
             # recycle next result, updating directory to new location
             cur_res = next_res

--- a/src/relentless/optimize/objective.py
+++ b/src/relentless/optimize/objective.py
@@ -178,7 +178,8 @@ class ObjectiveFunctionResult:
     @directory.setter
     def directory(self, value):
         if value is not None:
-            value = data.Directory.cast(value)
+            value = data.Directory.cast(value, create=mpi.world.rank_is_root)
+            mpi.world.barrier()
         self._directory = value
 
     def save(self, filename):
@@ -336,13 +337,15 @@ class RelativeEntropy(ObjectiveFunction):
         else:
             tmp = None
             directory_is_tmp = False
-        directory = data.Directory.cast(directory)
+        directory = data.Directory.cast(directory, create=mpi.world.rank_is_root)
+        mpi.world.barrier()
 
         # write the pair potential parameters *before* the run
         if not directory_is_tmp:
             if mpi.world.rank_is_root:
                 for n, p in enumerate(self.potentials.pair.potentials):
                     p.save(directory.file("pair_potential.{}.json".format(n)))
+            mpi.world.barrier()
 
         # run simulation and use result to compute gradient
         try:
@@ -365,6 +368,7 @@ class RelativeEntropy(ObjectiveFunction):
             if mpi.world.rank_is_root:
                 sim_ens.save(directory.file("ensemble.json"))
                 result.save(directory.file("result.json"))
+            mpi.world.barrier()
 
         return result
 

--- a/src/relentless/optimize/objective.py
+++ b/src/relentless/optimize/objective.py
@@ -349,6 +349,7 @@ class RelativeEntropy(ObjectiveFunction):
             sim = self.simulation.run(self.potentials, directory)
             sim_ens = sim[self.thermo]["ensemble"]
         finally:
+            mpi.world.barrier()
             if tmp is not None:
                 tmp.cleanup()
 

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -9,7 +9,7 @@ import abc
 
 import numpy
 
-from relentless import data
+from relentless import data, mpi
 
 
 class SimulationOperation(abc.ABC):
@@ -229,9 +229,8 @@ class SimulationInstance:
         self.backend = backend
         self.potentials = potentials
 
-        if directory is not None:
-            directory = data.Directory.cast(directory)
-        self.directory = directory
+        self.directory = data.Directory.cast(directory, create=mpi.world.rank_is_root)
+        mpi.world.barrier()
 
         # properties of simulation, to be set
         self.dimension = None

--- a/tests/optimize/test_method.py
+++ b/tests/optimize/test_method.py
@@ -89,6 +89,7 @@ class test_LineSearch(unittest.TestCase):
             ls.find(objective=q, start=res_1, end=res_3)
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp
@@ -257,6 +258,7 @@ class test_SteepestDescent(unittest.TestCase):
             self.assertAlmostEqual(float(f.readline()), 1.0)
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -79,6 +79,7 @@ class test_ObjectiveFunction(unittest.TestCase):
         self.assertAlmostEqual(x, 1.0)
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp
@@ -255,6 +256,7 @@ class test_RelativeEntropy(unittest.TestCase):
         )
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -159,6 +159,7 @@ class test_Dilute(unittest.TestCase):
         self.assertAlmostEqual(ens_.P, -1.1987890)
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -16,7 +16,10 @@ class test_Dilute(unittest.TestCase):
         else:
             directory = None
         directory = relentless.mpi.world.bcast(directory)
-        self.directory = relentless.data.Directory(directory)
+        self.directory = relentless.data.Directory(
+            directory, create=relentless.mpi.world.rank_is_root
+        )
+        relentless.mpi.world.barrier()
 
     def test_run(self):
         """Test run method."""

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -311,6 +311,7 @@ class test_HOOMD(unittest.TestCase):
             self.assertEqual(ens_.rdf[i, j].table[0, 1], 0.0)
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -31,7 +31,10 @@ class test_HOOMD(unittest.TestCase):
         else:
             directory = None
         directory = relentless.mpi.world.bcast(directory)
-        self.directory = relentless.data.Directory(directory)
+        self.directory = relentless.data.Directory(
+            directory, create=relentless.mpi.world.rank_is_root
+        )
+        relentless.mpi.world.barrier()
 
     # mock (NVT) ensemble and potential for testing
     def ens_pot(self):

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -36,7 +36,10 @@ class test_LAMMPS(unittest.TestCase):
         else:
             directory = None
         directory = relentless.mpi.world.bcast(directory)
-        self.directory = relentless.data.Directory(directory)
+        self.directory = relentless.data.Directory(
+            directory, create=relentless.mpi.world.rank_is_root
+        )
+        relentless.mpi.world.barrier()
 
     # mock (NVT) ensemble and potential for testing
     def ens_pot(self):

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -319,6 +319,7 @@ class test_LAMMPS(unittest.TestCase):
             self.assertCountEqual(snap.mass, [1, 1, 1, 1, 1])
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -130,12 +130,18 @@ class test_Directory(unittest.TestCase):
         # delete sub-directory
         self.assertCountEqual(os.listdir(d1.path), ["bar", "ham.txt", "eggs.txt"])
         self.assertCountEqual(os.listdir(d3.path), ["baz.txt"])
-        d3.clear_contents()
+        relentless.mpi.world.barrier()
+        if relentless.mpi.world.rank_is_root:
+            d3.clear_contents()
+        relentless.mpi.world.barrier()
         self.assertCountEqual(os.listdir(d1.path), ["bar", "ham.txt", "eggs.txt"])
         self.assertCountEqual(os.listdir(d3.path), [])
         # delete parent directory
         self.assertCountEqual(os.listdir(d.path), ["foo", "bar", "spam.txt"])
-        d.clear_contents()
+        relentless.mpi.world.barrier()
+        if relentless.mpi.world.rank_is_root:
+            d.clear_contents()
+        relentless.mpi.world.barrier()
         self.assertCountEqual(os.listdir(d.path), [])
 
     def test_path(self):
@@ -165,14 +171,20 @@ class test_Directory(unittest.TestCase):
         self.assertFalse(os.path.isdir(os.path.join(bar, "fizz")))
 
         # move to bar
-        dfoo.move_contents(dbar)
+        relentless.mpi.world.barrier()
+        if relentless.mpi.world.rank_is_root:
+            dfoo.move_contents(dbar)
+        relentless.mpi.world.barrier()
         self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
         self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))
         self.assertTrue(os.path.isfile(os.path.join(bar, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(bar, "fizz")))
 
         # move to baz (doesn't exist as Directory yet)
-        dbar.move_contents(baz)
+        relentless.mpi.world.barrier()
+        if relentless.mpi.world.rank_is_root:
+            dbar.move_contents(baz)
+        relentless.mpi.world.barrier()
         self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
         self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))
         self.assertFalse(os.path.isfile(os.path.join(bar, "spam.txt")))
@@ -199,14 +211,20 @@ class test_Directory(unittest.TestCase):
         self.assertFalse(os.path.isdir(os.path.join(bar, "fizz")))
 
         # copy to bar
-        dfoo.copy_contents(dbar)
+        relentless.mpi.world.barrier()
+        if relentless.mpi.world.rank_is_root:
+            dfoo.copy_contents(dbar)
+        relentless.mpi.world.barrier()
         self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
         self.assertTrue(os.path.isfile(os.path.join(bar, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(bar, "fizz")))
 
         # copy to baz (doesn't exist as Directory yet)
-        dfoo.copy_contents(baz)
+        relentless.mpi.world.barrier()
+        if relentless.mpi.world.rank_is_root:
+            dfoo.copy_contents(baz)
+        relentless.mpi.world.barrier()
         self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
         self.assertTrue(os.path.isfile(os.path.join(bar, "spam.txt")))
@@ -215,6 +233,7 @@ class test_Directory(unittest.TestCase):
         self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
 
     def tearDown(self):
+        relentless.mpi.world.barrier()
         if relentless.mpi.world.rank_is_root:
             self._tmp.cleanup()
             del self._tmp


### PR DESCRIPTION
This PR enables MPI testing of:

- [X] Core features
- [x] LAMMPS

HOOMD is not able to be tested with MPI because the conda build lacks support. We would need to use a container built with MPI to test this in future.

In the process of running the tests, I noticed race-like conditions on the I/O. I have refactored the `Directory` object and tests to try to address these issues. The caller now has more control over who makes the directories, and there are some additional synchronization barriers to ensure required files are in place before they are consumed. We may need to keep an eye on the code to see if there are any other I/O points that have similar issues, but the tests seem much more robust now.

Fixes #121 
Fixes #150 