### PR TITLE
Refactor interpolators and splines

### DIFF
--- a/src/relentless/model/ensemble.py
+++ b/src/relentless/model/ensemble.py
@@ -25,16 +25,13 @@ using an Akima spline.
 import copy
 import json
 
-import numpy
-
-from relentless import mpi
+from relentless import math, mpi
 from relentless.collections import FixedKeyDict, PairMatrix
-from relentless.math import Interpolator
 
 from . import extent
 
 
-class RDF(Interpolator):
+class RDF:
     r"""Radial distribution function.
 
     Represents the pair distribution function :math:`g(r)` as a ``(N,2)``
@@ -50,8 +47,14 @@ class RDF(Interpolator):
     """
 
     def __init__(self, r, g):
-        super().__init__(r, g)
-        self.table = numpy.column_stack((r, g))
+        self._spline = math.AkimaSpline(r, g)
+
+    def __call__(self, r):
+        return self._spline(r)
+
+    @property
+    def table(self):
+        return self._spline.table
 
 
 class Ensemble:

--- a/src/relentless/model/potential/pair.py
+++ b/src/relentless/model/potential/pair.py
@@ -1050,7 +1050,7 @@ class PairSpline(PairPotential):
         # reconstruct the energies from differences, starting from the end
         if self.mode == "diff":
             u = numpy.flip(numpy.cumsum(numpy.flip(u)))
-        return math.Interpolator(x=r, y=u)
+        return math.AkimaSpline(x=r, y=u)
 
     @property
     def num_knots(self):

--- a/src/relentless/model/potential/pair.py
+++ b/src/relentless/model/potential/pair.py
@@ -923,9 +923,13 @@ class PairSpline(PairPotential):
             # with last knot fixed at its current value
             ks[:-1] -= ks[1:]
 
-        # make all knots variables, but hold all r and the last knot const
+        # convert knot positions to differences
+        drs = numpy.zeros_like(rs)
+        drs[0] = rs[0]
+        drs[1:] = rs[1:] - rs[:-1]
+
         for i in range(self.num_knots):
-            self._set_knot(pair, i, rs[i], ks[i])
+            self._set_knot(pair, i, drs[i], ks[i])
 
     def to_json(self):
         data = super().to_json()
@@ -956,9 +960,9 @@ class PairSpline(PairPotential):
         """
         if not isinstance(i, int):
             raise TypeError("Knots are keyed by integers")
-        return f"r-{i}", f"{self.mode}-{i}"
+        return f"dr-{i}", f"{self.mode}-{i}"
 
-    def _set_knot(self, pair, i, r, k):
+    def _set_knot(self, pair, i, dr, k):
         """Set the value of knot variables.
 
         The meaning of the value of the knot variable is defined by the ``mode``.
@@ -971,16 +975,19 @@ class PairSpline(PairPotential):
         i : int
             Index of the knot.
         r : float
-            Position of each knot.
+            Relative position of each knot from previous one.
         u : float
             Value of the knot variable.
 
         """
-        ri, ki = self.knot_params(i)
-        if isinstance(self.coeff[pair][ri], variable.IndependentVariable):
-            self.coeff[pair][ri].value = r
+        if i > 0 and dr <= 0:
+            raise ValueError("Knot spacings must be positive")
+
+        dri, ki = self.knot_params(i)
+        if isinstance(self.coeff[pair][dri], variable.IndependentVariable):
+            self.coeff[pair][dri].value = dr
         else:
-            self.coeff[pair][ri] = variable.IndependentVariable(r)
+            self.coeff[pair][dri] = variable.IndependentVariable(dr)
         if isinstance(self.coeff[pair][ki], variable.IndependentVariable):
             self.coeff[pair][ki].value = k
         else:
@@ -1007,15 +1014,25 @@ class PairSpline(PairPotential):
         r, d, s = self._zeros(r)
         h = 0.001
 
-        # perturb knot param value
-        knot_p = params[param]
-        params[param] = knot_p + h
-        f_high = self._interpolate(params)(r)
-        params[param] = knot_p - h
-        f_low = self._interpolate(params)(r)
+        if "dr-" in param:
+            f_low = self._interpolate(params)(r)
+            knot_p = params[param]
+            params[param] = knot_p + h
+            f_high = self._interpolate(params)(r)
+            params[param] = knot_p
+            d = (f_high - f_low) / h
+        elif "akima-" in param:
+            # perturb knot param value
+            knot_p = params[param]
+            params[param] = knot_p + h
+            f_high = self._interpolate(params)(r)
+            params[param] = knot_p - h
+            f_low = self._interpolate(params)(r)
+            params[param] = knot_p
+            d = (f_high - f_low) / (2 * h)
+        else:
+            raise ValueError("Parameter cannot be differentiated")
 
-        params[param] = knot_p
-        d = (f_high - f_low) / (2 * h)
         if s:
             d = d.item()
         return d
@@ -1034,15 +1051,23 @@ class PairSpline(PairPotential):
             The interpolated spline potential.
 
         """
-        r = numpy.zeros(self.num_knots)
+        dr = numpy.zeros(self.num_knots)
         u = numpy.zeros(self.num_knots)
         for i in range(self.num_knots):
-            ri, ki = self.knot_params(i)
-            r[i] = params[ri]
+            dri, ki = self.knot_params(i)
+            dr[i] = params[dri]
             u[i] = params[ki]
+
+        if numpy.any(dr[1:] <= 0):
+            raise ValueError("Knot differences must be positive")
+
+        # reconstruct r from differences
+        r = numpy.cumsum(dr)
+
         # reconstruct the energies from differences, starting from the end
         if self.mode == "akima-diff":
             u = numpy.flip(numpy.cumsum(numpy.flip(u)))
+
         return math.AkimaSpline(x=r, y=u)
 
     @property
@@ -1065,24 +1090,24 @@ class PairSpline(PairPotential):
 
         Yields
         ------
-        :class:`~relentless.variable.DesignVariable`
-            The next :math:`r` variable in the parameters.
-        :class:`~relentless.variable.DesignVariable`
+        :class:`~relentless.variable.Variable`
+            The next :math:`dr` variable in the parameters.
+        :class:`~relentless.variable.Variable`
             The next knot variable in the parameters.
 
         """
         for i in range(self.num_knots):
-            ri, ki = self.knot_params(i)
-            r = self.coeff[pair][ri]
-            k = self.coeff[pair][ki]
-            yield r, k
+            dri, ki = self.knot_params(i)
+            yield self.coeff[pair][dri], self.coeff[pair][ki]
 
     @property
     def design_variables(self):
         """tuple: Designable variables of the spline."""
         dvars = []
         for pair in self.coeff:
-            for r, k in self.knots(pair):
+            for dr, k in self.knots(pair):
+                if isinstance(dr, variable.DesignVariable):
+                    dvars.append(dr)
                 if isinstance(k, variable.DesignVariable):
                     dvars.append(k)
         return tuple(dvars)

--- a/src/relentless/optimize/objective.py
+++ b/src/relentless/optimize/objective.py
@@ -412,12 +412,16 @@ class RelativeEntropy(ObjectiveFunction):
                     continue
 
                 # interpolate derivative wrt design variable with r
-                dudvar = math.Interpolator(rs, dus)
+                dudvar = math.AkimaSpline(rs, dus)
 
                 # find common domain to compare rdfs
-                r0 = max(g_sim[i, j].domain[0], g_tgt[i, j].domain[0], dudvar.domain[0])
+                r0 = max(
+                    g_sim[i, j].table[0, 0], g_tgt[i, j].table[0, 0], dudvar.table[0, 0]
+                )
                 r1 = min(
-                    g_sim[i, j].domain[-1], g_tgt[i, j].domain[-1], dudvar.domain[-1]
+                    g_sim[i, j].table[-1, 0],
+                    g_tgt[i, j].table[-1, 0],
+                    dudvar.table[-1, 0],
                 )
                 sim_dr = numpy.min(numpy.diff(g_sim[i, j].table[:, 0]))
                 tgt_dr = numpy.min(numpy.diff(g_tgt[i, j].table[:, 0]))

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -6,7 +6,6 @@ from packaging import version
 
 from relentless import mpi
 from relentless.collections import FixedKeyDict, PairMatrix
-from relentless.math import Interpolator
 from relentless.model import ensemble, extent
 
 from . import initialize, md, simulate
@@ -150,9 +149,7 @@ class InitializationOperation(SimulationOperation, simulate.InitializationOperat
             r = coeff["r"]
             u = coeff["u"]
             f = coeff["f"]
-            u_r = Interpolator(r, u)
-            f_r = Interpolator(r, f)
-            return (u_r(r_i), f_r(r_i))
+            return (numpy.interp(r_i, r, u), numpy.interp(r_i, r, f))
 
         with sim["engine"]["_hoomd"]:
             neighbor_list = hoomd.md.nlist.tree(

--- a/tests/model/potential/test_pair.py
+++ b/tests/model/potential/test_pair.py
@@ -582,9 +582,9 @@ class test_PairSpline(unittest.TestCase):
         coeff = relentless.model.potential.PairParameters(
             types=("1",),
             params=(
-                "r-0",
-                "r-1",
-                "r-2",
+                "dr-0",
+                "dr-1",
+                "dr-2",
                 "akima-diff-0",
                 "akima-diff-1",
                 "akima-diff-2",
@@ -605,9 +605,9 @@ class test_PairSpline(unittest.TestCase):
         coeff = relentless.model.potential.PairParameters(
             types=("1",),
             params=(
-                "r-0",
-                "r-1",
-                "r-2",
+                "dr-0",
+                "dr-1",
+                "dr-2",
                 "akima-value-0",
                 "akima-value-1",
                 "akima-value-2",
@@ -641,7 +641,7 @@ class test_PairSpline(unittest.TestCase):
 
         dvars = []
         for i, (r, k) in enumerate(s.knots(pair=("1", "1"))):
-            self.assertAlmostEqual(r.value, r_arr[i])
+            self.assertAlmostEqual(r.value, 1.0)
             self.assertAlmostEqual(k.value, u_arr_diff[i])
             self.assertIsInstance(r, relentless.model.IndependentVariable)
             if i == s.num_knots - 1:
@@ -659,7 +659,7 @@ class test_PairSpline(unittest.TestCase):
 
         dvars = []
         for i, (r, k) in enumerate(s.knots(pair=("1", "1"))):
-            self.assertAlmostEqual(r.value, r_arr[i])
+            self.assertAlmostEqual(r.value, 1.0)
             self.assertAlmostEqual(k.value, u_arr[i])
             self.assertIsInstance(r, relentless.model.IndependentVariable)
             if i == s.num_knots - 1:
@@ -771,7 +771,7 @@ class test_PairSpline(unittest.TestCase):
 
         s2 = relentless.model.potential.PairSpline.from_json(data)
         for i, (r, k) in enumerate(s2.knots(pair=("1", "1"))):
-            self.assertAlmostEqual(r.value, r_arr[i])
+            self.assertAlmostEqual(r.value, 1.0)
             self.assertAlmostEqual(k.value, u_arr_diff[i])
 
 

--- a/tests/model/potential/test_pair.py
+++ b/tests/model/potential/test_pair.py
@@ -578,16 +578,16 @@ class test_PairSpline(unittest.TestCase):
         # test diff mode
         s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
         self.assertEqual(s.num_knots, 3)
-        self.assertEqual(s.mode, "akima-diff")
+        self.assertEqual(s.mode, "diff")
         coeff = relentless.model.potential.PairParameters(
             types=("1",),
             params=(
                 "dr-0",
                 "dr-1",
                 "dr-2",
-                "akima-diff-0",
-                "akima-diff-1",
-                "akima-diff-2",
+                "diff-0",
+                "diff-1",
+                "diff-2",
                 "rmin",
                 "rmax",
                 "shift",
@@ -598,19 +598,19 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="akima-value"
+            types=("1",), num_knots=3, mode="value"
         )
         self.assertEqual(s.num_knots, 3)
-        self.assertEqual(s.mode, "akima-value")
+        self.assertEqual(s.mode, "value")
         coeff = relentless.model.potential.PairParameters(
             types=("1",),
             params=(
                 "dr-0",
                 "dr-1",
                 "dr-2",
-                "akima-value-0",
-                "akima-value-1",
-                "akima-value-2",
+                "value-0",
+                "value-1",
+                "value-2",
                 "rmin",
                 "rmax",
                 "shift",
@@ -653,7 +653,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="akima-value"
+            types=("1",), num_knots=3, mode="value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
 
@@ -693,7 +693,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="akima-value"
+            types=("1",), num_knots=3, mode="value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
         u_actual = numpy.array([6.25, 2.25, 1])
@@ -702,7 +702,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test PairSpline with 2 knots
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=2, mode="akima-value"
+            types=("1",), num_knots=2, mode="value"
         )
         s.from_array(pair=("1", "1"), r=[1, 2], u=[4, 2])
         u = s.energy(pair=("1", "1"), r=1.5)
@@ -722,7 +722,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="akima-value"
+            types=("1",), num_knots=3, mode="value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
         f_actual = numpy.array([5, 3, 0])
@@ -731,7 +731,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test PairSpline with 2 knots
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=2, mode="akima-value"
+            types=("1",), num_knots=2, mode="value"
         )
         s.from_array(pair=("1", "1"), r=[1, 2], u=[4, 2])
         f = s.force(pair=("1", "1"), r=1.5)
@@ -752,7 +752,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="akima-value"
+            types=("1",), num_knots=3, mode="value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
         d_actual = numpy.array([0.75, 0.75, 0])

--- a/tests/model/potential/test_pair.py
+++ b/tests/model/potential/test_pair.py
@@ -578,16 +578,16 @@ class test_PairSpline(unittest.TestCase):
         # test diff mode
         s = relentless.model.potential.PairSpline(types=("1",), num_knots=3)
         self.assertEqual(s.num_knots, 3)
-        self.assertEqual(s.mode, "diff")
+        self.assertEqual(s.mode, "akima-diff")
         coeff = relentless.model.potential.PairParameters(
             types=("1",),
             params=(
                 "r-0",
                 "r-1",
                 "r-2",
-                "knot-0",
-                "knot-1",
-                "knot-2",
+                "akima-diff-0",
+                "akima-diff-1",
+                "akima-diff-2",
                 "rmin",
                 "rmax",
                 "shift",
@@ -598,19 +598,19 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="value"
+            types=("1",), num_knots=3, mode="akima-value"
         )
         self.assertEqual(s.num_knots, 3)
-        self.assertEqual(s.mode, "value")
+        self.assertEqual(s.mode, "akima-value")
         coeff = relentless.model.potential.PairParameters(
             types=("1",),
             params=(
                 "r-0",
                 "r-1",
                 "r-2",
-                "knot-0",
-                "knot-1",
-                "knot-2",
+                "akima-value-0",
+                "akima-value-1",
+                "akima-value-2",
                 "rmin",
                 "rmax",
                 "shift",
@@ -653,7 +653,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="value"
+            types=("1",), num_knots=3, mode="akima-value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
 
@@ -693,7 +693,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="value"
+            types=("1",), num_knots=3, mode="akima-value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
         u_actual = numpy.array([6.25, 2.25, 1])
@@ -702,7 +702,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test PairSpline with 2 knots
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=2, mode="value"
+            types=("1",), num_knots=2, mode="akima-value"
         )
         s.from_array(pair=("1", "1"), r=[1, 2], u=[4, 2])
         u = s.energy(pair=("1", "1"), r=1.5)
@@ -722,7 +722,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="value"
+            types=("1",), num_knots=3, mode="akima-value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
         f_actual = numpy.array([5, 3, 0])
@@ -731,7 +731,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test PairSpline with 2 knots
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=2, mode="value"
+            types=("1",), num_knots=2, mode="akima-value"
         )
         s.from_array(pair=("1", "1"), r=[1, 2], u=[4, 2])
         f = s.force(pair=("1", "1"), r=1.5)
@@ -752,7 +752,7 @@ class test_PairSpline(unittest.TestCase):
 
         # test value mode
         s = relentless.model.potential.PairSpline(
-            types=("1",), num_knots=3, mode="value"
+            types=("1",), num_knots=3, mode="akima-value"
         )
         s.from_array(pair=("1", "1"), r=r_arr, u=u_arr)
         d_actual = numpy.array([0.75, 0.75, 0])

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -131,12 +131,12 @@ class test_RelativeEntropy(unittest.TestCase):
         rs = numpy.linspace(0, 3.6, 1001)[1:]
         r6_inv = numpy.power(0.9 / rs, 6)
         gs = numpy.exp(-(1 / 1.5) * 4.0 * 1.0 * (r6_inv**2 - r6_inv))
-        sim_rdf = relentless.math.Interpolator(rs, gs)
+        sim_rdf = relentless.math.AkimaSpline(rs, gs)
 
         rs = numpy.arange(0.05, 5.0, 0.1)
         r6_inv = numpy.power(0.9 / rs, 6)
         gs = numpy.exp(-4.0 * 1.0 * (r6_inv**2 - r6_inv))
-        tgt_rdf = relentless.math.Interpolator(rs, gs)
+        tgt_rdf = relentless.math.AkimaSpline(rs, gs)
 
         rs = numpy.linspace(0, 3.6, 1001)[1:]
         r6_inv = numpy.power(0.9 / rs, 6)
@@ -144,7 +144,7 @@ class test_RelativeEntropy(unittest.TestCase):
             dus = 4 * (r6_inv**2 - r6_inv)
         elif var is self.sigma:
             dus = (48.0 * 1.0 / 0.9) * (r6_inv**2 - 0.5 * r6_inv)
-        dudvar = relentless.math.Interpolator(rs, dus)
+        dudvar = relentless.math.AkimaSpline(rs, dus)
 
         if ext:
             norm_factor = 1.0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -6,51 +6,51 @@ import numpy
 import relentless
 
 
-class test_Interpolator(unittest.TestCase):
-    """Unit tests for relentless.math.Interpolator."""
+class test_AkimaSpline(unittest.TestCase):
+    """Unit tests for relentless.math.AkimaSpline."""
 
     def test_init(self):
         """Test creation from data."""
         # test construction with tuple input
-        f = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
+        f = relentless.math.AkimaSpline(x=(-1, 0, 1), y=(-2, 0, 2))
         self.assertEqual(f.domain, (-1, 1))
 
         # test construction with list input
-        f = relentless.math.Interpolator(x=[-1, 0, 1], y=[-2, 0, 2])
+        f = relentless.math.AkimaSpline(x=[-1, 0, 1], y=[-2, 0, 2])
         self.assertEqual(f.domain, (-1, 1))
 
         # test construction with numpy array input
-        f = relentless.math.Interpolator(
+        f = relentless.math.AkimaSpline(
             x=numpy.array([-1, 0, 1]), y=numpy.array([-2, 0, 2])
         )
         self.assertEqual(f.domain, (-1, 1))
 
         # test construction with mixed input
-        f = relentless.math.Interpolator(x=[-1, 0, 1], y=(-2, 0, 2))
+        f = relentless.math.AkimaSpline(x=[-1, 0, 1], y=(-2, 0, 2))
         self.assertEqual(f.domain, (-1, 1))
 
         # test construction with scalar input
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(x=1, y=2)
+            f = relentless.math.AkimaSpline(x=1, y=2)
 
         # test construction with 2d-array input
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(
+            f = relentless.math.AkimaSpline(
                 x=numpy.array([[-1, 0, 1], [-2, 2, 4]]),
                 y=numpy.array([[-1, 0, 1], [-2, 2, 4]]),
             )
 
         # test construction with x and y having different lengths
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(x=[-1, 0], y=[-2, 0, 2])
+            f = relentless.math.AkimaSpline(x=[-1, 0], y=[-2, 0, 2])
 
         # test construction with non-strictly-increasing domain
         with self.assertRaises(ValueError):
-            f = relentless.math.Interpolator(x=(0, 1, -1), y=(0, 2, -2))
+            f = relentless.math.AkimaSpline(x=(0, 1, -1), y=(0, 2, -2))
 
     def test_call(self):
         """Test calls, both scalar and array."""
-        f = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
+        f = relentless.math.AkimaSpline(x=(-1, 0, 1), y=(-2, 0, 2))
 
         # test scalar call
         self.assertAlmostEqual(f(-0.5), -1.0)
@@ -61,7 +61,7 @@ class test_Interpolator(unittest.TestCase):
 
     def test_derivative(self):
         """Test derivative function, both scalar and array."""
-        f = relentless.math.Interpolator(x=(-2, -1, 0, 1, 2), y=(4, 1, 0, 1, 4))
+        f = relentless.math.AkimaSpline(x=(-2, -1, 0, 1, 2), y=(4, 1, 0, 1, 4))
 
         # test scalar call
         d = f.derivative(x=1.5, n=1)
@@ -73,7 +73,7 @@ class test_Interpolator(unittest.TestCase):
 
     def test_extrap(self):
         """Test extrapolation calls."""
-        f = relentless.math.Interpolator(x=(-1, 0, 1), y=(-2, 0, 2))
+        f = relentless.math.AkimaSpline(x=(-1, 0, 1), y=(-2, 0, 2))
 
         # test extrap below lo
         self.assertAlmostEqual(f(-2), -2.0)


### PR DESCRIPTION
This PR refactors `Interpolator` and `PairSpline` to give future flexibility in defining the spline potential. For example, it would now be possible to implement B splines in the pair potential rather than Akima splines. This was not previously possible.

It also modifies the way the knot positions are stored so that they are now differences. This would allow these variables to be optimized in future.

One question is if we should rename "mode" to "style" or something like that. We could also separate them into a "mode" (which is value or diff) AND a "style" / "basis" (which is akima, bspline, etc.). That way we would not need to use the "-" that I currently chose. Ex:
```
mode="diff", style="akima"
```
vs.
```
mode="akima-diff"
```

@clpetix what do you think?