### PR TITLE
Allow LAMMPS to run as an executable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: ${{ matrix.mpi }}
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -110,7 +114,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
+          conda install -c conda-forge "${{ matrix.mpi }}=*=external_*" mpi4py "lammps=${{ matrix.lammps-version }}"
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        mpi: ['serial', 'mpich', 'openmpi']
+        mpi: ['nompi', 'mpich', 'openmpi']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup MPI
-        if: ${{ matrix.mpi != 'serial' }}
+        if: ${{ matrix.mpi != 'nompi' }}
         uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
@@ -46,11 +46,11 @@ jobs:
         run: |
           python -m unittest discover -v -s ./tests -p 'test_*.py'
       - name: Install mpi4py
-        if: ${{ matrix.mpi != 'serial' }}
+        if: ${{ matrix.mpi != 'nompi' }}
         run: |
           pip install --no-cache-dir mpi4py
       - name: Test MPI [${{ matrix.mpi }}]
-        if: ${{ matrix.mpi != 'serial' }}
+        if: ${{ matrix.mpi != 'nompi' }}
         run: |
           mpiexec -n 2 python -m unittest discover -v -s ./tests -p 'test_*.py'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,9 +100,6 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         lammps-version: ['2021.09.29', '2022.06.23']
         mpi: ['mpich', 'openmpi']
-        exclude:
-          - lammps-version: '2021.09.29'
-            mpi: 'openmpi'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         lammps-version: ['2021.09.29', '2022.06.23']
         mpi: ['mpich', 'openmpi']
+        exclude:
+          - lammps-version: '2021.09.29'
+            mpi: 'openmpi'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -110,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge ${{ matrix.mpi }} mpi4py lammps=${{ matrix.lammps-version }}
+          conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,9 +112,11 @@ jobs:
       - name: Test
         run: |
           python -m unittest -v tests/simulate/test_lammps.py
+          python tests/simulate/test_lammps.py -v --lammps lmp_serial
       - name: Test MPI
         run: |
           mpiexec -n 2 python -m unittest -v tests/simulate/test_lammps.py
+          python tests/simulate/test_lammps.py -v --lammps "mpiexec -n 2 lmp_mpi"
 
   # final exit point for unit tests on PRs, which can be a required check
   test-exit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           python -m unittest -v tests/simulate/test_hoomd.py
 
   test-lammps:
-    name: unit test [python-${{ matrix.python-version }}, ${{ matrix.mpi }}, lammps-${{ matrix.lammps-version }}]
+    name: unit test [python-${{ matrix.python-version }}, lammps-${{ matrix.lammps-version }}, ${{ matrix.mpi }}]
     needs: test
     runs-on: ubuntu-latest
     env:
@@ -110,7 +110,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge ${{ matrix.mpi }} mpi4py lammps=${{ matrix.lammps-version }}
+          conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,17 +106,15 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          miniconda-version: latest
           python-version: ${{ matrix.python-version }}
-      - name: Setup conda MPI workaround
+      - name: Install conda MPI workaround
         if: ${{ matrix.lammps-version == '2021.09.29' && matrix.mpi == 'openmpi' }}
         run: |
-          mamba install "openmpi=4.1.4=ha*"
+          conda install -c conda-forge "openmpi=4.1.4=ha*"
       - name: Install test dependencies
         run: |
-          mamba install "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
+          conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    name: unit test [python-${{ matrix.python-version }}]
+    name: unit test [python-${{ matrix.python-version }}, ${{ matrix.mpi }}]
     runs-on: ubuntu-latest
     env:
       MPIEXEC_TIMEOUT: 300
@@ -23,11 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
+        mpi: ['serial', 'mpich', 'openmpi']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup MPI
+        if: ${{ matrix.mpi != 'serial' }}
         uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: ${{ matrix.mpi }}
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -42,9 +46,11 @@ jobs:
         run: |
           python -m unittest discover -v -s ./tests -p 'test_*.py'
       - name: Install mpi4py
+        if: ${{ matrix.mpi != 'serial' }}
         run: |
           pip install --no-cache-dir mpi4py
-      - name: Test MPI
+      - name: Test MPI [${{ matrix.mpi }}]
+        if: ${{ matrix.mpi != 'serial' }}
         run: |
           mpiexec -n 2 python -m unittest discover -v -s ./tests -p 'test_*.py'
 
@@ -80,7 +86,7 @@ jobs:
           python -m unittest -v tests/simulate/test_hoomd.py
 
   test-lammps:
-    name: unit test [python-${{ matrix.python-version }}, lammps-${{ matrix.lammps-version }}]
+    name: unit test [python-${{ matrix.python-version }}, ${{ matrix.mpi }}, lammps-${{ matrix.lammps-version }}]
     needs: test
     runs-on: ubuntu-latest
     env:
@@ -93,6 +99,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
         lammps-version: ['2021.09.29', '2022.06.23']
+        mpi: ['mpich', 'openmpi']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -103,7 +110,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge lammps=${{ matrix.lammps-version }} mpi4py
+          conda install -c conda-forge ${{ matrix.mpi }} mpi4py lammps=${{ matrix.lammps-version }}
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install
@@ -112,10 +119,14 @@ jobs:
       - name: Test
         run: |
           python -m unittest -v tests/simulate/test_lammps.py
+      - name: Test executable
+        run: |
           python tests/simulate/test_lammps.py -v --lammps lmp_serial
       - name: Test MPI
         run: |
           mpiexec -n 2 python -m unittest -v tests/simulate/test_lammps.py
+      - name: Test MPI executable
+        run: |
           python tests/simulate/test_lammps.py -v --lammps "mpiexec -n 2 lmp_mpi"
 
   # final exit point for unit tests on PRs, which can be a required check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,15 +106,17 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: latest
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
           python-version: ${{ matrix.python-version }}
       - name: Setup conda MPI workaround
         if: ${{ matrix.lammps-version == '2021.09.29' && matrix.mpi == 'openmpi' }}
         run: |
-          conda install -c conda-forge "openmpi=4.1.4=ha*"
+          mamba install "openmpi=4.1.4=ha*"
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
+          mamba install "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,10 @@ jobs:
         with:
           miniconda-version: latest
           python-version: ${{ matrix.python-version }}
+      - name: Setup conda MPI workaround
+        if: ${{ matrix.lammps-version == '2021.09.29' && matrix.mpi == 'openmpi' }}
+        run: |
+          conda install -c conda-forge "openmpi=4.1.4=ha*"
       - name: Install test dependencies
         run: |
           conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: ${{ matrix.mpi }}
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -114,7 +110,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge "${{ matrix.mpi }}=*=external_*" mpi4py "lammps=${{ matrix.lammps-version }}"
+          conda install -c conda-forge ${{ matrix.mpi }} mpi4py lammps=${{ matrix.lammps-version }}
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0
       - name: Install

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -28,7 +28,7 @@ except ImportError:
 
 
 # initializers
-class _Initialize(simulate.SimulationOperation):
+class _Initialize(simulate.InitializationOperation):
     """Initialize a simulation.
 
     This is an abstract base class that needs to have its :meth:`initialize`

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -48,6 +48,25 @@ class _Initialize(simulate.InitializationOperation):
         sim.dimension = sim[self]["_system"].box.dimensions
         sim.types = sim[self]["_system"].particles.types
 
+        # parse masses by type
+        sim.masses = FixedKeyDict(sim.types)
+        with sim[self]["_context"]:
+            snap = sim[self]["_system"].take_snapshot(particles=True)
+            masses = {}
+            # snapshot is only valid on root, so read there and broadcast
+            if mpi.world.rank == 0:
+                for i in sim.types:
+                    mi = snap.particles.mass[
+                        snap.particles.typeid == snap.particles.types.index(i)
+                    ]
+                    if len(mi) == 0:
+                        raise KeyError("Type {} not present in simulation".format(i))
+                    elif not numpy.all(mi == mi[0]):
+                        raise ValueError("All masses for a type must be equal")
+                    masses[i] = mi[0]
+            masses = mpi.world.bcast(masses, root=0)
+            sim.masses.update(masses)
+
         # attach the potentials
         def _table_eval(r_i, rmin, rmax, **coeff):
             r = coeff["r"]

--- a/src/relentless/simulate/initialize.py
+++ b/src/relentless/simulate/initialize.py
@@ -9,7 +9,7 @@ from . import simulate
 
 
 # initializers
-class InitializeFromFile(simulate.DelegatedSimulationOperation):
+class InitializeFromFile(simulate.DelegatedInitializationOperation):
     """Initialize a simulation from a file.
 
     Description.
@@ -28,7 +28,7 @@ class InitializeFromFile(simulate.DelegatedSimulationOperation):
         return self._get_delegate(sim, filename=self.filename)
 
 
-class InitializeRandomly(simulate.DelegatedSimulationOperation):
+class InitializeRandomly(simulate.DelegatedInitializationOperation):
     """Initialize a randomly generated simulation box.
 
     If ``diameters`` is ``None``, the particles are randomly placed in the box.

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -1109,9 +1109,12 @@ class LAMMPS(simulate.Simulation):
             file_ = mpi.world.bcast(file_)
 
             # only launch process on the root rank with MPI launcher
-            run_cmd = sim[sim.initializer]["_lammps"] + ["-i", file_]
             if mpi.world.rank_is_root:
-                result = subprocess.run("mpirun " + " ".join(run_cmd), shell=True)
+                run_cmd = sim[sim.initializer]["_lammps"] + ["-i", file_]
+                run_cmd = " ".join(run_cmd)
+                if mpi.world.enabled:
+                    run_cmd = "mpiexec " + run_cmd
+                result = subprocess.run(run_cmd, shell=True)
                 returncode = result.returncode
             else:
                 returncode = None

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -628,7 +628,7 @@ class RunLangevinDynamics(_MDIntegrator):
         if Ntypes > 1:
             scale = damp / damp_ref
             scale_str = " ".join(
-                ["scale {} {}".format(i + 1, s) for i, s in enumerate(scale[1:])]
+                ["scale {} {}".format(i + 2, s) for i, s in enumerate(scale[1:])]
             )
         else:
             scale_str = ""

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -1,9 +1,11 @@
 import abc
+import shutil
+import subprocess
 import uuid
 
 import numpy
 
-from relentless import mpi
+from relentless import collections, mpi
 from relentless.model import ensemble, extent, variable
 
 from . import initialize, md, simulate
@@ -46,7 +48,12 @@ class LAMMPSOperation(simulate.SimulationOperation):
 
         """
         cmds = self.to_commands(sim)
-        sim[sim.initializer]["_lammps"].commands_list(cmds)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim[sim.initializer]["_lammps_commands"] += cmds
+        if sim[sim.initializer]["_lammps_python"]:
+            sim[sim.initializer]["_lammps"].commands_list(cmds)
 
     @classmethod
     def new_compute_id(cls):
@@ -138,6 +145,34 @@ class LAMMPSOperation(simulate.SimulationOperation):
         pass
 
 
+class LAMMPSAnalysisOperation(simulate.AnalysisOperation):
+    def pre_run(self, sim, sim_op):
+        cmds = self.pre_run_commands(sim, sim_op)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim[sim.initializer]["_lammps_commands"] += cmds
+        if sim[sim.initializer]["_lammps_python"]:
+            sim[sim.initializer]["_lammps"].commands_list(cmds)
+
+    def post_run(self, sim, sim_op):
+        cmds = self.post_run_commands(sim, sim_op)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim[sim.initializer]["_lammps_commands"] += cmds
+        if sim[sim.initializer]["_lammps_python"]:
+            sim[sim.initializer]["_lammps"].commands_list(cmds)
+
+    @abc.abstractmethod
+    def pre_run_commands(self, sim, sim_op):
+        pass
+
+    @abc.abstractmethod
+    def post_run_commands(self, sim, sim_op):
+        pass
+
+
 # initializers
 class _Initialize(simulate.InitializationOperation, LAMMPSOperation):
     """Initialize a simulation."""
@@ -158,6 +193,21 @@ class _Initialize(simulate.InitializationOperation, LAMMPSOperation):
 
         cmds += self.initialize_commands(sim)
         sim.types = sim[self]["lammps_types"].keys()
+
+        sim.masses = collections.FixedKeyDict(sim.types)
+        # file is opened only valid on root and result is broadcast
+        masses = {}
+        if mpi.world.rank_is_root:
+            snap = lammpsio.DataFile(sim[self]["_datafile"]).read()
+            for i in sim.types:
+                mi = snap.mass[snap.typeid == sim[self]["lammps_types"][i]]
+                if len(mi) == 0:
+                    raise KeyError("Type {} not present in simulation".format(i))
+                elif not numpy.all(mi == mi[0]):
+                    raise ValueError("All masses for a type must be equal")
+                masses[i] = mi[0]
+        masses = mpi.world.bcast(masses)
+        sim.masses.update(masses)
 
         # attach the potentials
         if sim.potentials.pair.start == 0:
@@ -282,6 +332,7 @@ class InitializeFromFile(_Initialize):
     def initialize_commands(self, sim):
         if sim[self]["lammps_types"] is None:
             raise ValueError("lammps_types needs to be manually specified with a file")
+        sim[self]["_datafile"] = self.filename
         return ["read_data {filename}".format(filename=self.filename)]
 
 
@@ -412,6 +463,7 @@ class InitializeRandomly(_Initialize):
             init_file = None
         init_file = mpi.world.bcast(init_file)
 
+        sim[self]["_datafile"] = init_file
         return ["read_data {}".format(init_file)]
 
 
@@ -555,30 +607,28 @@ class RunLangevinDynamics(_MDIntegrator):
         self.seed = seed
 
     def to_commands(self, sim):
-        # obtain per-type mass (arrays 1-indexed using lammps convention)
-        Ntypes = len(sim.types)
-        mass = sim[sim.initializer]["_lammps"].numpy.extract_atom("mass")
-        if mass is None or mass.shape != (Ntypes + 1,):
-            raise ValueError("Per-type masses not set.")
-        mass = numpy.squeeze(mass)
-
         # obtain per-type friction factor
-        friction = numpy.zeros_like(mass)
+        Ntypes = len(sim.types)
+        mass = numpy.zeros(Ntypes)
+        friction = numpy.zeros(Ntypes)
         for t in sim.types:
+            typeidx = sim[sim.initializer]["lammps_types"][t] - 1
             try:
-                friction[sim[sim.initializer]["lammps_types"][t]] = self.friction[t]
+                friction[typeidx] = self.friction[t]
             except TypeError:
-                friction[sim[sim.initializer]["lammps_types"][t]] = self.friction
+                friction[typeidx] = self.friction
             except KeyError:
                 raise KeyError("The friction factor for type {} is not set.".format(t))
 
+            mass[typeidx] = sim.masses[t]
+
         # compute per-type damping parameter and rescale if multiple types
         damp = numpy.divide(mass, friction, where=(friction > 0))
-        damp_ref = damp[1]
+        damp_ref = damp[0]
         if Ntypes > 1:
             scale = damp / damp_ref
             scale_str = " ".join(
-                ["scale {} {}".format(i + 1, s) for i, s in enumerate(scale[2:])]
+                ["scale {} {}".format(i + 1, s) for i, s in enumerate(scale[1:])]
             )
         else:
             scale_str = ""
@@ -733,7 +783,7 @@ class RunMolecularDynamics(_MDIntegrator):
         return cmds
 
 
-class EnsembleAverage(simulate.AnalysisOperation):
+class EnsembleAverage(LAMMPSAnalysisOperation):
     """Analyzes the simulation ensemble and rdf at specified timestep intervals.
 
     Parameters
@@ -759,7 +809,7 @@ class EnsembleAverage(simulate.AnalysisOperation):
         self.check_rdf_every = check_rdf_every
         self.rdf_dr = rdf_dr
 
-    def pre_run(self, sim, sim_op):
+    def pre_run_commands(self, sim, sim_op):
         fix_ids = {
             "thermo_avg": LAMMPSOperation.new_fix_id(),
             "rdf_avg": LAMMPSOperation.new_fix_id(),
@@ -868,10 +918,10 @@ class EnsembleAverage(simulate.AnalysisOperation):
             ),
         ]
 
-        sim[sim.initializer]["_lammps"].commands_list(cmds)
+        return cmds
 
-    def post_run(self, sim, sim_op):
-        pass
+    def post_run_commands(self, sim, sim_op):
+        return None
 
     def process(self, sim, sim_op):
         # extract thermo properties
@@ -911,7 +961,7 @@ class EnsembleAverage(simulate.AnalysisOperation):
         sim[self]["num_rdf_samples"] = None
 
 
-class WriteTrajectory(simulate.AnalysisOperation):
+class WriteTrajectory(LAMMPSAnalysisOperation):
     """Writes a LAMMPS dump file.
 
     When all options are set to True the file has the following format::
@@ -946,7 +996,7 @@ class WriteTrajectory(simulate.AnalysisOperation):
         self.types = types
         self.masses = masses
 
-    def pre_run(self, sim, sim_op):
+    def pre_run_commands(self, sim, sim_op):
         dump_format = "id"
         if self.types is True:
             dump_format += " type"
@@ -967,10 +1017,10 @@ class WriteTrajectory(simulate.AnalysisOperation):
             "dump_modify {} append no pbc yes flush yes".format(dump_id),
         ]
 
-        sim[sim.initializer]["_lammps"].commands_list(cmds)
+        return cmds
 
-    def post_run(self, sim, sim_op):
-        pass
+    def post_run_commands(self, sim, sim_op):
+        return None
 
     def process(self, sim, sim_op):
         pass
@@ -1017,9 +1067,24 @@ class LAMMPS(simulate.Simulation):
     """
 
     def __init__(
-        self, initializer, operations=None, dimension=3, quiet=True, lammps_types=None
+        self,
+        initializer,
+        operations=None,
+        dimension=3,
+        quiet=True,
+        lammps_types=None,
+        executable=None,
     ):
-        if not _lammps_found:
+        # try to find executable if it is specified
+        if executable is not None:
+            executable_ = shutil.which(executable)
+            if executable_ is None:
+                raise OSError("LAMMPS executable {} not found".format(executable))
+            self.executable = executable_
+        else:
+            self.executable = None
+
+        if self.executable is None and not _lammps_found:
             raise ImportError("LAMMPS not found.")
 
         if not _lammpsio_found:
@@ -1029,6 +1094,23 @@ class LAMMPS(simulate.Simulation):
         self.dimension = dimension
         self.quiet = quiet
         self.lammps_types = lammps_types
+
+    def _post_run(self, sim):
+        # force all the lammps commands to execute, since the operations did
+        # not actually do it
+        if not sim[sim.initializer]["_lammps_python"]:
+            if mpi.world.rank_is_root:
+                file_ = sim.directory.file(str(uuid.uuid4().hex))
+                with open(file_, "w") as f:
+                    for cmd in sim[sim.initializer]["_lammps_commands"]:
+                        f.write(cmd + "\n")
+            else:
+                file_ = None
+            file_ = mpi.world.bcast(file_)
+            run_cmd = sim[sim.initializer]["_lammps"] + ["-i", file_]
+            subprocess.run(" ".join(run_cmd), shell=True, check=True)
+        # then keep going
+        super()._post_run(sim)
 
     def _new_instance(self, potentials, directory):
         sim = simulate.SimulationInstance(
@@ -1054,10 +1136,18 @@ class LAMMPS(simulate.Simulation):
                 sim.directory.file("log.lammps"),
                 "-nocite",
             ]
-        lmp = lammps.lammps(cmdargs=launch_args)
-        if lmp.version() < 20210929:
-            raise ImportError("Only LAMMPS 29 Sep 2021 or newer is supported.")
-        sim[sim.initializer]["_lammps"] = lmp
+
+        sim[sim.initializer]["_lammps_commands"] = []
+        if self.executable is not None:
+            sim[sim.initializer]["_lammps_python"] = False
+            sim[sim.initializer]["_lammps"] = [self.executable] + launch_args
+        else:
+            lmp = lammps.lammps(cmdargs=launch_args)
+            if lmp.version() < 20210929:
+                raise ImportError("Only LAMMPS 29 Sep 2021 or newer is supported.")
+            sim[sim.initializer]["_lammps_python"] = True
+            sim[sim.initializer]["_lammps"] = lmp
+
         sim[sim.initializer]["lammps_types"] = self.lammps_types
         sim[sim.initializer]["units"] = "lj"
         sim[sim.initializer]["atom_style"] = "atomic"

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -1034,9 +1034,20 @@ class LAMMPS(simulate.Simulation):
     GPUs, as a single process or with MPI parallelism. The launch configuration
     will be automatically selected for you when the simulation is run.
 
-    LAMMPS must be built with its
-    `Python interface <https://docs.lammps.org/Python_head.html>`_ and must be
-    version 29 Sep 2021 or newer.
+    The version of LAMMPS must be 29 Sep 2021 or newer. It is recommended to build
+    LAMMPS with its `Python interface <https://docs.lammps.org/Python_head.html>`_.
+    However, it is possible to run LAMMPS as a binary by specifying ``executable``::
+
+        relentless.simulate.LAMMPS(init, ops, executable="lmp_serial")
+
+    This can be helpful if you do not have a build of LAMMPS with Python support
+    enabled; however, it will typically be a bit slower than running LAMMPS via
+    Python. To run LAMMPS as an executable with MPI support, you should **not**
+    launch ``relentless`` with ``mpirexec``, and instead should include the
+    ``mpiexec` command and options in the ``executable``::
+
+        relentless.simulate.LAMMPS(init, ops, executable="mpiexec -n 8 lmp_mpi")
+
 
     .. warning::
 
@@ -1058,6 +1069,12 @@ class LAMMPS(simulate.Simulation):
         If ``True``, silence LAMMPS screen output. Setting this to ``False`` can
         be helpful for debugging but would be very noisy in a long production
         simulation.
+    lammps_types : dict
+        Mapping from relentless types to LAMMPS integer types. This mapping may
+        be used during initialization (and is required for some operations).
+    executable : str
+        LAMMPS executable. If specified, LAMMPS will be run as a binary
+        application rather than its Python library.
 
     Raises
     ------

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -139,7 +139,7 @@ class LAMMPSOperation(simulate.SimulationOperation):
 
 
 # initializers
-class _Initialize(LAMMPSOperation):
+class _Initialize(simulate.InitializationOperation, LAMMPSOperation):
     """Initialize a simulation."""
 
     def __call__(self, sim):

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -27,6 +27,8 @@ class InitializationOperation(SimulationOperation):
 
     * Set `sim.dimension`, the dimensionality of the simulation.
     * Set `sim.types`, the list of particle types in the simulation.
+    * Set `sim.masses`, the dictionary of masses for each particle type in the
+      simulation.py
     * Attach the :class:`Potentials` given by `sim.potentials`.
 
     The initialization operation may additionally stash any data required to

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -180,13 +180,17 @@ class Simulation:
         # run the operations
         for op in self.operations:
             op(sim)
+        # execute post run commands
+        self._post_run(sim)
+
+        return sim
+
+    def _post_run(self, sim):
         # finalize the analysis operations
         for op in self.operations:
             if hasattr(op, "analyzers"):
                 for analyzer in op.analyzers:
                     analyzer.process(sim, op)
-
-        return sim
 
     @property
     def initializer(self):

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -20,6 +20,24 @@ class SimulationOperation(abc.ABC):
         pass
 
 
+class InitializationOperation(SimulationOperation):
+    """Operation that initializes a :class:`Simulation`.
+
+    An initialization operation must do the following:
+
+    * Set `sim.dimension`, the dimensionality of the simulation.
+    * Set `sim.types`, the list of particle types in the simulation.
+    * Attach the :class:`Potentials` given by `sim.potentials`.
+
+    The initialization operation may additionally stash any data required to
+    run the simulation (e.g., a specific instance of the simulation engine).
+    These should be stored as private data keys beginning with an `_`.
+
+    """
+
+    pass
+
+
 class AnalysisOperation(abc.ABC):
     """Analysis operation to be performed by a :class:`Simulation`."""
 
@@ -58,6 +76,12 @@ class DelegatedSimulationOperation(SimulationOperation):
     @abc.abstractmethod
     def _make_delegate(self, sim):
         pass
+
+
+class DelegatedInitializationOperation(
+    DelegatedSimulationOperation, InitializationOperation
+):
+    pass
 
 
 class DelegatedAnalysisOperation(AnalysisOperation):
@@ -171,8 +195,8 @@ class Simulation:
 
     @initializer.setter
     def initializer(self, op):
-        if not isinstance(op, SimulationOperation):
-            return TypeError("Initializer must be SimulationOperation")
+        if not isinstance(op, InitializationOperation):
+            return TypeError("Initializer must be an InitializationOperation")
         self._initializer = op
 
     @property

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -154,26 +154,21 @@ class test_LAMMPS(unittest.TestCase):
         h.run(potentials=pot, directory=self.directory)
 
         # T + diameters
-        op = relentless.simulate.InitializeRandomly(
+        h.initializer = relentless.simulate.InitializeRandomly(
             seed=1, N=ens.N, V=ens.V, diameters={"1": 1.0, "2": 2.0}
-        )
-        h = relentless.simulate.LAMMPS(
-            op, dimension=self.dim, executable=self.executable
         )
         h.run(potentials=pot, directory=self.directory)
 
         # no T + mass
         m = {i: idx + 1 for idx, i in enumerate(ens.N)}
-        op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, masses=m)
-        h = relentless.simulate.LAMMPS(op, dimension=self.dim)
+        h.initializer = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, masses=m
+        )
         h.run(potentials=pot, directory=self.directory)
 
         # T + mass
-        op = relentless.simulate.InitializeRandomly(
+        h.initializer = relentless.simulate.InitializeRandomly(
             seed=1, N=ens.N, V=ens.V, T=ens.T, masses=m
-        )
-        h = relentless.simulate.LAMMPS(
-            op, dimension=self.dim, executable=self.executable
         )
         h.run(potentials=pot, directory=self.directory)
 
@@ -204,13 +199,7 @@ class test_LAMMPS(unittest.TestCase):
         emin = relentless.simulate.MinimizeEnergy(
             energy_tolerance=1e-7, force_tolerance=1e-7, max_iterations=1000, options={}
         )
-        lmp = relentless.simulate.LAMMPS(
-            init,
-            operations=[emin],
-            dimension=self.dim,
-            lammps_types={"1": 1, "2": 2},
-            executable=self.executable,
-        )
+        lmp.operations = emin
         lmp.run(potentials=pot, directory=self.directory)
         self.assertEqual(emin.options["max_evaluations"], 100 * emin.max_iterations)
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     pass
 
-has_mpi = relentless.mpi._mpi_running()
+has_mpi = relentless.mpi._mpi_running
 
 
 class test_Communicator(unittest.TestCase):


### PR DESCRIPTION
This PR enables running LAMMPS as an executable rather than a Python library. MPI is supported with the restriction that relentless itself cannot be launched with MPI. This should be fine since only the simulation really needs it.

To implement this, the following major changes were made:

* Create an `InitializationOperation` type that guarantees certain data will be present after it runs.
* Set the masses of different particle types during initialization. This was the only spot where LAMMPS was requiring immediate feedback from the MPI library.
* Add a LAMMPSAnalysisOperation type that breaks its calls into running and commands, e.g. `pre_run` and `pre_run_commands`.
* Only run LAMMPS commands through the Python interface when we are in that run configuration. Otherwise, just save the commands.
* Add a `_post_run` method to the simulations. By default, this executes the `process` command of all detected analyzers. However, LAMMPS now leverages this step to write all the commands to an input file, then run it with the executable.
* To avoid some nasty fork stuff when `mpi4py` is installed but the process is not being run under MPI, `mpi4py` is only loaded when we detect the program is being run under MPI due to one of the environment variables.
* Tests are run on multiple MPI implementations, as what works with MPICH does not always work with OpenMPI.
* LAMMPS is tested as both a Python library and executable.

Closes #81 