### PR TITLE
Refactor operation types

### DIFF
--- a/src/relentless/simulate/__init__.py
+++ b/src/relentless/simulate/__init__.py
@@ -89,6 +89,7 @@ Other dynamics
 .. autosummary::
     :toctree: generated/
 
+    MinimizeEnergy
     RunBrownianDynamics
     RunLangevinDynamics
 

--- a/src/relentless/simulate/dilute.py
+++ b/src/relentless/simulate/dilute.py
@@ -14,7 +14,6 @@ import numpy
 from relentless.model import ensemble, extent
 
 from . import simulate
-from .hoomd import _MDIntegrator
 
 
 class NullOperation(simulate.SimulationOperation):
@@ -27,7 +26,7 @@ class NullOperation(simulate.SimulationOperation):
         pass
 
 
-class InitializeRandomly(simulate.SimulationOperation):
+class InitializeRandomly(simulate.InitializationOperation):
     """Initializes a "randomly" generated simulation.
 
     Since this is a dilute system, there is not actual particle configuration.
@@ -68,7 +67,14 @@ class InitializeRandomly(simulate.SimulationOperation):
         sim.types = ens.types
 
 
-class RunBrownianDynamics(_MDIntegrator):
+class _Integrator(simulate.SimulationOperation):
+    def __init__(self, steps, timestep, analyzers):
+        super().__init__(analyzers)
+        self.steps = steps
+        self.timestep = timestep
+
+
+class RunBrownianDynamics(_Integrator):
     def __init__(self, steps, timestep, T, friction, seed, analyzers):
         super().__init__(steps, timestep, analyzers)
         self.T = T
@@ -83,7 +89,7 @@ class RunBrownianDynamics(_MDIntegrator):
             analyzer.post_run(sim, self)
 
 
-class RunLangevinDynamics(_MDIntegrator):
+class RunLangevinDynamics(_Integrator):
     def __init__(self, steps, timestep, T, friction, seed, analyzers):
         super().__init__(steps, timestep, analyzers)
         self.T = T
@@ -98,7 +104,7 @@ class RunLangevinDynamics(_MDIntegrator):
             analyzer.post_run(sim, self)
 
 
-class RunMolecularDynamics(_MDIntegrator):
+class RunMolecularDynamics(_Integrator):
     def __init__(self, steps, timestep, thermostat, barostat, analyzers):
         super().__init__(steps, timestep, analyzers)
         self.thermostat = thermostat
@@ -226,7 +232,6 @@ class Dilute(simulate.Simulation):
     """
 
     # initialize
-    # InitializeFromFile = simulate.NotImplementedOperation
     _InitializeRandomly = InitializeRandomly
 
     # md

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1,3 +1,4 @@
+import enum
 import os
 import warnings
 
@@ -34,7 +35,8 @@ if _hoomd_found and _version.major == 3:
 else:
     # we need to spoof this Action class to use later in v2 callbacks
     class Action:
-        pass
+        class Flags(enum.IntEnum):
+            PRESSURE_TENSOR = 0
 
 
 try:
@@ -45,66 +47,11 @@ except ImportError:
     _freud_found = False
 
 
-class SimulationOperation(simulate.SimulationOperation):
-    def __call__(self, sim):
-        if _version.major == 3:
-            self._call_v3(sim)
-        elif _version.major == 2:
-            self._call_v2(sim)
-        else:
-            raise NotImplementedError(f"HOOMD {_version} not supported")
-
-    def _call_v3(self, sim):
-        raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 3"
-        )
-
-    def _call_v2(self, sim):
-        raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 2"
-        )
-
-
-class AnalysisOperation(simulate.AnalysisOperation):
-    def pre_run(self, sim, sim_op):
-        if _version.major == 3:
-            self._pre_run_v3(sim, sim_op)
-        elif _version.major == 2:
-            self._pre_run_v2(sim, sim_op)
-        else:
-            raise NotImplementedError(f"HOOMD {_version} not supported")
-
-    def post_run(self, sim, sim_op):
-        if _version.major == 3:
-            self._post_run_v3(sim, sim_op)
-        elif _version.major == 2:
-            self._post_run_v2(sim, sim_op)
-        else:
-            raise NotImplementedError(f"HOOMD {_version} not supported")
-
-    def _pre_run_v3(self, sim, sim_op):
-        raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 3"
-        )
-
-    def _pre_run_v2(self, sim, sim_op):
-        raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 2"
-        )
-
-    def _post_run_v3(self, sim, sim_op):
-        raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 3"
-        )
-
-    def _post_run_v2(self, sim, sim_op):
-        raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 2"
-        )
-
-
 # initializers
-class InitializationOperation(SimulationOperation, simulate.InitializationOperation):
+class InitializationOperation(simulate.InitializationOperation):
+    def __call__(self, sim):
+        SimulationOperation.__call__(self, sim)
+
     def _call_v3(self, sim):
         self._initialize_v3(sim)
         sim.dimension = sim["engine"]["_hoomd"].state.box.dimensions
@@ -140,7 +87,6 @@ class InitializationOperation(SimulationOperation, simulate.InitializationOperat
         sim.types = sim[self]["_system"].particles.types
 
         # parse masses by type
-
         with sim["engine"]["_hoomd"]:
             snap = sim[self]["_system"].take_snapshot(particles=True)
             sim.masses = self._get_masses_from_snapshot(sim, snap)
@@ -178,12 +124,12 @@ class InitializationOperation(SimulationOperation, simulate.InitializationOperat
 
     def _initialize_v3(self, sim):
         raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 3"
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
         )
 
     def _initialize_v2(self, sim):
         raise NotImplementedError(
-            f"{self.__class__.__name__} not implemented in HOOMD 2"
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
         )
 
     def _get_masses_from_snapshot(self, sim, snap):
@@ -365,7 +311,27 @@ class InitializeRandomly(InitializationOperation):
         return snap
 
 
-# integrators
+# simulation operations
+class SimulationOperation(simulate.SimulationOperation):
+    def __call__(self, sim):
+        if _version.major == 3:
+            self._call_v3(sim)
+        elif _version.major == 2:
+            self._call_v2(sim)
+        else:
+            raise NotImplementedError(f"HOOMD {_version} not supported")
+
+    def _call_v3(self, sim):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
+        )
+
+    def _call_v2(self, sim):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
+        )
+
+
 class MinimizeEnergy(SimulationOperation):
     """Run energy minimization until convergence.
 
@@ -461,7 +427,7 @@ class MinimizeEnergy(SimulationOperation):
             del fire
 
 
-class _MDIntegrator(SimulationOperation):
+class _Integrator(SimulationOperation):
     """Base HOOMD molecular dynamics integrator.
 
     Parameters
@@ -476,25 +442,9 @@ class _MDIntegrator(SimulationOperation):
     """
 
     def __init__(self, steps, timestep, analyzers):
+        super().__init__(analyzers)
         self.steps = steps
         self.timestep = timestep
-        self.analyzers = analyzers
-
-    @property
-    def analyzers(self):
-        return self._analyzers
-
-    @analyzers.setter
-    def analyzers(self, ops):
-        if ops is not None:
-            try:
-                ops_ = list(ops)
-            except TypeError:
-                ops_ = [ops]
-        else:
-            ops_ = []
-
-        self._analyzers = ops_
 
     @staticmethod
     def _make_kT(sim, thermostat, steps):
@@ -527,7 +477,7 @@ class _MDIntegrator(SimulationOperation):
             return kB * thermostat.T
 
 
-class RunBrownianDynamics(_MDIntegrator):
+class RunBrownianDynamics(_Integrator):
     """Perform a Brownian dynamics simulation.
 
     See :class:`relentless.simulate.RunBrownianDynamics` for details.
@@ -611,7 +561,7 @@ class RunBrownianDynamics(_MDIntegrator):
             del bd, ig
 
 
-class RunLangevinDynamics(_MDIntegrator):
+class RunLangevinDynamics(_Integrator):
     """Perform a Langevin dynamics simulation.
 
     See :class:`relentless.simulate.RunLangevinDynamics` for details.
@@ -695,7 +645,7 @@ class RunLangevinDynamics(_MDIntegrator):
             del ld, ig
 
 
-class RunMolecularDynamics(_MDIntegrator):
+class RunMolecularDynamics(_Integrator):
     """Perform a molecular dynamics simulation.
 
     This method supports:
@@ -873,6 +823,44 @@ class RunMolecularDynamics(_MDIntegrator):
 
 
 # analyzers
+class AnalysisOperation(simulate.AnalysisOperation):
+    def pre_run(self, sim, sim_op):
+        if _version.major == 3:
+            self._pre_run_v3(sim, sim_op)
+        elif _version.major == 2:
+            self._pre_run_v2(sim, sim_op)
+        else:
+            raise NotImplementedError(f"HOOMD {_version} not supported")
+
+    def post_run(self, sim, sim_op):
+        if _version.major == 3:
+            self._post_run_v3(sim, sim_op)
+        elif _version.major == 2:
+            self._post_run_v2(sim, sim_op)
+        else:
+            raise NotImplementedError(f"HOOMD {_version} not supported")
+
+    def _pre_run_v3(self, sim, sim_op):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
+        )
+
+    def _pre_run_v2(self, sim, sim_op):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
+        )
+
+    def _post_run_v3(self, sim, sim_op):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
+        )
+
+    def _post_run_v2(self, sim, sim_op):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} not implemented in HOOMD {_version}"
+        )
+
+
 class EnsembleAverage(AnalysisOperation):
     """Analyzer for the simulation ensemble.
 
@@ -1028,10 +1016,7 @@ class EnsembleAverage(AnalysisOperation):
         return rdf_params
 
     class ThermodynamicsCallback(Action):
-        """HOOMD callback for averaging thermodynamic properties."""
-
-        if _version is not None and _version.major == 3:
-            flags = [Action.Flags.PRESSURE_TENSOR]
+        flags = [Action.Flags.PRESSURE_TENSOR]
 
         def __init__(self, thermo, dimension):
             if dimension not in (2, 3):
@@ -1281,10 +1266,7 @@ class Record(AnalysisOperation):
         del sim[self]["_recorder"]
 
     class RecorderCallback(Action):
-        """HOOMD callback for recording thermodynamic properties."""
-
-        if _version is not None and _version.major == 3:
-            flags = [Action.Flags.PRESSURE_TENSOR]
+        flags = [Action.Flags.PRESSURE_TENSOR]
 
         def __init__(self, thermo, quantities):
             self.thermo = thermo

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -25,159 +25,14 @@ except ImportError:
     _lammpsio_found = False
 
 
-class SimulationOperation(simulate.SimulationOperation):
-    """LAMMPS simulation operation."""
-
-    _compute_counter = 1
-    _dump_counter = 1
-    _fix_counter = 1
-    _group_counter = 1
-    _variable_counter = 1
-
-    def __call__(self, sim):
-        """Evaluate the LAMMPS simulation operation.
-
-        Each deriving class of :class:`SimulationOperation` must implement a
-        :meth:`to_commands()` method that returns a list or tuple of LAMMPS
-        commands that can be executed by :meth:`lammps.commands_list()`.
-
-        Parameters
-        ----------
-        sim : :class:`~relentless.simulate.SimulationInstance`
-            The simulation instance.
-
-        """
-        cmds = self.to_commands(sim)
-        if cmds is None or len(cmds) == 0:
-            return
-
-        sim["engine"]["_lammps_commands"] += cmds
-        if sim["engine"]["use_python"]:
-            sim["engine"]["_lammps"].commands_list(cmds)
-
-    @classmethod
-    def new_compute_id(cls):
-        """Make a unique new compute ID.
-
-        Returns
-        -------
-        int
-            The compute ID.
-
-        """
-        idx = int(SimulationOperation._compute_counter)
-        SimulationOperation._compute_counter += 1
-        return "c{}".format(idx)
-
-    @classmethod
-    def new_dump_id(cls):
-        """Make a unique new dump ID.
-
-        Returns
-        -------
-        int
-            The dump ID.
-
-        """
-        idx = int(SimulationOperation._dump_counter)
-        SimulationOperation._dump_counter += 1
-        return "d{}".format(idx)
-
-    @classmethod
-    def new_fix_id(cls):
-        """Make a unique new fix ID.
-
-        Returns
-        -------
-        int
-            The fix ID.
-
-        """
-        idx = int(SimulationOperation._fix_counter)
-        SimulationOperation._fix_counter += 1
-        return "f{}".format(idx)
-
-    @classmethod
-    def new_group_id(cls):
-        """Make a unique new fix ID.
-
-        Returns
-        -------
-        int
-            The fix ID.
-
-        """
-        idx = int(SimulationOperation._group_counter)
-        SimulationOperation._group_counter += 1
-        return "g{}".format(idx)
-
-    @classmethod
-    def new_variable_id(cls):
-        """Make a unique new variable ID.
-
-        Returns
-        -------
-        int
-            The variable ID.
-
-        """
-        idx = int(SimulationOperation._variable_counter)
-        SimulationOperation._variable_counter += 1
-        return "v{}".format(idx)
-
-    @abc.abstractmethod
-    def to_commands(self, sim):
-        """Create the LAMMPS commands for the simulation operation.
-
-        All deriving classes must implement this method.
-
-        Parameters
-        ----------
-        sim : :class:`~relentless.simulate.SimulationInstance`
-            The simulation instance.
-
-        Returns
-        -------
-        array_like
-            The LAMMPS commands for this operation.
-
-        """
-        pass
-
-
-class AnalysisOperation(simulate.AnalysisOperation):
-    def pre_run(self, sim, sim_op):
-        cmds = self.pre_run_commands(sim, sim_op)
-        if cmds is None or len(cmds) == 0:
-            return
-
-        sim["engine"]["_lammps_commands"] += cmds
-        if sim["engine"]["use_python"]:
-            sim["engine"]["_lammps"].commands_list(cmds)
-
-    def post_run(self, sim, sim_op):
-        cmds = self.post_run_commands(sim, sim_op)
-        if cmds is None or len(cmds) == 0:
-            return
-
-        sim["engine"]["_lammps_commands"] += cmds
-        if sim["engine"]["use_python"]:
-            sim["engine"]["_lammps"].commands_list(cmds)
-
-    @abc.abstractmethod
-    def pre_run_commands(self, sim, sim_op):
-        pass
-
-    @abc.abstractmethod
-    def post_run_commands(self, sim, sim_op):
-        pass
-
-
 # initializers
-class InitializationOperation(SimulationOperation, simulate.InitializationOperation):
+class InitializationOperation(simulate.InitializationOperation):
     """Initialize a simulation."""
 
-    def to_commands(self, sim):
+    def __call__(self, sim):
+        SimulationOperation.__call__(self, sim)
+
+    def call_commands(self, sim):
         cmds = [
             "units {style}".format(style=sim["engine"]["units"]),
             "boundary p p p",
@@ -445,6 +300,127 @@ class InitializeRandomly(InitializationOperation):
         return ["read_data {}".format(init_file)]
 
 
+# simulation operations
+class SimulationOperation(simulate.SimulationOperation):
+    """LAMMPS simulation operation."""
+
+    _compute_counter = 1
+    _dump_counter = 1
+    _fix_counter = 1
+    _group_counter = 1
+    _variable_counter = 1
+
+    def __call__(self, sim):
+        """Evaluate the LAMMPS simulation operation.
+
+        Each deriving class of :class:`SimulationOperation` must implement a
+        :meth:`call_commands()` method that returns a list or tuple of LAMMPS
+        commands that can be executed by :meth:`lammps.commands_list()`.
+
+        Parameters
+        ----------
+        sim : :class:`~relentless.simulate.SimulationInstance`
+            The simulation instance.
+
+        """
+        cmds = self.call_commands(sim)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim["engine"]["_lammps_commands"] += cmds
+        if sim["engine"]["use_python"]:
+            sim["engine"]["_lammps"].commands_list(cmds)
+
+    @classmethod
+    def new_compute_id(cls):
+        """Make a unique new compute ID.
+
+        Returns
+        -------
+        int
+            The compute ID.
+
+        """
+        idx = int(SimulationOperation._compute_counter)
+        SimulationOperation._compute_counter += 1
+        return "c{}".format(idx)
+
+    @classmethod
+    def new_dump_id(cls):
+        """Make a unique new dump ID.
+
+        Returns
+        -------
+        int
+            The dump ID.
+
+        """
+        idx = int(SimulationOperation._dump_counter)
+        SimulationOperation._dump_counter += 1
+        return "d{}".format(idx)
+
+    @classmethod
+    def new_fix_id(cls):
+        """Make a unique new fix ID.
+
+        Returns
+        -------
+        int
+            The fix ID.
+
+        """
+        idx = int(SimulationOperation._fix_counter)
+        SimulationOperation._fix_counter += 1
+        return "f{}".format(idx)
+
+    @classmethod
+    def new_group_id(cls):
+        """Make a unique new fix ID.
+
+        Returns
+        -------
+        int
+            The fix ID.
+
+        """
+        idx = int(SimulationOperation._group_counter)
+        SimulationOperation._group_counter += 1
+        return "g{}".format(idx)
+
+    @classmethod
+    def new_variable_id(cls):
+        """Make a unique new variable ID.
+
+        Returns
+        -------
+        int
+            The variable ID.
+
+        """
+        idx = int(SimulationOperation._variable_counter)
+        SimulationOperation._variable_counter += 1
+        return "v{}".format(idx)
+
+    @abc.abstractmethod
+    def call_commands(self, sim):
+        """Create the LAMMPS commands for the simulation operation.
+
+        All deriving classes must implement this method.
+
+        Parameters
+        ----------
+        sim : :class:`~relentless.simulate.SimulationInstance`
+            The simulation instance.
+
+        Returns
+        -------
+        array_like
+            The LAMMPS commands for this operation.
+
+        """
+        pass
+
+
 class MinimizeEnergy(SimulationOperation):
     """Perform energy minimization on a configuration.
 
@@ -474,7 +450,7 @@ class MinimizeEnergy(SimulationOperation):
         if "max_evaluations" not in self.options:
             self.options["max_evaluations"] = None
 
-    def to_commands(self, sim):
+    def call_commands(self, sim):
         if self.options["max_evaluations"] is None:
             self.options["max_evaluations"] = 100 * self.max_iterations
 
@@ -497,7 +473,7 @@ class MinimizeEnergy(SimulationOperation):
         return cmds
 
 
-class _MDIntegrator(SimulationOperation):
+class _Integrator(SimulationOperation):
     """Base LAMMPS molecular dynamics integrator.
 
     Parameters
@@ -512,9 +488,9 @@ class _MDIntegrator(SimulationOperation):
     """
 
     def __init__(self, steps, timestep, analyzers):
+        super().__init__(analyzers)
         self.steps = steps
         self.timestep = timestep
-        self.analyzers = analyzers
 
     def __call__(self, sim):
         for analyzer in self.analyzers:
@@ -524,22 +500,6 @@ class _MDIntegrator(SimulationOperation):
 
         for analyzer in self.analyzers:
             analyzer.post_run(sim, self)
-
-    @property
-    def analyzers(self):
-        return self._analyzers
-
-    @analyzers.setter
-    def analyzers(self, ops):
-        if ops is not None:
-            try:
-                ops_ = list(ops)
-            except TypeError:
-                ops_ = [ops]
-        else:
-            ops_ = []
-
-        self._analyzers = ops_
 
     def _run_commands(self, sim):
         cmds = ["run {N}".format(N=self.steps)]
@@ -568,7 +528,7 @@ class _MDIntegrator(SimulationOperation):
             return (thermostat.T, thermostat.T)
 
 
-class RunLangevinDynamics(_MDIntegrator):
+class RunLangevinDynamics(_Integrator):
     """Perform a Langevin dynamics simulation.
 
     See :class:`relentless.simulate.RunLangevinDynamics` for details.
@@ -596,7 +556,7 @@ class RunLangevinDynamics(_MDIntegrator):
         self.friction = friction
         self.seed = seed
 
-    def to_commands(self, sim):
+    def call_commands(self, sim):
         # obtain per-type friction factor
         Ntypes = len(sim.types)
         mass = numpy.zeros(Ntypes)
@@ -646,7 +606,7 @@ class RunLangevinDynamics(_MDIntegrator):
         return cmds
 
 
-class RunMolecularDynamics(_MDIntegrator):
+class RunMolecularDynamics(_Integrator):
     """Perform a molecular dynamics simulation.
 
     This method supports:
@@ -682,7 +642,7 @@ class RunMolecularDynamics(_MDIntegrator):
         self.thermostat = thermostat
         self.barostat = barostat
 
-    def to_commands(self, sim):
+    def call_commands(self, sim):
         fix_ids = {"ig": self.new_fix_id()}
 
         if self.thermostat is not None:
@@ -777,6 +737,35 @@ class RunMolecularDynamics(_MDIntegrator):
         cmds += self._run_commands(sim)
         cmds += ["unfix {}".format(idx) for idx in fix_ids.values()]
         return cmds
+
+
+# analyzers
+class AnalysisOperation(simulate.AnalysisOperation):
+    def pre_run(self, sim, sim_op):
+        cmds = self.pre_run_commands(sim, sim_op)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim["engine"]["_lammps_commands"] += cmds
+        if sim["engine"]["use_python"]:
+            sim["engine"]["_lammps"].commands_list(cmds)
+
+    def post_run(self, sim, sim_op):
+        cmds = self.post_run_commands(sim, sim_op)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim["engine"]["_lammps_commands"] += cmds
+        if sim["engine"]["use_python"]:
+            sim["engine"]["_lammps"].commands_list(cmds)
+
+    @abc.abstractmethod
+    def pre_run_commands(self, sim, sim_op):
+        pass
+
+    @abc.abstractmethod
+    def post_run_commands(self, sim, sim_op):
+        pass
 
 
 class EnsembleAverage(AnalysisOperation):

--- a/src/relentless/simulate/md.py
+++ b/src/relentless/simulate/md.py
@@ -20,6 +20,7 @@ class MinimizeEnergy(simulate.DelegatedSimulationOperation):
     """
 
     def __init__(self, energy_tolerance, force_tolerance, max_iterations, options=None):
+        super().__init__(None)
         self.energy_tolerance = energy_tolerance
         self.force_tolerance = force_tolerance
         self.max_iterations = max_iterations
@@ -50,25 +51,9 @@ class _Integrator(simulate.DelegatedSimulationOperation):
     """
 
     def __init__(self, steps, timestep, analyzers):
+        super().__init__(analyzers)
         self.steps = steps
         self.timestep = timestep
-        self.analyzers = analyzers
-
-    @property
-    def analyzers(self):
-        return self._analyzers
-
-    @analyzers.setter
-    def analyzers(self, ops):
-        if ops is not None:
-            try:
-                ops_ = list(ops)
-            except TypeError:
-                ops_ = [ops]
-        else:
-            ops_ = []
-
-        self._analyzers = ops_
 
 
 class RunBrownianDynamics(_Integrator):


### PR DESCRIPTION
To break diamond inheritance patterns and make a clear hierarchy of operations:

- `InitializationOperation`
- `SimulationOperation`
- `AnalysisOperation`

This should be rebased after PR #169 is merged.