### PR TITLE
Add error messages to EnsembleAnalyzer

### DIFF
--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -634,6 +634,13 @@ class EnsembleAverage(simulate.AnalysisOperation):
     def process(self, sim, sim_op):
         rdf_recorder = sim[self]["_rdf_callback"]
         thermo_recorder = sim[self]["_thermo_callback"]
+
+        # make sure samples were collected
+        if thermo_recorder.num_samples == 0:
+            raise RuntimeError("No thermo samples were collected")
+        if rdf_recorder.num_samples == 0:
+            raise RuntimeError("No RDF samples were collected")
+
         ens = ensemble.Ensemble(
             T=thermo_recorder.T,
             N=rdf_recorder.N,

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -927,7 +927,10 @@ class EnsembleAverage(LAMMPSAnalysisOperation):
         # extract thermo properties
         # we skip the first 2 rows, which are LAMMPS junk, and slice out the
         # timestep from col. 0
-        thermo = mpi.world.loadtxt(sim[self]["_thermo_file"], skiprows=2)[1:]
+        try:
+            thermo = mpi.world.loadtxt(sim[self]["_thermo_file"], skiprows=2)[1:]
+        except FileNotFoundError as e:
+            raise FileNotFoundError("No LAMMPS thermo file generated") from e
         N = {i: Ni for i, Ni in zip(sim.types, thermo[8 : 8 + len(sim.types)])}
         if sim.dimension == 3:
             V = extent.TriclinicBox(
@@ -952,7 +955,10 @@ class EnsembleAverage(LAMMPSAnalysisOperation):
         # LAMMPS injects a column for the row index, so we start at column 1 for r
         # we skip the first 4 rows, which are LAMMPS junk, and slice out the
         # first column
-        rdf = mpi.world.loadtxt(sim[self]["_rdf_file"], skiprows=4)[:, 1:]
+        try:
+            rdf = mpi.world.loadtxt(sim[self]["_rdf_file"], skiprows=4)[:, 1:]
+        except FileNotFoundError as e:
+            raise FileNotFoundError("No LAMMPS RDF file generated") from e
         for i, pair in enumerate(sim[self]["_rdf_pairs"]):
             ens.rdf[pair] = ensemble.RDF(rdf[:, 0], rdf[:, i + 1])
 

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -929,8 +929,8 @@ class EnsembleAverage(LAMMPSAnalysisOperation):
         # timestep from col. 0
         try:
             thermo = mpi.world.loadtxt(sim[self]["_thermo_file"], skiprows=2)[1:]
-        except FileNotFoundError as e:
-            raise FileNotFoundError("No LAMMPS thermo file generated") from e
+        except Exception as e:
+            raise RuntimeError("No LAMMPS thermo file generated") from e
         N = {i: Ni for i, Ni in zip(sim.types, thermo[8 : 8 + len(sim.types)])}
         if sim.dimension == 3:
             V = extent.TriclinicBox(
@@ -957,8 +957,8 @@ class EnsembleAverage(LAMMPSAnalysisOperation):
         # first column
         try:
             rdf = mpi.world.loadtxt(sim[self]["_rdf_file"], skiprows=4)[:, 1:]
-        except FileNotFoundError as e:
-            raise FileNotFoundError("No LAMMPS RDF file generated") from e
+        except Exception as e:
+            raise RuntimeError("LAMMPS RDF file could not be read") from e
         for i, pair in enumerate(sim[self]["_rdf_pairs"]):
             ens.rdf[pair] = ensemble.RDF(rdf[:, 0], rdf[:, i + 1])
 

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -246,6 +246,14 @@ class test_HOOMD(unittest.TestCase):
         self.assertEqual(sim[analyzer]["num_thermo_samples"], 100)
         self.assertEqual(sim[analyzer]["num_rdf_samples"], 50)
 
+        # make sure we get an error if this doesn't actually run
+        if relentless.mpi.world.rank_is_root:
+            self.directory.clear_contents()
+        relentless.mpi.world.barrier()
+        lgv.steps = 0
+        with self.assertRaises(RuntimeError):
+            h.run(pot, self.directory)
+
     def test_writetrajectory(self):
         """Test write trajectory simulation operation."""
         ens, pot = self.ens_pot()


### PR DESCRIPTION
This PR throws a meaningful error message if the EnsembleAnalyzer fails during the `process` step. For HOOMD, this could occur if a short run was performed to increment the timestep to something that isn't a multiple of the reporting period, then another very short run is done.

Fixes #157 