### PR TITLE
Refactor EnsembleAverage interface and implementations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,6 @@ jobs:
         run: |
           conda install -c conda-forge hoomd=${{ matrix.hoomd-version }}
           pip install -r tests/requirements.txt
-          pip install freud-analysis>=2
       - name: Install
         run: |
           pip install .
@@ -127,7 +126,6 @@ jobs:
         run: |
           conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
-          pip install lammpsio>=0.2.0
       - name: Install
         run: |
           pip install .

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,6 @@
 ipython==8.10.0
 nbsphinx==0.8.12
+notebook
 pydata_sphinx_theme==0.12.0
 sphinx==5.3.0
 sphinx_design==0.3.0

--- a/doc/source/guide/examples/binary_hard_spheres/binary_hard_spheres.ipynb
+++ b/doc/source/guide/examples/binary_hard_spheres/binary_hard_spheres.ipynb
@@ -211,7 +211,7 @@
     ")\n",
     "\n",
     "ens_avg = relentless.simulate.EnsembleAverage(\n",
-    "    check_thermo_every=20, check_rdf_every=2e3, rdf_dr=0.05\n",
+    "    every=20, rdf={\"every\": 2000, \"stop\": 6., \"num\": 120}\n",
     ")\n",
     "prod = relentless.simulate.RunLangevinDynamics(\n",
     "    steps=2e5,\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+freud-analysis>=2
+lammpsio>=0.3
 networkx>=2.5
 numpy
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ package_dir =
 include_package_data = True
 python_requires = >=3.8
 install_requires =
+    freud-analysis>=2
+    lammpsio>=0.3
     networkx>=2.5
     numpy
     packaging

--- a/src/relentless/simulate/analyze.py
+++ b/src/relentless/simulate/analyze.py
@@ -21,18 +21,31 @@ class EnsembleAverage(simulate.DelegatedAnalysisOperation):
         It *may* also have the following keys:
 
         - ``every``: sampling frequency (defaults to the same as for properties)
+    assume_constraints : bool
+        If ``True``, allow the analyzer to assume that constraints implied by
+        the :class:`~relentless.simulate.SimulationOperation` are valid. This
+        can decrease the simulation time required. For example, the number of
+        particles of each type only needs to be computed once for a
+        constant-number integrator.
+
+        .. note::
+
+            An implementation of this operation is not *required* to do anything
+            when this option is set, but it is *allowed* to.
 
     """
 
-    def __init__(self, every, rdf=None):
+    def __init__(self, every, rdf=None, assume_constraints=False):
         self.every = every
         self.rdf = rdf
+        self.assume_constraints = assume_constraints
 
     def _make_delegate(self, sim):
         return self._get_delegate(
             sim,
             every=self.every,
             rdf=self.rdf,
+            assume_constraints=self.assume_constraints,
         )
 
     def _get_rdf_params(self, sim):

--- a/src/relentless/simulate/analyze.py
+++ b/src/relentless/simulate/analyze.py
@@ -2,32 +2,63 @@ from . import simulate
 
 
 class EnsembleAverage(simulate.DelegatedAnalysisOperation):
-    """Analyze the simulation ensemble.
+    """Compute average properties.
 
     Parameters
     ----------
-    check_thermo_every : int
-        Interval of time steps at which to log thermodynamic properties of
-        the simulation.
-    check_rdf_every : int
-        Interval of time steps at which to log the rdf of the simulation.
-    rdf_dr : float
-        The width (in units ``r``) of a bin in the histogram of the rdf.
+    every : int
+        Interval of time steps at which to average thermodynamic properties of
+        the ensemble.
+    rdf : dict
+        Options for computing the :class:`~relentless.model.ensemble.RDF`.
+        If specified, the RDF is computed for each pair of types in the simulation.
+
+        The dictionary **must** have the following keys:
+
+        - ``stop``: largest bin distance
+        - ``num``: number of bins
+
+        It *may* also have the following keys:
+
+        - ``every``: sampling frequency (defaults to the same as for properties)
 
     """
 
-    def __init__(self, check_thermo_every, check_rdf_every, rdf_dr):
-        self.check_thermo_every = check_thermo_every
-        self.check_rdf_every = check_rdf_every
-        self.rdf_dr = rdf_dr
+    def __init__(self, every, rdf=None):
+        self.every = every
+        self.rdf = rdf
 
     def _make_delegate(self, sim):
         return self._get_delegate(
             sim,
-            check_thermo_every=self.check_thermo_every,
-            check_rdf_every=self.check_rdf_every,
-            rdf_dr=self.rdf_dr,
+            every=self.every,
+            rdf=self.rdf,
         )
+
+    def _get_rdf_params(self, sim):
+        if self.rdf is not None:
+            # required keys
+            if "num" not in self.rdf:
+                raise KeyError("Number of bins is required for RDF")
+            if "stop" not in self.rdf:
+                raise KeyError("Stopping distance is required for RDF")
+
+            # optional keys
+            if "every" in self.rdf:
+                rdf_every = self.rdf["every"]
+                if rdf_every % self.every != 0:
+                    raise ValueError("RDF every must be a multiple of every")
+            else:
+                rdf_every = self.every
+
+            rdf_params = {
+                "bins": self.rdf["num"],
+                "stop": self.rdf["stop"],
+                "every": rdf_every,
+            }
+        else:
+            rdf_params = None
+        return rdf_params
 
 
 class Record(simulate.DelegatedAnalysisOperation):

--- a/src/relentless/simulate/dilute.py
+++ b/src/relentless/simulate/dilute.py
@@ -153,9 +153,10 @@ class EnsembleAverage(simulate.AnalysisOperation):
 
     """
 
-    def __init__(self, every, rdf):
+    def __init__(self, every, rdf, assume_constraints):
         self.every = every
         self.rdf = rdf
+        self.assume_constraints = assume_constraints
 
     def pre_run(self, sim, sim_op):
         pass

--- a/src/relentless/simulate/dilute.py
+++ b/src/relentless/simulate/dilute.py
@@ -213,7 +213,12 @@ class EnsembleAverage(simulate.AnalysisOperation):
         # adjust extent to maintain pressure if barostat
         else:
             coeffs = numpy.array([-ens.P / kT, 1, B])
-            v = numpy.max(numpy.roots(coeffs))
+            roots = numpy.roots(coeffs)
+            if not numpy.allclose(numpy.imag(roots), 0):
+                raise ValueError(
+                    "Unable to solve for volume, imaginary roots obtained."
+                )
+            v = numpy.max(numpy.real(roots))
             V = v * N
             L = V ** (1 / sim.dimension)
 

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1004,13 +1004,14 @@ class EnsembleAverage(AnalysisOperation):
                             snap.particles.typeid == snap.particles.types.index(i)
                         )
 
-                    box = snap.box
-                    if sim.dimension == 3:
-                        box_array = numpy.array(
-                            [box.Lx, box.Ly, box.Lz, box.xy, box.xz, box.yz]
-                        )
+                    if _version.major == 3:
+                        box_array = snap.configuration.box
                     else:
-                        box_array = numpy.array([box.Lx, box.Ly, box.xy])
+                        box = snap.box
+                        box_array = [box.Lx, box.Ly, box.Lz, box.xy, box.xz, box.yz]
+                    if sim.dimension == 2:
+                        box_array = [box_array[0], box_array[1], box_array[3]]
+                    box_array = numpy.array(box_array)
 
                 N = mpi.world.bcast(N, root=0)
                 box_array = mpi.world.bcast_numpy(box_array, root=0)

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1023,7 +1023,7 @@ class EnsembleAverage(AnalysisOperation):
 
             N = {i: 0 for i in sim.types}
             if _version.major == 3:
-                snap = sim["engine"]["_hoomd"].get_snapshot()
+                snap = sim["engine"]["_hoomd"].state.get_snapshot()
                 N, V = _get_NV_from_snapshot(sim, snap)
             elif _version.major == 2:
                 with sim["engine"]["_hoomd"]:

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -968,7 +968,7 @@ class EnsembleAverage(AnalysisOperation):
             cmds.append("variable {} delete".format(var_id))
         del sim[self]["_var_ids"]
 
-        if sim[self]["_rdf_params"] is not None:
+        if "_rdf_dump" in sim[self]:
             sim[self]["_rdf_dump"].post_run(sim, sim_op)
 
         return cmds
@@ -984,7 +984,7 @@ class EnsembleAverage(AnalysisOperation):
 
                 if "N" in constraints:
                     N = {
-                        numpy.sum(snap.typeid == sim["engine"]["types"][i])
+                        i: numpy.sum(snap.typeid == sim["engine"]["types"][i])
                         for i in sim.types
                     }
 
@@ -1025,7 +1025,7 @@ class EnsembleAverage(AnalysisOperation):
         else:
             T = constraints["T"]
 
-        if "P" not in "constraints":
+        if "P" not in constraints:
             P = thermo[columns["P"]]
         else:
             P = constraints["P"]
@@ -1054,7 +1054,7 @@ class EnsembleAverage(AnalysisOperation):
         ens = ensemble.Ensemble(T=T, N=N, V=V, P=P)
 
         # extract rdfs from trajectory
-        if sim[self]["_rdf_params"] is not None:
+        if "_rdf_params" in sim[self]:
             sim[self]["_rdf_dump"].process(sim, sim_op)
             rdf = collections.PairMatrix(sim.types)
             num_rdf_samples = 0

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -20,12 +20,131 @@ except ImportError:
     _lammps_found = False
 
 
-# initializers
-class InitializationOperation(simulate.InitializationOperation):
-    """Initialize a simulation."""
+class Counters:
+    _compute = 1
+    _dump = 1
+    _fix = 1
+    _group = 1
+    _variable = 1
+
+    @classmethod
+    def new_compute_id(cls):
+        """Make a unique new compute ID.
+
+        Returns
+        -------
+        int
+            The compute ID.
+
+        """
+        idx = int(cls._compute)
+        cls._compute += 1
+        return "c{}".format(idx)
+
+    @classmethod
+    def new_dump_id(cls):
+        """Make a unique new dump ID.
+
+        Returns
+        -------
+        int
+            The dump ID.
+
+        """
+        idx = int(cls._dump)
+        cls._dump += 1
+        return "d{}".format(idx)
+
+    @classmethod
+    def new_fix_id(cls):
+        """Make a unique new fix ID.
+
+        Returns
+        -------
+        int
+            The fix ID.
+
+        """
+        idx = int(cls._fix)
+        cls._fix += 1
+        return "f{}".format(idx)
+
+    @classmethod
+    def new_group_id(cls):
+        """Make a unique new fix ID.
+
+        Returns
+        -------
+        int
+            The fix ID.
+
+        """
+        idx = int(cls._group)
+        cls._group += 1
+        return "g{}".format(idx)
+
+    @classmethod
+    def new_variable_id(cls):
+        """Make a unique new variable ID.
+
+        Returns
+        -------
+        int
+            The variable ID.
+
+        """
+        idx = int(cls._variable)
+        cls._variable += 1
+        return "v{}".format(idx)
+
+
+class SimulationOperation(simulate.SimulationOperation):
+    """LAMMPS simulation operation."""
 
     def __call__(self, sim):
-        SimulationOperation.__call__(self, sim)
+        """Evaluate the LAMMPS simulation operation.
+
+        Each deriving class of :class:`SimulationOperation` must implement a
+        :meth:`_call_commands()` method that returns a list or tuple of LAMMPS
+        commands that can be executed by :meth:`lammps.commands_list()`.
+
+        Parameters
+        ----------
+        sim : :class:`~relentless.simulate.SimulationInstance`
+            The simulation instance.
+
+        """
+        cmds = self._call_commands(sim)
+        if cmds is None or len(cmds) == 0:
+            return
+
+        sim["engine"]["_lammps_commands"] += cmds
+        if sim["engine"]["use_python"]:
+            sim["engine"]["_lammps"].commands_list(cmds)
+
+    @abc.abstractmethod
+    def _call_commands(self, sim):
+        """Create the LAMMPS commands for the simulation operation.
+
+        All deriving classes must implement this method.
+
+        Parameters
+        ----------
+        sim : :class:`~relentless.simulate.SimulationInstance`
+            The simulation instance.
+
+        Returns
+        -------
+        array_like
+            The LAMMPS commands for this operation.
+
+        """
+        pass
+
+
+# initializers
+class InitializationOperation(SimulationOperation, simulate.InitializationOperation):
+    """Initialize a simulation."""
 
     def _call_commands(self, sim):
         cmds = [
@@ -38,6 +157,14 @@ class InitializationOperation(simulate.InitializationOperation):
         sim.dimension = sim["engine"]["dimension"]
         cmds += self.initialize_commands(sim)
         sim.types = sim["engine"]["types"].keys()
+
+        # create a group for each type
+        sim[self]["_type_groups"] = collections.FixedKeyDict(sim.types)
+        for i in sim.types:
+            typeid = sim["engine"]["types"][i]
+            groupid = Counters.new_group_id()
+            sim[self]["_type_groups"][i] = groupid
+            cmds.append(f"group {groupid} type {typeid}")
 
         sim.masses = collections.FixedKeyDict(sim.types)
         # file is opened only valid on root and result is broadcast
@@ -289,126 +416,6 @@ class InitializeRandomly(InitializationOperation):
 
 
 # simulation operations
-class SimulationOperation(simulate.SimulationOperation):
-    """LAMMPS simulation operation."""
-
-    _compute_counter = 1
-    _dump_counter = 1
-    _fix_counter = 1
-    _group_counter = 1
-    _variable_counter = 1
-
-    def __call__(self, sim):
-        """Evaluate the LAMMPS simulation operation.
-
-        Each deriving class of :class:`SimulationOperation` must implement a
-        :meth:`_call_commands()` method that returns a list or tuple of LAMMPS
-        commands that can be executed by :meth:`lammps.commands_list()`.
-
-        Parameters
-        ----------
-        sim : :class:`~relentless.simulate.SimulationInstance`
-            The simulation instance.
-
-        """
-        cmds = self._call_commands(sim)
-        if cmds is None or len(cmds) == 0:
-            return
-
-        sim["engine"]["_lammps_commands"] += cmds
-        if sim["engine"]["use_python"]:
-            sim["engine"]["_lammps"].commands_list(cmds)
-
-    @classmethod
-    def new_compute_id(cls):
-        """Make a unique new compute ID.
-
-        Returns
-        -------
-        int
-            The compute ID.
-
-        """
-        idx = int(SimulationOperation._compute_counter)
-        SimulationOperation._compute_counter += 1
-        return "c{}".format(idx)
-
-    @classmethod
-    def new_dump_id(cls):
-        """Make a unique new dump ID.
-
-        Returns
-        -------
-        int
-            The dump ID.
-
-        """
-        idx = int(SimulationOperation._dump_counter)
-        SimulationOperation._dump_counter += 1
-        return "d{}".format(idx)
-
-    @classmethod
-    def new_fix_id(cls):
-        """Make a unique new fix ID.
-
-        Returns
-        -------
-        int
-            The fix ID.
-
-        """
-        idx = int(SimulationOperation._fix_counter)
-        SimulationOperation._fix_counter += 1
-        return "f{}".format(idx)
-
-    @classmethod
-    def new_group_id(cls):
-        """Make a unique new fix ID.
-
-        Returns
-        -------
-        int
-            The fix ID.
-
-        """
-        idx = int(SimulationOperation._group_counter)
-        SimulationOperation._group_counter += 1
-        return "g{}".format(idx)
-
-    @classmethod
-    def new_variable_id(cls):
-        """Make a unique new variable ID.
-
-        Returns
-        -------
-        int
-            The variable ID.
-
-        """
-        idx = int(SimulationOperation._variable_counter)
-        SimulationOperation._variable_counter += 1
-        return "v{}".format(idx)
-
-    @abc.abstractmethod
-    def _call_commands(self, sim):
-        """Create the LAMMPS commands for the simulation operation.
-
-        All deriving classes must implement this method.
-
-        Parameters
-        ----------
-        sim : :class:`~relentless.simulate.SimulationInstance`
-            The simulation instance.
-
-        Returns
-        -------
-        array_like
-            The LAMMPS commands for this operation.
-
-        """
-        pass
-
-
 class MinimizeEnergy(SimulationOperation):
     """Perform energy minimization on a configuration.
 
@@ -451,7 +458,7 @@ class MinimizeEnergy(SimulationOperation):
             )
         ]
         if sim.dimension == 2:
-            fix_2d = self.new_fix_id()
+            fix_2d = Counters.new_fix_id()
             cmds = (
                 ["fix {} all enforce2d".format(fix_2d)]
                 + cmds
@@ -494,7 +501,7 @@ class _Integrator(SimulationOperation):
 
         # wrap with fixes
         if sim.dimension == 2:
-            fix_2d = self.new_fix_id()
+            fix_2d = Counters.new_fix_id()
             cmds = (
                 ["fix {} all enforce2d".format(fix_2d)]
                 + cmds
@@ -566,12 +573,11 @@ class RunBrownianDynamics(_Integrator):
             same_friction = True
 
         fix_ids = []
-        group_ids = []
         cmd_template = "fix {fixid} {groupid} brownian {T} {seed} gamma_t {friction}"
 
         cmds = ["timestep {}".format(self.timestep)]
         if same_friction:
-            fixid = self.new_fix_id()
+            fixid = Counters.new_fix_id()
             cmds.append(
                 cmd_template.format(
                     fixid=fixid,
@@ -584,11 +590,9 @@ class RunBrownianDynamics(_Integrator):
             fix_ids.append(fixid)
         else:
             for i, t in enumerate(sim.types):
-                typeidx = sim["engine"]["types"][t]
-                groupid = self.new_group_id()
-                fixid = self.new_fix_id()
-                cmds += [
-                    f"group {groupid} type {typeidx}",
+                groupid = sim[sim.initializer]["_type_groups"][t]
+                fixid = Counters.new_fix_id()
+                cmds.append(
                     cmd_template.format(
                         fixid=fixid,
                         groupid=groupid,
@@ -596,12 +600,10 @@ class RunBrownianDynamics(_Integrator):
                         seed=self.seed + i,
                         friction=self.friction[t],
                     ),
-                ]
+                )
                 fix_ids.append(fixid)
-                group_ids.append(groupid)
         cmds += self._run_commands(sim)
         cmds += ["unfix {}".format(idx) for idx in fix_ids]
-        cmds += ["group {} delete".format(idx) for idx in group_ids]
         return cmds
 
 
@@ -661,7 +663,7 @@ class RunLangevinDynamics(_Integrator):
             scale_str = ""
 
         T = self._make_T(self.T)
-        fix_ids = {"nve": self.new_fix_id(), "langevin": self.new_fix_id()}
+        fix_ids = {"nve": Counters.new_fix_id(), "langevin": Counters.new_fix_id()}
         cmds = [
             "timestep {}".format(self.timestep),
             "fix {idx} {group_idx} nve".format(idx=fix_ids["nve"], group_idx="all"),
@@ -720,7 +722,7 @@ class RunMolecularDynamics(_Integrator):
         self.barostat = barostat
 
     def _call_commands(self, sim):
-        fix_ids = {"ig": self.new_fix_id()}
+        fix_ids = {"ig": Counters.new_fix_id()}
 
         if self.thermostat is not None:
             T = self._make_T(self.thermostat)
@@ -786,7 +788,7 @@ class RunMolecularDynamics(_Integrator):
             )
 
         if isinstance(self.thermostat, md.BerendsenThermostat):
-            fix_ids["berendsen_temp"] = self.new_fix_id()
+            fix_ids["berendsen_temp"] = Counters.new_fix_id()
             cmds += [
                 "fix {idx} {group_idx} temp/berendsen {Tstart} {Tstop} {Tdamp}".format(
                     idx=fix_ids["berendsen_temp"],
@@ -797,7 +799,7 @@ class RunMolecularDynamics(_Integrator):
                 )
             ]
         if isinstance(self.barostat, md.BerendsenBarostat):
-            fix_ids["berendsen_press"] = self.new_fix_id()
+            fix_ids["berendsen_press"] = Counters.new_fix_id()
             cmds += [
                 (
                     "fix {idx} {group_idx} press/berendsen iso"
@@ -846,87 +848,98 @@ class AnalysisOperation(simulate.AnalysisOperation):
 
 
 class EnsembleAverage(AnalysisOperation):
-    def __init__(self, every, rdf):
+    def __init__(self, every, rdf, assume_constraints):
         self.every = every
         self.rdf = rdf
+        self.assume_constraints = assume_constraints
 
     def _pre_run_commands(self, sim, sim_op):
-        fix_ids = {
-            "thermo_avg": SimulationOperation.new_fix_id(),
-        }
-        var_ids = {
-            "T": SimulationOperation.new_variable_id(),
-            "P": SimulationOperation.new_variable_id(),
-            "Lx": SimulationOperation.new_variable_id(),
-            "Ly": SimulationOperation.new_variable_id(),
-            "Lz": SimulationOperation.new_variable_id(),
-            "xy": SimulationOperation.new_variable_id(),
-            "xz": SimulationOperation.new_variable_id(),
-            "yz": SimulationOperation.new_variable_id(),
-        }
+        cmds = []
 
-        group_ids = {}
-        for i in sim.types:
-            typeid = sim["engine"]["types"][i]
-            typekey = "N_{}".format(typeid)
-            group_ids[typekey] = SimulationOperation.new_group_id()
-            var_ids[typekey] = SimulationOperation.new_variable_id()
+        constraints = self._get_constrained_quantities(sim, sim_op)
+        if constraints is None:
+            constraints = {}
+        sim[self]["_constraints"] = constraints
 
-        # generate temporary file names
+        # dicts are insertion ordered, so we can rely on this for thermo columns
+        fix_ids = {}
+        var_ids = {}
+        if "T" not in constraints:
+            var_ids["T"] = Counters.new_variable_id()
+            cmds.append("variable {} equal temp".format(var_ids["T"]))
+        if "P" not in constraints:
+            var_ids["P"] = Counters.new_variable_id()
+            cmds.append("variable {} equal press".format(var_ids["P"]))
+        if "V" not in constraints:
+            var_ids.update(
+                {
+                    "Lx": Counters.new_variable_id(),
+                    "Ly": Counters.new_variable_id(),
+                    "Lz": Counters.new_variable_id(),
+                    "xy": Counters.new_variable_id(),
+                    "xz": Counters.new_variable_id(),
+                    "yz": Counters.new_variable_id(),
+                }
+            )
+            cmds += [
+                "variable {} equal lx".format(var_ids["Lx"]),
+                "variable {} equal ly".format(var_ids["Ly"]),
+                "variable {} equal lz".format(var_ids["Lz"]),
+                "variable {} equal xy".format(var_ids["xy"]),
+                "variable {} equal xz".format(var_ids["xz"]),
+                "variable {} equal yz".format(var_ids["yz"]),
+            ]
+        if "N" not in constraints:
+            for i in sim.types:
+                groupid = sim[sim.initializer]["_type_groups"][i]
+                typekey = f"N_{i}"
+                var_ids[typekey] = Counters.new_variable_id()
+                cmds.append(
+                    'variable {vid} equal "count({gid})"'.format(
+                        vid=var_ids[typekey], gid=groupid
+                    ),
+                )
+
+        # generate temporary file names, may or may not get used but that's OK
         if mpi.world.rank_is_root:
             file_ = {
                 "thermo": sim.directory.file(str(uuid.uuid4().hex)),
                 "rdf": sim.directory.file(str(uuid.uuid4().hex)),
+                "data": sim.directory.file(str(uuid.uuid4().hex)),
             }
         else:
             file_ = None
         file_ = mpi.world.bcast(file_)
 
         # thermodynamic properties
-        sim[self]["_thermo_file"] = file_["thermo"]
-        cmds = [
-            "variable {} equal temp".format(var_ids["T"]),
-            "variable {} equal press".format(var_ids["P"]),
-            "variable {} equal lx".format(var_ids["Lx"]),
-            "variable {} equal ly".format(var_ids["Ly"]),
-            "variable {} equal lz".format(var_ids["Lz"]),
-            "variable {} equal xy".format(var_ids["xy"]),
-            "variable {} equal xz".format(var_ids["xz"]),
-            "variable {} equal yz".format(var_ids["yz"]),
-        ]
-        N_vars = []
-        for i in sim.types:
-            typeid = sim["engine"]["types"][i]
-            typekey = "N_{}".format(typeid)
+        if len(var_ids) > 0:
+            sim[self]["_thermo_file"] = file_["thermo"]
+            fix_ids["thermo_avg"] = Counters.new_fix_id()
             cmds += [
-                "group {gid} type {typeid}".format(
-                    gid=group_ids[typekey], typeid=typeid
-                ),
-                'variable {vid} equal "count({gid})"'.format(
-                    vid=var_ids[typekey], gid=group_ids[typekey]
-                ),
+                (
+                    "fix {fixid} all ave/time {every} 1 {every}"
+                    + " "
+                    + " ".join(["v_" + v_ for v_ in var_ids.values()])
+                    + " mode scalar ave running"
+                    ' file {filename} overwrite format " %.16e"'
+                ).format(
+                    fixid=fix_ids["thermo_avg"],
+                    every=self.every,
+                    filename=sim[self]["_thermo_file"],
+                )
             ]
-            N_vars.append("v_{" + typekey + "}")
-        cmds += [
-            (
-                "fix {fixid} all ave/time {every} 1 {every}"
-                " v_{T} v_{P} v_{Lx} v_{Ly} v_{Lz} v_{xy} v_{xz} v_{yz}"
-                + " "
-                + " ".join(N_vars)
-                + " mode scalar ave running"
-                ' file {filename} overwrite format " %.16e"'
-            ).format(
-                fixid=fix_ids["thermo_avg"],
-                every=self.every,
-                filename=sim[self]["_thermo_file"],
-                **var_ids,
-            )
-        ]
+
+            sim[self]["_thermo_columns"] = {k: i for i, k in enumerate(var_ids.keys())}
+
+        # write a data file if there are constraints on N or V
+        if "N" in constraints or "V" in constraints:
+            cmds += ["write_data {filename}".format(filename=file_["data"])]
+            sim[self]["_constraint_data_file"] = file_["data"]
 
         # dump a trajectory for the RDF calculation
         rdf_params = self._get_rdf_params(sim)
-        sim[self]["_rdf_params"] = rdf_params
         if rdf_params is not None:
+            sim[self]["_rdf_params"] = rdf_params
             sim[self]["_rdf_file"] = file_["rdf"]
             sim[self]["_rdf_dump"] = WriteTrajectory(
                 filename=sim[self]["_rdf_file"],
@@ -941,7 +954,6 @@ class EnsembleAverage(AnalysisOperation):
         # save ids so we can remove them later
         sim[self]["_fix_ids"] = fix_ids
         sim[self]["_var_ids"] = var_ids
-        sim[self]["_group_ids"] = group_ids
 
         return cmds
 
@@ -955,10 +967,6 @@ class EnsembleAverage(AnalysisOperation):
         for var_id in sim[self]["_var_ids"].values():
             cmds.append("variable {} delete".format(var_id))
         del sim[self]["_var_ids"]
-        # delete groups
-        for group_id in sim[self]["_group_ids"].values():
-            cmds.append("group {} delete".format(group_id))
-        del sim[self]["_group_ids"]
 
         if sim[self]["_rdf_params"] is not None:
             sim[self]["_rdf_dump"].post_run(sim, sim_op)
@@ -966,6 +974,43 @@ class EnsembleAverage(AnalysisOperation):
         return cmds
 
     def process(self, sim, sim_op):
+        # first process any constraints
+        constraints = sim[self]["_constraints"]
+        if "N" in constraints or "V" in constraints:
+            N = None
+            box_array = None
+            if mpi.world.rank_is_root:
+                snap = lammpsio.DataFile(sim[self]["_constraint_data_file"]).read()
+
+                if "N" in constraints:
+                    N = {
+                        numpy.sum(snap.typeid == sim["engine"]["types"][i])
+                        for i in sim.types
+                    }
+
+                if "V" in constraints:
+                    L = snap.box.high - snap.box.low
+                    L = L[: sim.dimension]
+                    tilt = snap.box.tilt
+                    if tilt is None:
+                        if sim.dimension == 3:
+                            tilt = [0, 0, 0]
+                        else:
+                            tilt = [0]
+                    box_array = numpy.concatenate((L, tilt))
+
+            if N is not None:
+                N = mpi.world.bcast(N)
+            else:
+                del N
+
+            if box_array is not None:
+                box_array = mpi.world.bcast_numpy(box_array)
+                if sim.dimension == 3:
+                    V = extent.TriclinicBox(*box_array, convention="LAMMPS")
+                else:
+                    V = extent.ObliqueArea(*box_array, convention="LAMMPS")
+
         # extract thermo properties
         # we skip the first 2 rows, which are LAMMPS junk, and slice out the
         # timestep from col. 0
@@ -973,25 +1018,40 @@ class EnsembleAverage(AnalysisOperation):
             thermo = mpi.world.loadtxt(sim[self]["_thermo_file"], skiprows=2)[1:]
         except Exception as e:
             raise RuntimeError("No LAMMPS thermo file generated") from e
-        N = {i: Ni for i, Ni in zip(sim.types, thermo[8 : 8 + len(sim.types)])}
-        if sim.dimension == 3:
-            V = extent.TriclinicBox(
-                Lx=thermo[2],
-                Ly=thermo[3],
-                Lz=thermo[4],
-                xy=thermo[5],
-                xz=thermo[6],
-                yz=thermo[7],
-                convention="LAMMPS",
-            )
+        columns = sim[self]["_thermo_columns"]
+
+        if "T" not in constraints:
+            T = thermo[columns["T"]]
         else:
-            V = extent.ObliqueArea(
-                Lx=thermo[2],
-                Ly=thermo[3],
-                xy=thermo[5],
-                convention="LAMMPS",
-            )
-        ens = ensemble.Ensemble(N=N, T=thermo[0], P=thermo[1], V=V)
+            T = constraints["T"]
+
+        if "P" not in "constraints":
+            P = thermo[columns["P"]]
+        else:
+            P = constraints["P"]
+
+        if "N" not in constraints:
+            N = {i: thermo[columns[f"N_{i}"]] for i in sim.types}
+
+        if "V" not in constraints:
+            if sim.dimension == 3:
+                V = extent.TriclinicBox(
+                    Lx=thermo[columns["Lx"]],
+                    Ly=thermo[columns["Ly"]],
+                    Lz=thermo[columns["Lz"]],
+                    xy=thermo[columns["xy"]],
+                    xz=thermo[columns["xz"]],
+                    yz=thermo[columns["yz"]],
+                    convention="LAMMPS",
+                )
+            else:
+                V = extent.ObliqueArea(
+                    Lx=thermo[columns["Lx"]],
+                    Ly=thermo[columns["Ly"]],
+                    xy=thermo[columns["xy"]],
+                    convention="LAMMPS",
+                )
+        ens = ensemble.Ensemble(T=T, N=N, V=V, P=P)
 
         # extract rdfs from trajectory
         if sim[self]["_rdf_params"] is not None:
@@ -1069,6 +1129,47 @@ class EnsembleAverage(AnalysisOperation):
 
     _get_rdf_params = analyze.EnsembleAverage._get_rdf_params
 
+    def _get_constrained_quantities(self, sim, sim_op):
+        if not self.assume_constraints:
+            return None
+
+        constraints = {}
+
+        # then we opt-in the operations we know
+        if isinstance(
+            sim_op,
+            (
+                md.RunBrownianDynamics,
+                md.RunLangevinDynamics,
+                RunBrownianDynamics,
+                RunLangevinDynamics,
+            ),
+        ):
+            constraints["N"] = True
+            constraints["T"] = md.Thermostat(sim_op.T)
+            constraints["V"] = True
+        elif isinstance(sim_op, (md.RunMolecularDynamics, RunMolecularDynamics)):
+            constraints["N"] = True
+            if sim_op.thermostat is not None:
+                constraints["T"] = sim_op.thermostat
+            # conjugate pair: one or the other is set
+            if sim_op.barostat is not None:
+                constraints["P"] = sim_op.barostat.P
+            else:
+                constraints["V"] = True
+
+        # get T now
+        if "T" in constraints:
+            thermostat = constraints["T"]
+            if thermostat.anneal:
+                constraints["T"] = 0.5 * (thermostat.T[0] + thermostat.T[1])
+            else:
+                constraints["T"] = thermostat.T
+
+        # defer N & V calculations until later...
+
+        return constraints
+
 
 class Record(AnalysisOperation):
     def __init__(self, quantities, every):
@@ -1086,7 +1187,7 @@ class Record(AnalysisOperation):
         var_ids = {}
         cmds = []
         for q in self.quantities:
-            var_ids[q] = SimulationOperation.new_variable_id()
+            var_ids[q] = Counters.new_variable_id()
             cmds.append("variable {} equal {}".format(var_ids[q], quantity_map[q]))
 
         # write quantities to file with fix ave/time
@@ -1094,7 +1195,7 @@ class Record(AnalysisOperation):
             file_ = sim.directory.file(str(uuid.uuid4().hex))
         else:
             file_ = None
-        sim[self]["_fix_id"] = SimulationOperation.new_fix_id()
+        sim[self]["_fix_id"] = Counters.new_fix_id()
         sim[self]["_log_file"] = mpi.world.bcast(file_)
         cmds.append(
             (
@@ -1177,7 +1278,7 @@ class WriteTrajectory(AnalysisOperation):
         if self.images is True:
             dump_format += " ix iy iz"
 
-        dump_id = SimulationOperation.new_dump_id()
+        dump_id = Counters.new_dump_id()
         cmds = [
             "dump {} all custom {} {} {}".format(
                 dump_id, self.every, sim.directory.file(self.filename), dump_format

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -119,7 +119,7 @@ class test_RelativeEntropy(unittest.TestCase):
             seed=42, N=self.target.N, V=self.target.V, T=self.target.T
         )
         self.thermo = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.6, "num": 360}
         )
         md = relentless.simulate.RunMolecularDynamics(
             steps=100, timestep=1e-3, analyzers=self.thermo

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -134,7 +134,7 @@ class test_Dilute(unittest.TestCase):
             seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.0, "num": 30}
         )
         md = relentless.simulate.RunMolecularDynamics(
             steps=100,

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -141,24 +141,33 @@ class test_Dilute(unittest.TestCase):
             timestep=1e-3,
             analyzers=analyzer,
             thermostat=relentless.simulate.BerendsenThermostat(T=2, tau=0.1),
-            barostat=relentless.simulate.Barostat(P=1),
         )
 
         # set up potentials
         pot = LinPot(("A", "B"), params=("m",))
         for pair in pot.coeff:
-            pot.coeff[pair]["m"] = 2.0
+            pot.coeff[pair].update({"m": -2.0, "rmax": 1.0})
         pots = relentless.simulate.Potentials()
         pots.pair = relentless.simulate.PairPotentialTabulator(
             pot, start=0.0, stop=3.0, num=4, neighbor_buffer=0.5
         )
 
+        # run NVT forward to get pressure
         d = relentless.simulate.Dilute(init, operations=md)
         sim = d.run(potentials=pots, directory=self.directory)
         ens_ = sim[analyzer]["ensemble"]
-        self.assertAlmostEqual(ens_.P, 1)
+        P = ens_.P
+        # TODO: we should add an assert to make sure this pressure is right
+
+        # change volume and attach barostat, and make sure we get same answer
+        # for volume if we set the pressure at the same as above
+        init.V = relentless.model.Cube(L=3.0)
+        md.barostat = relentless.simulate.Barostat(P=P)
+        sim = d.run(potentials=pots, directory=self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertAlmostEqual(ens_.P, P)
         self.assertAlmostEqual(ens_.T, 2)
-        self.assertAlmostEqual(ens_.V.extent ** (1 / 3), 3.52463375)
+        self.assertAlmostEqual(ens_.V.extent ** (1 / 3), 2.0)
 
     def test_inf_potential(self):
         """Test potential with infinite value."""

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -27,7 +27,7 @@ class test_Dilute(unittest.TestCase):
             seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.0, "num": 30}
         )
         md = relentless.simulate.RunMolecularDynamics(
             steps=100, timestep=1e-3, analyzers=analyzer
@@ -53,7 +53,7 @@ class test_Dilute(unittest.TestCase):
             seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.0, "num": 10}
         )
         md = relentless.simulate.RunMolecularDynamics(
             steps=100,
@@ -82,7 +82,7 @@ class test_Dilute(unittest.TestCase):
             seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.0, "num": 30}
         )
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=100, timestep=1e-3, T=2, friction=0.1, seed=2, analyzers=analyzer
@@ -108,7 +108,7 @@ class test_Dilute(unittest.TestCase):
             seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.0, "num": 30}
         )
         bd = relentless.simulate.RunBrownianDynamics(
             steps=100, timestep=1e-3, T=2.0, friction=0.1, seed=2, analyzers=analyzer
@@ -166,7 +166,7 @@ class test_Dilute(unittest.TestCase):
             seed=42, N={"A": 2, "B": 3}, V=relentless.model.Cube(L=2.0), T=1.0
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 3.0, "num": 30}
         )
         md = relentless.simulate.RunMolecularDynamics(
             steps=100, timestep=1e-3, analyzers=analyzer

--- a/tests/simulate/test_dilute.py
+++ b/tests/simulate/test_dilute.py
@@ -157,7 +157,7 @@ class test_Dilute(unittest.TestCase):
         sim = d.run(potentials=pots, directory=self.directory)
         ens_ = sim[analyzer]["ensemble"]
         P = ens_.P
-        # TODO: we should add an assert to make sure this pressure is right
+        self.assertAlmostEqual(P, 1.25)
 
         # change volume and attach barostat, and make sure we get same answer
         # for volume if we set the pressure at the same as above

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -263,7 +263,7 @@ class test_HOOMD(unittest.TestCase):
         self.assertAlmostEqual(result.intercept, 2.0, places=1)
         self.assertAlmostEqual(result.slope, -1.0 / brn.steps, places=4)
 
-    def test_analyzer(self):
+    def test_ensemble_average(self):
         """Test ensemble analyzer simulation operation."""
         ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(
@@ -315,7 +315,7 @@ class test_HOOMD(unittest.TestCase):
         self.assertAlmostEqual(numpy.mean(sim[logger]["temperature"]), ens_.T)
         self.assertAlmostEqual(numpy.mean(sim[logger]["pressure"]), ens_.P)
 
-    def test_analyzer_no_run(self):
+    def test_ensemble_average_no_run(self):
         ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(
             seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"A": 1, "B": 1}
@@ -339,6 +339,89 @@ class test_HOOMD(unittest.TestCase):
         lgv2.steps = 5
         with self.assertRaises(RuntimeError):
             h.run(pot, self.directory)
+
+    def test_ensemble_average_constraints(self):
+        """Test ensemble analyzer simulation operation."""
+        ens, pot = self.ens_pot()
+        init = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"A": 1, "B": 1}
+        )
+        analyzer = relentless.simulate.EnsembleAverage(every=1, assume_constraints=True)
+        md = relentless.simulate.RunMolecularDynamics(
+            steps=100,
+            timestep=0.001,
+            thermostat=relentless.simulate.NoseHooverThermostat(ens.T, 0.1),
+            barostat=relentless.simulate.MTKBarostat(0.0, 1.0),
+            analyzers=analyzer,
+        )
+        h = relentless.simulate.HOOMD(init, md)
+
+        # NPT
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertEqual(ens_.P, 0.0)
+        self.assertNotEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # NVT
+        md.barostat = None
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # NVT with annealing
+        md.thermostat.T = [2 * ens.T, ens.T]
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, 1.5 * ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # NVE
+        md.thermostat = None
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertNotEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # Langevin dynamics
+        h.operations = relentless.simulate.RunLangevinDynamics(
+            steps=100,
+            timestep=0.001,
+            T=ens.T,
+            friction=0.1,
+            seed=42,
+            analyzers=analyzer,
+        )
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # Brownian dynamics
+        h.operations = relentless.simulate.RunBrownianDynamics(
+            steps=100,
+            timestep=0.001,
+            T=ens.T,
+            friction=0.1,
+            seed=42,
+            analyzers=analyzer,
+        )
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
 
     def test_writetrajectory(self):
         """Test write trajectory simulation operation."""

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -270,7 +270,7 @@ class test_HOOMD(unittest.TestCase):
             seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"A": 1, "B": 1}
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=5, check_rdf_every=10, rdf_dr=0.1
+            every=5, rdf={"every": 10, "stop": 2.0, "num": 20}
         )
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=500, timestep=0.001, T=ens.T, friction=1.0, seed=1, analyzers=analyzer
@@ -324,7 +324,7 @@ class test_HOOMD(unittest.TestCase):
             steps=1, timestep=0.001, T=ens.T, friction=1.0, seed=1
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=5, check_rdf_every=10, rdf_dr=0.1
+            every=5, rdf={"every": 10, "stop": 2.0, "num": 20}
         )
         lgv2 = relentless.simulate.RunLangevinDynamics(
             steps=1, timestep=0.001, T=ens.T, friction=1.0, seed=1, analyzers=analyzer
@@ -395,7 +395,7 @@ class test_HOOMD(unittest.TestCase):
         _, pot = self.ens_pot()
         init = relentless.simulate.InitializeFromFile(filename=filename)
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=1, check_rdf_every=1, rdf_dr=0.1
+            every=1, rdf={"stop": 2.0, "num": 20}
         )
         ig = relentless.simulate.RunMolecularDynamics(
             steps=1, timestep=0.0, analyzers=analyzer

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -475,7 +475,7 @@ class test_LAMMPS(unittest.TestCase):
         if "BROWNIAN" in h.packages:
             h.operations = relentless.simulate.RunBrownianDynamics(
                 steps=100,
-                timestep=0.001,
+                timestep=1e-5,
                 T=ens.T,
                 friction=0.1,
                 seed=42,

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -43,10 +43,7 @@ elif relentless.simulate.lammps._lammps_found:
 else:
     test_params = []
 
-_has_lammps_dependencies = relentless.simulate.lammps._lammpsio_found
 
-
-@unittest.skipIf(not _has_lammps_dependencies, "LAMMPS dependencies not installed")
 @unittest.skipIf(len(test_params) == 0, "No version of LAMMPS installed")
 @parameterized.parameterized_class(
     ("dim", "executable"),
@@ -346,10 +343,10 @@ class test_LAMMPS(unittest.TestCase):
             seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"1": 1, "2": 1}
         )
         analyzer = relentless.simulate.EnsembleAverage(
-            check_thermo_every=5, check_rdf_every=5, rdf_dr=0.1
+            every=5, rdf={"stop": 2.0, "num": 20}
         )
         analyzer2 = relentless.simulate.EnsembleAverage(
-            check_thermo_every=10, check_rdf_every=10, rdf_dr=0.2
+            every=10, rdf={"stop": 2.0, "num": 10}
         )
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=500,

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -336,7 +336,7 @@ class test_LAMMPS(unittest.TestCase):
         self.assertAlmostEqual(result.intercept, 2.0, places=1)
         self.assertAlmostEqual(result.slope, -1.0 / brn.steps, places=4)
 
-    def test_analyzer(self):
+    def test_ensemble_average(self):
         """Test ensemble analyzer simulation operation."""
         ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(
@@ -401,6 +401,92 @@ class test_LAMMPS(unittest.TestCase):
         )
         self.assertAlmostEqual(numpy.mean(sim[logger]["temperature"]), ens_.T)
         self.assertAlmostEqual(numpy.mean(sim[logger]["pressure"]), ens_.P)
+
+    def test_ensemble_average_constraints(self):
+        """Test ensemble analyzer simulation operation."""
+        ens, pot = self.ens_pot()
+        init = relentless.simulate.InitializeRandomly(
+            seed=1, N=ens.N, V=ens.V, T=ens.T, diameters={"1": 1, "2": 1}
+        )
+        analyzer = relentless.simulate.EnsembleAverage(every=1, assume_constraints=True)
+        md = relentless.simulate.RunMolecularDynamics(
+            steps=100,
+            timestep=0.001,
+            thermostat=relentless.simulate.NoseHooverThermostat(ens.T, 0.1),
+            barostat=relentless.simulate.MTKBarostat(0.0, 1.0),
+            analyzers=analyzer,
+        )
+        h = relentless.simulate.LAMMPS(
+            init, md, dimension=self.dim, executable=self.executable
+        )
+
+        # NPT
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertEqual(ens_.P, 0.0)
+        self.assertNotEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # NVT
+        md.barostat = None
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # NVT with annealing
+        md.thermostat.T = [2 * ens.T, ens.T]
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, 1.5 * ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # NVE
+        md.thermostat = None
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertNotEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # Langevin dynamics
+        h.operations = relentless.simulate.RunLangevinDynamics(
+            steps=100,
+            timestep=0.001,
+            T=ens.T,
+            friction=0.1,
+            seed=42,
+            analyzers=analyzer,
+        )
+        sim = h.run(pot, self.directory)
+        ens_ = sim[analyzer]["ensemble"]
+        self.assertEqual(ens_.T, ens.T)
+        self.assertNotEqual(ens_.P, 0.0)
+        self.assertEqual(ens_.V.extent, ens.V.extent)
+        self.assertDictEqual(dict(ens_.N), dict(ens.N))
+
+        # Brownian dynamics
+        if "BROWNIAN" in h.packages:
+            h.operations = relentless.simulate.RunBrownianDynamics(
+                steps=100,
+                timestep=0.001,
+                T=ens.T,
+                friction=0.1,
+                seed=42,
+                analyzers=analyzer,
+            )
+            sim = h.run(pot, self.directory)
+            ens_ = sim[analyzer]["ensemble"]
+            self.assertEqual(ens_.T, ens.T)
+            self.assertNotEqual(ens_.P, 0.0)
+            self.assertEqual(ens_.V.extent, ens.V.extent)
+            self.assertDictEqual(dict(ens_.N), dict(ens.N))
 
     def test_writetrajectory(self):
         """Test write trajectory simulation operation."""


### PR DESCRIPTION
This PR updates the `EnsembleAverage` operation in a few ways:

* Improve the user interface for specifying parameters (Fixes #188)
* Allow users to specify RDF cutoffs greater than the tabulated potential cutoff. This is a feature we would like to have for analysis. To support this, LAMMPS files are postprocessed with freud instead of computed on the fly. HOOMD could do something similar if performance becomes a bottleneck, but for now, it is done on the fly.
* Refactor the HOOMD compute operation into one callback. This is moving toward optimizing the operations.
* `lammpsio` and `freud-analysis` are required dependencies of `relentless` again. I used `freud` in both `simulate.hoomd` and `simulate.lammps`, so I didn't think it was worth making the user figure out they needed to install this. I am envisioning using `lammpsio` between these packages in future (#156), so I moved that as well now. Now users just need to know "install HOOMD" or "install LAMMPS", which is nice.
* Optimize the averaging to assume certain things are constant (Fixes #163) via the `assume_constraints` option.