### PR TITLE
Fix moving contents of directory

### DIFF
--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -249,15 +249,12 @@ class Directory:
                 shutil.copytree(entry.path, os.path.join(dest.path, entry.name))
 
     def is_empty(self):
-        """Returns whether the directory is empty.
+        """Check if the directory is empty.
 
         Returns
         -------
-        :Bool
+        :bool
             True if the directory is empty.
 
         """
-        empty = True
-        if len(os.listdir(self.path)) != 0:
-            empty = False
-        return empty
+        return len(os.listdir(self.path)) != 0

--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -12,6 +12,7 @@ Data management (`relentless.data`)
 
 """
 import os
+import pathlib
 import shutil
 
 
@@ -198,27 +199,38 @@ class Directory:
             elif entry.is_dir():
                 shutil.rmtree(entry.path)
 
-    def move_contents(self, dest, overwrite=True):
+    def move_contents(self, dest):
         """Move the contents of the directory.
 
         Parameters
         ----------
         dest : :class:`Directory` or :class:`str`
             Destination directory.
-        overwrite : bool
-            Clear destination directory before moving contents.
+
+        Raises
+        ------
+        OSError
+            If the destination exists and does not match the type of the source.
 
         """
         dest = Directory.cast(dest, create=True)
-        if overwrite is True:
-            dest.clear_contents()
-        try:
-            for entry in os.scandir(self.path):
-                shutil.move(entry.path, dest.path)
-        except Exception:
-            raise FileExistsError(
-                "File and/or directory already exists and overwrite is False"
-            )
+        for entry in os.scandir(self.path):
+            dest_entry = pathlib.Path(os.path.join(dest.path, entry.name))
+            if dest_entry.exists():
+                if dest_entry.is_dir() and entry.is_dir():
+                    shutil.copytree(entry.path, dest_entry, dirs_exist_ok=True)
+                    shutil.rmtree(entry.path)
+                elif dest_entry.is_file() and entry.is_file():
+                    shutil.move(entry.path, dest_entry)
+                else:
+                    raise OSError(
+                        "Destination "
+                        "{} exists and does not match type of source {}".format(
+                            dest_entry, entry.name
+                        )
+                    )
+            else:
+                shutil.move(entry.path, dest_entry)
 
     def copy_contents(self, dest):
         """Copy the contents of the directory.

--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -198,18 +198,27 @@ class Directory:
             elif entry.is_dir():
                 shutil.rmtree(entry.path)
 
-    def move_contents(self, dest):
+    def move_contents(self, dest, overwrite=True):
         """Move the contents of the directory.
 
         Parameters
         ----------
         dest : :class:`Directory` or :class:`str`
             Destination directory.
+        overwrite : bool
+            Clear destination directory before moving contents.
 
         """
         dest = Directory.cast(dest, create=True)
-        for entry in os.scandir(self.path):
-            shutil.move(entry.path, dest.path)
+        if overwrite is True:
+            dest.clear_contents()
+        try:
+            for entry in os.scandir(self.path):
+                shutil.move(entry.path, dest.path)
+        except Exception:
+            raise FileExistsError(
+                "File and/or directory already exists and overwrite is False"
+            )
 
     def copy_contents(self, dest):
         """Copy the contents of the directory.

--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -215,7 +215,7 @@ class Directory:
         """
         dest = Directory.cast(dest, create=True)
         for entry in os.scandir(self.path):
-            dest_entry = pathlib.Path(os.path.join(dest.path, entry.name))
+            dest_entry = pathlib.Path(dest.path, entry.name)
             if dest_entry.exists():
                 if dest_entry.is_dir() and entry.is_dir():
                     shutil.copytree(entry.path, dest_entry, dirs_exist_ok=True)
@@ -247,3 +247,17 @@ class Directory:
                 shutil.copy2(entry.path, dest.path)
             elif entry.is_dir():
                 shutil.copytree(entry.path, os.path.join(dest.path, entry.name))
+
+    def is_empty(self):
+        """Returns whether the directory is empty.
+
+        Returns
+        -------
+        :Bool
+            True if the directory is empty.
+
+        """
+        empty = True
+        if len(os.listdir(self.path)) != 0:
+            empty = False
+        return empty

--- a/src/relentless/optimize/method.py
+++ b/src/relentless/optimize/method.py
@@ -316,7 +316,8 @@ class SteepestDescent(Optimizer):
 
         If specified, a :class:`LineSearch` is performed to choose an optimal step size.
 
-        If ``directory`` is specified, output will be saved into a directory
+        If ``directory`` is specified, it will be cleared before the optimization
+        begins. The output will be saved into a directory
         created for each iteration of the optimization, e.g., ``directory/0``.
         To advance to the next iteration of the optimization (e.g., from iteration
         0 to iteration 1), a directory ``directory/0/.next`` is created at
@@ -351,6 +352,7 @@ class SteepestDescent(Optimizer):
 
         if directory is not None:
             directory = data.Directory.cast(directory, create=mpi.world.rank_is_root)
+            directory.clear_contents()
             mpi.world.barrier()
 
         # fix scaling parameters

--- a/src/relentless/optimize/method.py
+++ b/src/relentless/optimize/method.py
@@ -1,5 +1,4 @@
 import abc
-import os
 
 import numpy
 
@@ -39,6 +38,8 @@ class Optimizer(abc.ABC):
         directory : str or :class:`~relentless.data.Directory`
             Directory for writing output during optimization. Default of ``None``
             requests no output is written.
+        overwrite : bool
+            Overwrites the directory, if specified, before begining optimization.
 
         """
         pass
@@ -360,9 +361,10 @@ class SteepestDescent(Optimizer):
 
         if directory is not None:
             directory = data.Directory.cast(directory, create=mpi.world.rank_is_root)
-            if len(os.listdir(directory.path)) != 0:
+            if not directory.is_empty():
                 if overwrite is True:
-                    directory.clear_contents()
+                    if mpi.world.rank_is_root:
+                        directory.clear_contents()
                 else:
                     raise OSError(
                         "Directory {} is not empty and overwrite is not True".format(

--- a/tests/optimize/test_method.py
+++ b/tests/optimize/test_method.py
@@ -201,10 +201,14 @@ class test_SteepestDescent(unittest.TestCase):
         q = QuadraticObjective(x=x)
         t = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
         o = relentless.optimize.SteepestDescent(stop=t, max_iter=1, step_size=0.25)
+        d = self.directory
+
+        # test that overwrite raises error when False
+        with self.assertRaises(OSError):
+            o.optimize(q, x, d, overwrite=False)
 
         # optimize with output
-        d = self.directory
-        o.optimize(q, x, d)
+        o.optimize(q, x, d, overwrite=True)
 
         # 0/ holds the initial value
         self.assertTrue(os.path.isdir(os.path.join(d.path, "0")))
@@ -228,10 +232,14 @@ class test_SteepestDescent(unittest.TestCase):
         t = relentless.optimize.GradientTest(tolerance=1e-8, variables=x)
         o = relentless.optimize.SteepestDescent(stop=t, max_iter=1, step_size=2.0)
         o.line_search = relentless.optimize.LineSearch(tolerance=1e-5, max_iter=1)
+        d = self.directory
+
+        # test that overwrite raises error when False
+        with self.assertRaises(OSError):
+            o.optimize(q, x, d, overwrite=False)
 
         # optimize with output
-        d = self.directory
-        o.optimize(q, x, d)
+        o.optimize(q, x, d, overwrite=True)
 
         # 0/ holds the initial value
         self.assertTrue(os.path.isdir(os.path.join(d.path, "0")))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -199,14 +199,36 @@ class test_Directory(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
 
+        # add one file to each fizz named the same and one named different
+        foofizz = os.path.join(foo, "fizz")
+        bazfizz = os.path.join(baz, "fizz")
+
+        dfoofizz = relentless.data.Directory(
+            foofizz, create=relentless.mpi.world.rank_is_root
+        )
+        dbazfizz = relentless.data.Directory(
+            bazfizz, create=relentless.mpi.world.rank_is_root
+        )
+
+        if relentless.mpi.world.rank_is_root:
+            open(dfoofizz.file("buzz.txt"), "w").close()
+            open(dfoofizz.file("fred.txt"), "w").close()
+            open(dbazfizz.file("buzz.txt"), "w").close()
+            open(dbazfizz.file("jim.txt"), "w").close()
+
         # move file and directory from foo to baz
         if relentless.mpi.world.rank_is_root:
             dfoo.move_contents(baz)
         relentless.mpi.world.barrier()
         self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
         self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertFalse(os.path.isdir(os.path.join(foofizz, "buzz.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(foofizz, "fred.txt")))
         self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(bazfizz, "buzz.txt")))
+        self.assertTrue(os.path.isfile(os.path.join(bazfizz, "fred.txt")))
+        self.assertTrue(os.path.isfile(os.path.join(bazfizz, "jim.txt")))
 
     def test_copy_contents(self):
         foo = os.path.join(self.f, "foo")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -189,6 +189,25 @@ class test_Directory(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
         self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
 
+        # create a copy of the file and directory currently in baz in foo
+        if relentless.mpi.world.rank_is_root:
+            open(dfoo.file("spam.txt"), "w").close()
+        dfoo.directory("fizz", create=relentless.mpi.world.rank_is_root)
+        relentless.mpi.world.barrier()
+        self.assertTrue(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
+
+        # move file and directory from foo to baz
+        if relentless.mpi.world.rank_is_root:
+            dfoo.move_contents(baz, overwrite=True)
+        relentless.mpi.world.barrier()
+        self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
+        self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))
+        self.assertTrue(os.path.isfile(os.path.join(baz, "spam.txt")))
+        self.assertTrue(os.path.isdir(os.path.join(baz, "fizz")))
+
     def test_copy_contents(self):
         foo = os.path.join(self.f, "foo")
         bar = os.path.join(self.f, "bar")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -215,6 +215,7 @@ class test_Directory(unittest.TestCase):
             open(dfoofizz.file("fred.txt"), "w").close()
             open(dbazfizz.file("buzz.txt"), "w").close()
             open(dbazfizz.file("jim.txt"), "w").close()
+        relentless.mpi.world.barrier()
 
         # move file and directory from foo to baz
         if relentless.mpi.world.rank_is_root:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -201,7 +201,7 @@ class test_Directory(unittest.TestCase):
 
         # move file and directory from foo to baz
         if relentless.mpi.world.rank_is_root:
-            dfoo.move_contents(baz, overwrite=True)
+            dfoo.move_contents(baz)
         relentless.mpi.world.barrier()
         self.assertFalse(os.path.isfile(os.path.join(foo, "spam.txt")))
         self.assertFalse(os.path.isdir(os.path.join(foo, "fizz")))


### PR DESCRIPTION
This fixes the `move_contents` function to ensure that it can overwrite, if desired. The `move_contents` testing has been expanded to include a case where it will overwrite a file and directory. 

 `SteepestDescent`'s  `optimize` method was changed to overwrite the directory, if specified, before writing the outputs. This ensures that the directory is always initially empty. This will prevent a confusing situation that could occur when running an optimization and then increasing the tolerance and rerunning. In this scenario, the optimizer will converge in fewer iterations, only rewriting the data until convergence. This would leave mixed data from the two runs which could cause confusion to users. 