### PR TITLE
Fix tabulated pair potentials

### DIFF
--- a/src/relentless/optimize/objective.py
+++ b/src/relentless/optimize/objective.py
@@ -397,7 +397,7 @@ class RelativeEntropy(ObjectiveFunction):
         for var in dvars:
             update = 0
             for i, j in self.target.pairs:
-                rs = self.potentials.pair.x
+                rs = self.potentials.pair.linear_space
                 us = self.potentials.pair.energy((i, j))
                 dus = self.potentials.pair.derivative((i, j), var)
 

--- a/src/relentless/simulate/dilute.py
+++ b/src/relentless/simulate/dilute.py
@@ -168,7 +168,9 @@ class EnsembleAverage(simulate.AnalysisOperation):
         # pair distribution function
         for pair in ens.pairs:
             u = sim.potentials.pair.energy(pair)
-            ens.rdf[pair] = ensemble.RDF(sim.potentials.pair.x, numpy.exp(-u / kT))
+            ens.rdf[pair] = ensemble.RDF(
+                sim.potentials.pair.linear_space, numpy.exp(-u / kT)
+            )
 
         # compute pressure
         ens.P = 0.0
@@ -177,7 +179,7 @@ class EnsembleAverage(simulate.AnalysisOperation):
             ens.P += kT * rho_a
             for b in sim.types:
                 rho_b = ens.N[b] / ens.V.extent
-                r = sim.potentials.pair.x
+                r = sim.potentials.pair.linear_space
                 u = sim.potentials.pair.energy((a, b))
                 f = sim.potentials.pair.force((a, b))
                 gr = ens.rdf[a, b].table[:, 1]

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -9,7 +9,7 @@ import abc
 
 import numpy
 
-from relentless import data, mpi
+from relentless import collections, data, mpi
 from relentless.model import variable
 
 
@@ -33,31 +33,6 @@ class InitializationOperation(abc.ABC):
     @abc.abstractmethod
     def __call__(self, sim):
         pass
-
-    @staticmethod
-    def _get_tight_rcut(potential, pair, r, u, f):
-        # find r where potential and force are zero
-        if len(potential.potentials) > 0:
-            all_rmax = [
-                variable.evaluate(pair_pot.coeff[pair]["rmax"])
-                for pair_pot in potential.potentials
-            ]
-            if None not in all_rmax:
-                # use rmax if set for all potentials
-                rcut = min(max(all_rmax), potential.stop)
-            else:
-                # otherwise, deduce safe cutoff from tabulated values
-                nonzero_r = numpy.flatnonzero(
-                    numpy.logical_and(~numpy.isclose(u, 0), ~numpy.isclose(f, 0))
-                )
-                # cutoff at last nonzero r (cannot be first r)
-                # we add 1 to make sure we include the last point if
-                # potential happens to go smoothly to zero
-                rcut = r[min(nonzero_r[-1] + 1, len(r) - 1)]
-        else:
-            rcut = potential.stop
-
-        return rcut
 
 
 class SimulationOperation(abc.ABC):
@@ -698,3 +673,62 @@ class PairPotentialTabulator(PotentialTabulator):
         """
         d = super().derivative(pair, var, x) - super().derivative(pair, var, self.stop)
         return d
+
+    def all_energy_force(self, types, x=None, tight=False):
+        if x is None:
+            x = numpy.copy(self.x)
+        else:
+            x = numpy.atleast_1d(x)
+        if tight and len(x) < 2:
+            raise ValueError("Tight option can only be used if x has two points")
+
+        result = collections.PairMatrix(types)
+        stops = collections.PairMatrix(types)
+        for pair in result:
+            result[pair] = {
+                "energy": self.energy(pair, x),
+                "force": self.force(pair, x),
+            }
+
+            # compute the shrink wrapped rcut if requested
+            if tight:
+                all_rmax = [
+                    variable.evaluate(u.coeff[pair]["rmax"]) for u in self.potentials
+                ]
+                if len(all_rmax) == 0:
+                    # put first two points in the table if there are no potentials
+                    rcut = x[1]
+                elif None not in all_rmax:
+                    # use rmax if set for all potentials
+                    rcut = min(max(all_rmax), x[-1])
+                else:
+                    # otherwise, deduce safe cutoff from tabulated values
+                    nonzero_r = numpy.flatnonzero(
+                        numpy.logical_and(
+                            ~numpy.isclose(result[pair]["energy"], 0),
+                            ~numpy.isclose(result[pair]["force"], 0),
+                        )
+                    )
+                    # cutoff at last nonzero r (cannot be first r)
+                    # we add 1 to make sure we include the last point if
+                    # potential happens to go smoothly to zero
+                    rcut = x[min(nonzero_r[-1] + 1, len(x) - 1)]
+            else:
+                rcut = x[-1]
+
+            stops[pair] = rcut
+
+        # shrink wrap all of the data once largest stop is known
+        if tight:
+            max_stop = max(stops[pair] for pair in result)
+            flags = x <= max_stop
+            # make sure we get a second point, even if table is sparsely discretized
+            if numpy.sum(flags) == 1:
+                flags[1] = True
+
+            for pair in result:
+                result[pair]["energy"] = result[pair]["energy"][flags]
+                result[pair]["force"] = result[pair]["force"][flags]
+            x = x[flags]
+
+        return x, result

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -689,9 +689,9 @@ class PairPotentialTabulator(PotentialTabulator):
         tight : bool
             If ``True``, trim zeros from the ends of the energies and forces
             using a combination of cutoffs and evaluated potential. This option
-            can only be used when `x` is an array.
+            can only be used when ``x`` is an array.
         minimum_num : int
-            When ``tight`` is ``True`, the minimum number of points to include,
+            When ``tight`` is ``True``, the minimum number of points to include,
             even if they could be trimmed.
 
         Returns

--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -705,17 +705,18 @@ class PairPotentialTabulator(PotentialTabulator):
 
         """
         if x is None:
+            scalar_x = False
             x = numpy.copy(self.linear_space)
         else:
+            scalar_x = numpy.isscalar(x)
             x = numpy.atleast_1d(x)
             if x.ndim != 1:
                 raise TypeError("x can be at most a 1d array")
-        scalar_x = numpy.isscalar(x)
         if tight:
             if scalar_x:
-                raise ValueError("Tight option can only be used if x is an array")
+                raise TypeError("Tight option can only be used if x is an array")
             elif len(x) < minimum_num:
-                raise ValueError("Fewer coordinates given than required minimum")
+                raise IndexError("Fewer coordinates given than required minimum")
 
         u = collections.PairMatrix(types)
         f = collections.PairMatrix(types)

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -270,7 +270,7 @@ class test_HOOMD(unittest.TestCase):
             seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"A": 1, "B": 1}
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=5, check_rdf_every=10, rdf_dr=1.0
+            check_thermo_every=5, check_rdf_every=10, rdf_dr=0.1
         )
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=500, timestep=0.001, T=ens.T, friction=1.0, seed=1, analyzers=analyzer
@@ -295,7 +295,7 @@ class test_HOOMD(unittest.TestCase):
         self.assertIsNotNone(ens_.V)
         self.assertNotEqual(ens_.V.extent, 0)
         for i, j in ens_.rdf:
-            self.assertEqual(ens_.rdf[i, j].table.shape, (len(pot.pair.x) - 1, 2))
+            self.assertIsInstance(ens_.rdf[i, j], relentless.model.RDF)
         self.assertEqual(sim[analyzer]["num_thermo_samples"], expected_thermo_samples)
         self.assertEqual(sim[analyzer]["num_rdf_samples"], expected_rdf_samples)
 
@@ -324,7 +324,7 @@ class test_HOOMD(unittest.TestCase):
             steps=1, timestep=0.001, T=ens.T, friction=1.0, seed=1
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=5, check_rdf_every=10, rdf_dr=1.0
+            check_thermo_every=5, check_rdf_every=10, rdf_dr=0.1
         )
         lgv2 = relentless.simulate.RunLangevinDynamics(
             steps=1, timestep=0.001, T=ens.T, friction=1.0, seed=1, analyzers=analyzer

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -93,7 +93,7 @@ class test_LAMMPS(unittest.TestCase):
         pots.pair.potentials.append(pot)
         pots.pair.start = 1e-6
         pots.pair.stop = 2.0
-        pots.pair.num = 3
+        pots.pair.num = 10
 
         return (ens, pots)
 

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -348,10 +348,10 @@ class test_LAMMPS(unittest.TestCase):
             seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"1": 1, "2": 1}
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=5, check_rdf_every=5, rdf_dr=1.0
+            check_thermo_every=5, check_rdf_every=5, rdf_dr=0.1
         )
         analyzer2 = relentless.simulate.EnsembleAverage(
-            check_thermo_every=10, check_rdf_every=10, rdf_dr=0.5
+            check_thermo_every=10, check_rdf_every=10, rdf_dr=0.2
         )
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=500,
@@ -375,8 +375,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertIsNotNone(ens_.V)
         self.assertNotEqual(ens_.V.extent, 0)
         for i, j in ens_.rdf:
-            # shape is determined by rmax for potential and rdf_dr
-            self.assertEqual(ens_.rdf[i, j].table.shape, (2, 2))
+            self.assertIsInstance(ens_.rdf[i, j], relentless.model.RDF)
 
         # extract ensemble from second analyzer, answers should be slightly different
         # for any quantities that fluctuate
@@ -391,7 +390,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertNotEqual(ens2_.V.extent, 0)
         self.assertEqual(ens2_.V.extent, ens_.V.extent)
         for i, j in ens2_.rdf:
-            self.assertEqual(ens2_.rdf[i, j].table.shape, (4, 2))
+            self.assertNotEqual(ens2_.rdf[i, j].table.shape, ens_.rdf[i, j].table.shape)
 
         # repeat same analysis with logger, and make sure it still works
         logger = relentless.simulate.Record(

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -313,7 +313,7 @@ class test_LAMMPS(unittest.TestCase):
         else:
             V = relentless.model.Square(100.0)
         init = relentless.simulate.InitializeRandomly(
-            seed=1, N={"1": 10000}, V=V, T=2.0
+            seed=1, N={"1": 20000}, V=V, T=2.0
         )
         logger = relentless.simulate.Record(quantities=["temperature"], every=100)
         brn = relentless.simulate.RunLangevinDynamics(

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -106,8 +106,8 @@ class test_PotentialTabulator(unittest.TestCase):
 class QuadPairPot(relentless.model.potential.PairPotential):
     """Quadratic pair potential function"""
 
-    def __init__(self, types, params):
-        super().__init__(types, params)
+    def __init__(self, types):
+        super().__init__(types, ("m",))
 
     @classmethod
     def from_json(cls, data):
@@ -167,9 +167,15 @@ class test_PairPotentialTabulator(unittest.TestCase):
 
     def test_potential(self):
         """Test energy, force, and derivative methods"""
+<<<<<<< HEAD
         p1 = QuadPairPot(types=("1",), params=("m",))
         p1.coeff["1", "1"]["m"] = relentless.model.IndependentVariable(2.0)
         p2 = QuadPairPot(types=("1", "2"), params=("m",))
+=======
+        p1 = QuadPairPot(types=("1",))
+        p1.coeff["1", "1"]["m"] = relentless.model.DesignVariable(2.0)
+        p2 = QuadPairPot(types=("1", "2"))
+>>>>>>> 800de33 (Add unit test for new method)
         for pair in p2.coeff.pairs:
             p2.coeff[pair]["m"] = 1.0
         t = relentless.simulate.PairPotentialTabulator(
@@ -200,7 +206,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
 
     def test_fmax(self):
         """Test setting and changing fmax."""
-        p1 = QuadPairPot(types=("1",), params=("m",))
+        p1 = QuadPairPot(types=("1",))
         p1.coeff["1", "1"]["m"] = 3.0
 
         t = relentless.simulate.PairPotentialTabulator(
@@ -216,6 +222,72 @@ class test_PairPotentialTabulator(unittest.TestCase):
         t.fmax = 20
         f = t.force(("1", "1"))
         numpy.testing.assert_allclose(f, numpy.array([18, 12, 6, 0, -6, -12, -18]))
+
+    def test_pairwise_compute(self):
+        p1 = QuadPairPot(types=("1", "2"))
+        p1.coeff["1", "1"].update(m=2.0)
+        p1.coeff["1", "2"].update(m=0.0)
+        p1.coeff["2", "2"].update(m=0.0)
+
+        t = relentless.simulate.PairPotentialTabulator(
+            start=0.0, stop=6.0, num=7, neighbor_buffer=0.4, potentials=p1
+        )
+
+        r, u, f = t.pairwise_energy_and_force(("1",))
+        numpy.testing.assert_allclose(r, t.linear_space)
+        self.assertIsInstance(u, relentless.collections.PairMatrix)
+        self.assertIsInstance(f, relentless.collections.PairMatrix)
+
+        # manually specify r
+        r, u, f = t.pairwise_energy_and_force(("1",), x=t.linear_space[:-1])
+        numpy.testing.assert_allclose(r, t.linear_space[:-1])
+
+        # manually specify single r
+        r, u, f = t.pairwise_energy_and_force(("1",), x=t.linear_space[0])
+        self.assertEqual(r, t.linear_space[0])
+
+        # set rmax and use tight option
+        p1.coeff["1", "1"]["rmax"] = 3.0
+        r, u, f = t.pairwise_energy_and_force(("1",), tight=True)
+        numpy.testing.assert_allclose(r, t.linear_space[t.linear_space <= 3.0])
+        # same thing, manual r
+        r, u, f = t.pairwise_energy_and_force(("1",), x=t.linear_space[:-1], tight=True)
+        numpy.testing.assert_allclose(r, t.linear_space[t.linear_space <= 3.0])
+
+        # add the second type in, but make potential all zeros
+        # this will trigger the autodetect code path
+        r, u, f = t.pairwise_energy_and_force(("1", "2"), tight=True)
+        numpy.testing.assert_allclose(r, t.linear_space[t.linear_space <= 3.0])
+        # same thing, manual r
+        r, u, f = t.pairwise_energy_and_force(
+            ("1", "2"), x=t.linear_space[:-1], tight=True
+        )
+        numpy.testing.assert_allclose(r, t.linear_space[t.linear_space <= 3.0])
+
+        # make rmax *really* tight, but make sure we still get two points
+        p1.coeff["1", "1"]["rmax"] = 1.0e-16
+        r, u, f = t.pairwise_energy_and_force(("1",), tight=True, minimum_num=1)
+        numpy.testing.assert_allclose(r, t.linear_space[:1])
+        # same thing, manual r
+        r, u, f = t.pairwise_energy_and_force(
+            ("1",), x=t.linear_space[:-1], tight=True, minimum_num=1
+        )
+        numpy.testing.assert_allclose(r, t.linear_space[:1])
+        # same thing with type 2, different minimum number
+        r, u, f = t.pairwise_energy_and_force(("1", "2"), tight=True, minimum_num=2)
+        numpy.testing.assert_allclose(r, t.linear_space[:2])
+        # same thing, manual r
+        r, u, f = t.pairwise_energy_and_force(
+            ("1", "2"), x=t.linear_space[:-1], tight=True, minimum_num=2
+        )
+        numpy.testing.assert_allclose(r, t.linear_space[:2])
+
+        # error for bad combination of x and tight
+        with self.assertRaises(TypeError):
+            t.pairwise_energy_and_force(("1",), x=1.0, tight=True)
+        # error for short x with tight and minimum
+        with self.assertRaises(IndexError):
+            t.pairwise_energy_and_force(("1",), x=[1.0, 2.0], tight=True, minimum_num=3)
 
 
 @parameterized_class(

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -167,15 +167,9 @@ class test_PairPotentialTabulator(unittest.TestCase):
 
     def test_potential(self):
         """Test energy, force, and derivative methods"""
-<<<<<<< HEAD
-        p1 = QuadPairPot(types=("1",), params=("m",))
-        p1.coeff["1", "1"]["m"] = relentless.model.IndependentVariable(2.0)
-        p2 = QuadPairPot(types=("1", "2"), params=("m",))
-=======
         p1 = QuadPairPot(types=("1",))
-        p1.coeff["1", "1"]["m"] = relentless.model.DesignVariable(2.0)
+        p1.coeff["1", "1"]["m"] = relentless.model.IndependentVariable(2.0)
         p2 = QuadPairPot(types=("1", "2"))
->>>>>>> 800de33 (Add unit test for new method)
         for pair in p2.coeff.pairs:
             p2.coeff[pair]["m"] = 1.0
         t = relentless.simulate.PairPotentialTabulator(

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -53,7 +53,7 @@ class test_PotentialTabulator(unittest.TestCase):
 
         # test creation with no potential
         t = relentless.simulate.PotentialTabulator(start=0.0, stop=1.5, num=4)
-        numpy.testing.assert_allclose(t.x, xs)
+        numpy.testing.assert_allclose(t.linear_space, xs)
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
@@ -63,7 +63,7 @@ class test_PotentialTabulator(unittest.TestCase):
         t = relentless.simulate.PotentialTabulator(
             start=0.0, stop=1.5, num=4, potentials=p1
         )
-        numpy.testing.assert_allclose(t.x, xs)
+        numpy.testing.assert_allclose(t.linear_space, xs)
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
@@ -147,7 +147,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         t = relentless.simulate.PairPotentialTabulator(
             start=0.0, stop=1.5, num=4, neighbor_buffer=0.4
         )
-        numpy.testing.assert_allclose(t.x, rs)
+        numpy.testing.assert_allclose(t.linear_space, rs)
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)
@@ -158,7 +158,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         t = relentless.simulate.PairPotentialTabulator(
             start=0.0, stop=1.5, num=4, neighbor_buffer=0.4, fmax=1.5
         )
-        numpy.testing.assert_allclose(t.x, rs)
+        numpy.testing.assert_allclose(t.linear_space, rs)
         self.assertAlmostEqual(t.start, 0.0)
         self.assertAlmostEqual(t.stop, 1.5)
         self.assertEqual(t.num, 4)


### PR DESCRIPTION
This PR should fix the way that potentials get their cutoff trimmed down. Before, the trimming was causing the tabulated potentials to be interpolated in LAMMPS when the cutoff didn't match the end of the table.

Here, we add a method to compute the pairwise energies and forces. Then, all of them are trimmed simultaneously to the biggest required cutoff.

Fixes #173 