### PR TITLE
Support Brownian dynamics in LAMMPS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-        mpi: ['nompi', 'mpich', 'openmpi']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        mpi: ["nompi", "mpich", "openmpi"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup MPI
-        if: ${{ matrix.mpi != 'nompi' }}
+        if: ${{ matrix.mpi != "nompi" }}
         uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
@@ -44,15 +44,15 @@ jobs:
           pip install .
       - name: Test
         run: |
-          python -m unittest discover -v -s ./tests -p 'test_*.py'
+          python -m unittest discover -v -s ./tests -p "test_*.py"
       - name: Install mpi4py
-        if: ${{ matrix.mpi != 'nompi' }}
+        if: ${{ matrix.mpi != "nompi" }}
         run: |
           pip install --no-cache-dir mpi4py
       - name: Test MPI [${{ matrix.mpi }}]
-        if: ${{ matrix.mpi != 'nompi' }}
+        if: ${{ matrix.mpi != "nompi" }}
         run: |
-          mpiexec -n 2 python -m unittest discover -v -s ./tests -p 'test_*.py'
+          mpiexec -n 2 python -m unittest discover -v -s ./tests -p "test_*.py"
 
   test-hoomd:
     name: unit test [python-${{ matrix.python-version }}, hoomd-${{ matrix.hoomd-version }}]
@@ -64,11 +64,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-        hoomd-version: ['2.9.7', '3.9.0']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        hoomd-version: ["2.9.7", "3.9.0"]
         exclude:
-          - python-version: '3.11'
-            hoomd-version: '2.9.7'
+          - python-version: "3.11"
+            hoomd-version: "2.9.7"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -101,9 +101,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        lammps-version: ['2021.09.29', '2022.06.23']
-        mpi: ['mpich', 'openmpi']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        lammps-version: ["2021.09.29", "2022.06.23"]
+        mpi: ["mpich", "openmpi"]
+        exclude:
+          - python-version: "3.11"
+            lammps-version: "2021.09.29"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -113,7 +116,7 @@ jobs:
           miniconda-version: latest
           python-version: ${{ matrix.python-version }}
       - name: Install conda MPI workaround
-        if: ${{ matrix.lammps-version == '2021.09.29' && matrix.mpi == 'openmpi' }}
+        if: ${{ matrix.lammps-version == "2021.09.29" && matrix.mpi == "openmpi" }}
         run: |
           conda install -c conda-forge "openmpi=4.1.4=ha*"
       - name: Install test dependencies
@@ -141,15 +144,15 @@ jobs:
   test-exit:
     name: unit test
     needs: [test, test-hoomd, test-lammps]
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == "pull_request" }}
     runs-on: ubuntu-latest
     steps:
       - name: Check core tests
-        if: needs.test.result != 'success'
+        if: needs.test.result != "success"
         run: echo "::error ::core tests failed." && exit 1
       - name: Check hoomd tests
-        if: needs.test-hoomd.result != 'success'
+        if: needs.test-hoomd.result != "success"
         run: echo "::error ::hoomd tests failed." && exit 1
       - name: Check lammps tests
-        if: needs.test-lammps.result != 'success'
+        if: needs.test-lammps.result != "success"
         run: echo "::error ::lammps tests failed." && exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup MPI
-        if: ${{ matrix.mpi != "nompi" }}
+        if: ${{ matrix.mpi != 'nompi' }}
         uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
@@ -46,11 +46,11 @@ jobs:
         run: |
           python -m unittest discover -v -s ./tests -p "test_*.py"
       - name: Install mpi4py
-        if: ${{ matrix.mpi != "nompi" }}
+        if: ${{ matrix.mpi != 'nompi' }}
         run: |
           pip install --no-cache-dir mpi4py
       - name: Test MPI [${{ matrix.mpi }}]
-        if: ${{ matrix.mpi != "nompi" }}
+        if: ${{ matrix.mpi != 'nompi' }}
         run: |
           mpiexec -n 2 python -m unittest discover -v -s ./tests -p "test_*.py"
 
@@ -116,7 +116,7 @@ jobs:
           miniconda-version: latest
           python-version: ${{ matrix.python-version }}
       - name: Install conda MPI workaround
-        if: ${{ matrix.lammps-version == "2021.09.29" && matrix.mpi == "openmpi" }}
+        if: ${{ matrix.lammps-version == '2021.09.29' && matrix.mpi == 'openmpi' }}
         run: |
           conda install -c conda-forge "openmpi=4.1.4=ha*"
       - name: Install test dependencies
@@ -144,15 +144,15 @@ jobs:
   test-exit:
     name: unit test
     needs: [test, test-hoomd, test-lammps]
-    if: ${{ always() && github.event_name == "pull_request" }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check core tests
-        if: needs.test.result != "success"
+        if: needs.test.result != 'success'
         run: echo "::error ::core tests failed." && exit 1
       - name: Check hoomd tests
-        if: needs.test-hoomd.result != "success"
+        if: needs.test-hoomd.result != 'success'
         run: echo "::error ::hoomd tests failed." && exit 1
       - name: Check lammps tests
-        if: needs.test-lammps.result != "success"
+        if: needs.test-lammps.result != 'success'
         run: echo "::error ::lammps tests failed." && exit 1

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -529,7 +529,7 @@ class _Integrator(SimulationOperation):
 
 
 class RunBrownianDynamics(_Integrator):
-    """Perform a Langevin dynamics simulation.
+    """Perform a Brownian dynamics simulation.
 
     See :class:`relentless.simulate.RunBrownianDynamics` for details.
 

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -200,7 +200,9 @@ class test_LAMMPS(unittest.TestCase):
         brn = relentless.simulate.RunBrownianDynamics(
             steps=1, timestep=1.0e-3, T=ens.T, friction=1.0, seed=2
         )
-        h = relentless.simulate.LAMMPS(init, brn, dimension=self.dim)
+        h = relentless.simulate.LAMMPS(
+            init, brn, dimension=self.dim, executable=self.executable
+        )
         try:
             h.run(pot, self.directory)
         except NotImplementedError as e:
@@ -216,6 +218,7 @@ class test_LAMMPS(unittest.TestCase):
             else:
                 raise e
 
+        # different friction coefficients
         brn.friction = {"A": 1.5, "B": 2.5}
         h.run(pot, self.directory)
 

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -203,20 +203,10 @@ class test_LAMMPS(unittest.TestCase):
         h = relentless.simulate.LAMMPS(
             init, brn, dimension=self.dim, executable=self.executable
         )
-        try:
+        if "BROWNIAN" not in h.packages:
+            self.skipTest("LAMMPS BROWNIAN package not installed")
+        else:
             h.run(pot, self.directory)
-        except NotImplementedError as e:
-            msg = str(e)
-            if "support Brownian dynamics" in msg:
-                self.skipTest("LAMMPS version does not support Brownian dynamics")
-            else:
-                raise e
-        except Exception as e:
-            msg = str(e)
-            if "brownian" in msg and "not enabled" in msg:
-                self.skipTest("LAMMPS BROWNIAN package not installed")
-            else:
-                raise e
 
         # different friction coefficients
         brn.friction = {"A": 1.5, "B": 2.5}


### PR DESCRIPTION
This PR adds conditional / experimental support for Brownian dynamics in LAMMPS. There are several checks needed to make sure LAMMPS can run this type of simulation, and the CI does not currently include the `BROWNIAN` package so it is not very well tested. However, we can probably test in production since the changes are not too complicated.

This should be rebased and merged after PR #170.

Fixes #166 