### PR TITLE
Improve random initialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,9 +110,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install conda JPEG workaround
-        run: |
-          sudo apt-get install -y libjpeg9
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -124,6 +121,7 @@ jobs:
           conda install -c conda-forge "openmpi=4.1.4=ha*"
       - name: Install test dependencies
         run: |
+          sudo apt-get install -y libjpeg9
           conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
           pip install lammpsio>=0.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install conda JPEG workaround
         run: |
-          sudo apt-get install -y libjpeg*
+          sudo apt-get install -y libjpeg9
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Install conda JPEG workaround
+        run: |
+          sudo apt-get install -y libjpeg*
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/src/relentless/simulate/initialize.py
+++ b/src/relentless/simulate/initialize.py
@@ -152,7 +152,7 @@ class InitializeRandomly(simulate.DelegatedInitializationOperation):
             # such that no particle can cross the outside of the aabb. then, it loops
             # through all the cells and puts the particles in place. everything is based
             # on fractional coordinates, so it gets scaled by the lattice.
-            if is_skew:
+            if is_skew and len(N) > 1:
                 aabb = ortho_box - di
                 shift = 0.5 * di
             else:

--- a/src/relentless/simulate/initialize.py
+++ b/src/relentless/simulate/initialize.py
@@ -150,7 +150,7 @@ class InitializeRandomly(simulate.DelegatedInitializationOperation):
             # such that no particle can cross the outside of the aabb. then, it loops
             # through all the cells and puts the particles in place. everything is based
             # on fractional coordinates, so it gets scaled by the lattice.
-            num_lattice = numpy.floor((aabb - di) / lattice).astype(int)
+            num_lattice = numpy.floor(aabb / lattice).astype(int)
             sites = numpy.zeros(
                 (numpy.prod(num_lattice) * cell_coord.shape[0], dimension),
                 dtype=numpy.float64,

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -613,7 +613,7 @@ class RunBrownianDynamics(_Integrator):
                 group_ids.append(groupid)
         cmds += self._run_commands(sim)
         cmds += ["unfix {}".format(idx) for idx in fix_ids]
-        cmds += ["ungroup {}".format(idx) for idx in group_ids]
+        cmds += ["group {} delete".format(idx) for idx in group_ids]
         return cmds
 
 

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -209,7 +209,7 @@ class test_LAMMPS(unittest.TestCase):
             h.run(pot, self.directory)
 
         # different friction coefficients
-        brn.friction = {"A": 1.5, "B": 2.5}
+        brn.friction = {"1": 1.5, "2": 2.5}
         h.run(pot, self.directory)
 
         # temperature annealing


### PR DESCRIPTION
This PR increases the volume available for packing particles when the boxes are not skew or have only one type.

When there is one type, the procedure for choosing the FCC lattice should guarantee there are no overlaps.

When there is more than one type, the periodic boundary conditions of SciPy's KDTree can be used to exclude overlaps through the boundaries in orthorhombic boxes. When the box is skew, this is not possible, so we have to make sure all the particles are inside the box, as before.

It is still possible that there are certain packing fractions that are difficult to reach using this procedure, and this PR does not address them. We could consider adding support for packmol in future as an alternative that could work in those cases.

Fixes #177 