### PR TITLE
Support I/O with both GSD and LAMMPS files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
           python-version: 3.8
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge hoomd=3 gsd
+          conda install -c conda-forge hoomd=3
           pip install -r doc/requirements.txt
       - name: Install
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 freud-analysis>=2
-lammpsio>=0.3
+gsd
+lammpsio>=0.4
 networkx>=2.5
 numpy
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,8 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     freud-analysis>=2
-    lammpsio>=0.3
+    gsd
+    lammpsio>=0.4
     networkx>=2.5
     numpy
     packaging

--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -158,12 +158,18 @@ class Directory:
         """
         return os.path.join(self.path, name)
 
-    def temporary_file(self):
+    def temporary_file(self, suffix=None):
         """Get a temporary filename in the directory.
 
         This method generates a random filename using :func:`uuid.uuid4`. Unlike
         a Python temporary file, this file is not automatically created or
         destroyed. That responsibility is delegated to the caller.
+
+        Parameters
+        ----------
+        suffix : str
+            If specified, the suffix to add to the filename. If ``None`` (default),
+            no suffix is added.
 
         Returns
         -------
@@ -171,7 +177,10 @@ class Directory:
             The absolute path to the temporary file.
 
         """
-        return self.file(str(uuid.uuid4().hex))
+        filename = str(uuid.uuid4().hex)
+        if suffix is not None:
+            filename += suffix
+        return self.file(filename)
 
     def directory(self, name, create=True):
         """Get a child directory.

--- a/src/relentless/data.py
+++ b/src/relentless/data.py
@@ -14,6 +14,7 @@ Data management (`relentless.data`)
 import os
 import pathlib
 import shutil
+import uuid
 
 
 class Directory:
@@ -156,6 +157,21 @@ class Directory:
 
         """
         return os.path.join(self.path, name)
+
+    def temporary_file(self):
+        """Get a temporary filename in the directory.
+
+        This method generates a random filename using :func:`uuid.uuid4`. Unlike
+        a Python temporary file, this file is not automatically created or
+        destroyed. That responsibility is delegated to the caller.
+
+        Returns
+        -------
+        str
+            The absolute path to the temporary file.
+
+        """
+        return self.file(str(uuid.uuid4().hex))
 
     def directory(self, name, create=True):
         """Get a child directory.

--- a/src/relentless/simulate/analyze.py
+++ b/src/relentless/simulate/analyze.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from . import simulate
 
 
@@ -140,6 +142,21 @@ class WriteTrajectory(simulate.DelegatedAnalysisOperation):
         Name of the trajectory file to be written, as a relative path.
     every : int
         Interval of time steps at which to write a snapshot.
+    format : str
+        File format, from the following:
+
+        - ``"HOOMD-GSD"``: HOOMD GSD file
+        - ``"LAMMPS-dump"``: LAMMPS dump file
+
+        If ``None`` (default), ``format`` is inferred from the ``filename``
+        according to the following ordered rules:
+
+        - Files with ``.gsd`` as their sufix are HOOMD-GSD.
+        - Files with ``.dump`` or ``.lammpstrj`` anywhere in their suffix or
+          ``dump``as the stem of their file name are LAMMPS-dump.
+
+        Simulations are *encouraged* but not *required* to support as many file
+        formats as possible.
     velocities : bool
         Include particle velocities.
     images : bool
@@ -152,10 +169,18 @@ class WriteTrajectory(simulate.DelegatedAnalysisOperation):
     """
 
     def __init__(
-        self, filename, every, velocities=False, images=False, types=False, masses=False
+        self,
+        filename,
+        every,
+        format=None,
+        velocities=False,
+        images=False,
+        types=False,
+        masses=False,
     ):
         self.filename = filename
         self.every = every
+        self.format = format
         self.velocities = velocities
         self.images = images
         self.types = types
@@ -166,8 +191,62 @@ class WriteTrajectory(simulate.DelegatedAnalysisOperation):
             sim,
             filename=self.filename,
             every=self.every,
+            format=self.format,
             velocities=self.velocities,
             images=self.images,
             types=self.types,
             masses=self.masses,
         )
+
+    @staticmethod
+    def _detect_format(filename, format=None):
+        if format is not None:
+            known_formats = (
+                "HOOMD-GSD",
+                "LAMMPS-dump",
+            )
+            if format not in known_formats:
+                raise ValueError(
+                    "Format not recognized, must be one of: " + " ".join(known_formats)
+                )
+            format_ = format
+        else:
+            file_path = pathlib.Path(filename)
+
+            file_suffix = file_path.suffix
+            file_suffixes = file_path.suffixes
+            suffix_length = sum(len(ext) for ext in file_suffixes)
+            file_stem = file_path.stem[:-suffix_length]
+
+            format_ = None
+            if file_suffix == ".gsd":
+                format_ = "HOOMD-GSD"
+            elif (
+                ".lammpstrj" in file_suffixes
+                or ".dump" in file_suffixes
+                or file_stem == "dump"
+            ):
+                format_ = "LAMMPS-dump"
+
+        return format_
+
+    @staticmethod
+    def _make_lammps_schema(velocities, images, types, masses):
+        schema = {"id": 0}
+        column = 1
+        if types:
+            schema["typeid"] = column
+            column += 1
+        if masses:
+            schema["mass"] = column
+            column += 1
+        # position is always written
+        schema["position"] = (column, column + 1, column + 2)
+        column += 3
+        if velocities:
+            schema["velocity"] = (column, column + 1, column + 2)
+            column += 3
+        if images:
+            schema["image"] = (column, column + 1, column + 2)
+            column += 3
+        return schema

--- a/src/relentless/simulate/analyze.py
+++ b/src/relentless/simulate/analyze.py
@@ -153,7 +153,7 @@ class WriteTrajectory(simulate.DelegatedAnalysisOperation):
 
         - Files with ``.gsd`` as their sufix are HOOMD-GSD.
         - Files with ``.dump`` or ``.lammpstrj`` anywhere in their suffix or
-          ``dump``as the stem of their file name are LAMMPS-dump.
+          ``dump`` as the stem of their file name are LAMMPS-dump.
 
         Simulations are *encouraged* but not *required* to support as many file
         formats as possible.

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1448,14 +1448,14 @@ class WriteTrajectory(AnalysisOperation):
         if file_format == "LAMMPS-dump":
             if mpi.world.rank_is_root:
                 dump_file = sim.directory.temporary_file(".dump")
-                with gsd.hoomd.open(self.filename) as t:
-                    snaps = [lammpsio.Snapshot.from_hoomd_gsd(s) for s in t]
+                with gsd.hoomd.open(sim.directory.file(self.filename)) as t:
+                    snaps = [lammpsio.Snapshot.from_hoomd_gsd(s)[0] for s in t]
 
-                schema = analyze.WriteTrajectory._make_dump_schema(
+                schema = analyze.WriteTrajectory._make_lammps_schema(
                     self.velocities, self.images, self.types, self.masses
                 )
                 lammpsio.DumpFile.create(dump_file, schema, snaps)
-                shutil.move(dump_file, self.filename)
+                shutil.move(dump_file, sim.directory.file(self.filename))
             mpi.world.barrier()
 
     def _get_dynamic(self):

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1,7 +1,8 @@
 import enum
-import os
 import warnings
 
+import gsd.hoomd
+import lammpsio
 import numpy
 from packaging import version
 
@@ -58,6 +59,7 @@ class InitializationOperation(simulate.InitializationOperation):
         # parse masses by type
         snap = sim["engine"]["_hoomd"].state.get_snapshot()
         sim.masses = self._get_masses_from_snapshot(sim, snap)
+        self._assert_dimension_safe(sim, snap)
 
         # create the potentials, defer attaching until later
         neighbor_list = hoomd.md.nlist.Tree(buffer=sim.potentials.pair.neighbor_buffer)
@@ -85,6 +87,7 @@ class InitializationOperation(simulate.InitializationOperation):
         with sim["engine"]["_hoomd"]:
             snap = sim[self]["_system"].take_snapshot(particles=True)
             sim.masses = self._get_masses_from_snapshot(sim, snap)
+            self._assert_dimension_safe(sim, snap)
 
         # attach the potentials
         def _table_eval(r_i, rmin, rmax, **coeff):
@@ -145,26 +148,57 @@ class InitializationOperation(simulate.InitializationOperation):
         masses.update(masses_)
         return masses
 
+    def _assert_dimension_safe(self, sim, snap):
+        if sim.dimension == 3:
+            dim_safe = True
+        elif sim.dimension == 2:
+            if mpi.world.rank == 0:
+                dim_safe = numpy.allclose(
+                    snap.particles.position[:, 2], 0
+                ) and numpy.allclose(snap.particles.velocity[:, 2], 0)
+            else:
+                dim_safe = None
+            dim_safe = mpi.world.bcast(dim_safe, root=0)
+        else:
+            raise ValueError("Only 2d and 3d simulations are supported")
+
+        if not dim_safe:
+            raise ValueError("Simulation initialized inconsistent with dimension")
+
 
 class InitializeFromFile(InitializationOperation):
-    """Initialize a simulation from a GSD file.
-
-    Parameters
-    ----------
-    filename : str
-        The file from which to read the system data.
-
-    """
-
-    def __init__(self, filename):
-        self.filename = os.path.realpath(filename)
+    __init__ = initialize.InitializeFromFile.__init__
 
     def _initialize_v3(self, sim):
-        sim["engine"]["_hoomd"].create_state_from_gsd(self.filename)
+        gsd_filename = self._convert_to_gsd_file(sim)
+        sim["engine"]["_hoomd"].create_state_from_gsd(gsd_filename)
 
     def _initialize_v2(self, sim):
+        gsd_filename = self._convert_to_gsd_file(sim)
         with sim["engine"]["_hoomd"]:
-            return hoomd.init.read_gsd(self.filename)
+            return hoomd.init.read_gsd(gsd_filename)
+
+    def _convert_to_gsd_file(self, sim):
+        file_format = initialize.InitializeFromFile._detect_format(self.filename)
+        if file_format == "LAMMPS-data":
+            if mpi.world.rank == 0:
+                snap = lammpsio.DataFile(self.filename).read()
+                frame = snap.to_hoomd_gsd()
+                frame.configuration.dimensions = self.dimension
+                if self.dimension == 2:
+                    frame.configuration.box[4:6] = 0.0
+                    if _version.major >= 3:
+                        frame.configuration.box[2] = 0.0
+                gsd_filename = sim.directory.temporary_file()
+                with gsd.hoomd.open(gsd_filename, "wb") as f:
+                    f.append(frame)
+            else:
+                gsd_filename = None
+            gsd_filename = mpi.world.bcast(gsd_filename, root=0)
+        else:
+            gsd_filename = self.filename
+
+        return gsd_filename
 
 
 class InitializeRandomly(InitializationOperation):

--- a/src/relentless/simulate/initialize.py
+++ b/src/relentless/simulate/initialize.py
@@ -53,21 +53,32 @@ class InitializeFromFile(simulate.DelegatedInitializationOperation):
         )
 
     @staticmethod
-    def _detect_format(filename):
-        file_path = pathlib.Path(filename)
+    def _detect_format(filename, format=None):
+        if format is not None:
+            known_formats = (
+                "HOOMD-GSD",
+                "LAMMPS-data",
+            )
+            if format not in known_formats:
+                raise ValueError(
+                    "Format not recognized, must be one of: " + " ".join(known_formats)
+                )
+            format_ = format
+        else:
+            file_path = pathlib.Path(filename)
 
-        file_suffix = file_path.suffix
-        file_suffixes = file_path.suffixes
-        suffix_length = sum(len(ext) for ext in file_suffixes)
-        file_stem = file_path.stem[:-suffix_length]
+            file_suffix = file_path.suffix
+            file_suffixes = file_path.suffixes
+            suffix_length = sum(len(ext) for ext in file_suffixes)
+            file_stem = file_path.stem[:-suffix_length]
 
-        format = None
-        if file_suffix == ".gsd":
-            format = "HOOMD-GSD"
-        elif ".data" in file_suffixes or file_stem == "data":
-            format = "LAMMPS-data"
+            format_ = None
+            if file_suffix == ".gsd":
+                format_ = "HOOMD-GSD"
+            elif ".data" in file_suffixes or file_stem == "data":
+                format_ = "LAMMPS-data"
 
-        return format
+        return format_
 
 
 class InitializeRandomly(simulate.DelegatedInitializationOperation):

--- a/src/relentless/simulate/initialize.py
+++ b/src/relentless/simulate/initialize.py
@@ -13,8 +13,6 @@ from . import simulate
 class InitializeFromFile(simulate.DelegatedInitializationOperation):
     """Initialize a simulation from a file.
 
-    Description.
-
     Parameters
     ----------
     filename : str
@@ -28,9 +26,9 @@ class InitializeFromFile(simulate.DelegatedInitializationOperation):
         If ``None`` (default), ``format`` is inferred from the ``filename``
         according to the following ordered rules:
 
-        - Files with `.gsd` as their sufix are HOOMD-GSD.
-        - Files with `.data` anywhere in their suffix or as the stem of their
-        file name are LAMMPS-data.
+        - Files with ``.gsd`` as their sufix are HOOMD-GSD.
+        - Files with ``.data`` anywhere in their suffix or as the stem of their
+          file name are LAMMPS-data.
 
         Simulations are *encouraged* but not *required* to support as many file
         formats as possible.

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -150,10 +150,11 @@ class InitializationOperation(SimulationOperation, simulate.InitializationOperat
         cmds = [
             "units {style}".format(style=sim["engine"]["units"]),
             "boundary p p p",
-            "dimension {dim}".format(dim=sim["engine"]["dimension"]),
             "atom_style {style}".format(style=sim["engine"]["atom_style"]),
         ]
         cmds += self.initialize_commands(sim)
+        # dimension is only available after initialization commands, so we insert it now
+        cmds.insert(2, f"dimension {sim.dimension}")
         sim.types = sim["engine"]["types"].keys()
 
         # create a group for each type
@@ -1371,8 +1372,6 @@ class LAMMPS(simulate.Simulation):
     operations : array_like
         :class:`~relentless.simulate.SimulationOperation` to execute for run.
         Defaults to ``None``, which means nothing is done after initialization.
-    dimension : int
-        Dimensionality of the simulation. Defaults to 3.
     quiet : bool
         If ``True``, silence LAMMPS screen output. Setting this to ``False`` can
         be helpful for debugging but would be very noisy in a long production
@@ -1395,7 +1394,6 @@ class LAMMPS(simulate.Simulation):
         self,
         initializer,
         operations=None,
-        dimension=3,
         quiet=True,
         types=None,
         executable=None,
@@ -1459,7 +1457,6 @@ class LAMMPS(simulate.Simulation):
             raise ImportError("Only LAMMPS 29 Sep 2021 or newer is supported.")
 
         super().__init__(initializer, operations)
-        self.dimension = dimension
         self.quiet = quiet
         self.types = types
 
@@ -1517,7 +1514,6 @@ class LAMMPS(simulate.Simulation):
         sim["engine"]["types"] = self.types
         sim["engine"]["units"] = "lj"
         sim["engine"]["atom_style"] = "atomic"
-        sim["engine"]["dimension"] = self.dimension
 
     # initialize
     _InitializeFromFile = InitializeFromFile

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -296,7 +296,7 @@ class InitializeFromFile(InitializationOperation):
                 data_filename = sim.directory.temporary_file(".data")
                 with gsd.hoomd.open(self.filename) as f:
                     frame = f[0]
-                snap = lammpsio.Snapshot.from_hoomd_gsd(frame)
+                snap = lammpsio.Snapshot.from_hoomd_gsd(frame)[0]
 
                 # figure out dimensions
                 dimension = self.dimension
@@ -310,8 +310,8 @@ class InitializeFromFile(InitializationOperation):
                     if frame.configuration.box[2] == 0:
                         snap.low[2] = -0.5
                         snap.high[2] = 0.5
-                    if snap.tilt is not None:
-                        snap.tilt[1:] = 0.0
+                    if snap.box.tilt is not None:
+                        snap.box.tilt[1:] = 0.0
                 lammpsio.DataFile.create(
                     data_filename, snap, sim["engine"]["atom_style"]
                 )

--- a/src/relentless/simulate/lammps.py
+++ b/src/relentless/simulate/lammps.py
@@ -1347,15 +1347,19 @@ class WriteTrajectory(AnalysisOperation):
         return cmds
 
     def process(self, sim, sim_op):
-        file_format = analyze.WriteTrajectory._detect_format(self.filename, self.format)
+        file_format = analyze.WriteTrajectory._detect_format(
+            sim.directory.file(self.filename), self.format
+        )
         if file_format == "HOOMD-GSD":
             if mpi.world.rank_is_root:
                 gsd_file = sim.directory.temporary_file(".gsd")
                 with gsd.hoomd.open(gsd_file, "wb") as t:
-                    for snap in lammpsio.DumpFile(self.filename, sort_ids=True):
+                    for snap in lammpsio.DumpFile(
+                        sim.directory.file(self.filename), sort_ids=True
+                    ):
                         frame = snap.to_hoomd_gsd()
                         t.append(frame)
-                shutil.move(gsd_file, self.filename)
+                shutil.move(gsd_file, sim.directory.file(self.filename))
             mpi.world.barrier()
 
 

--- a/tests/simulate/test_hoomd.py
+++ b/tests/simulate/test_hoomd.py
@@ -123,24 +123,14 @@ class test_HOOMD(unittest.TestCase):
 
     def test_initialize_from_lammps_file(self):
         """Test running initialization simulation operations."""
-        if self.dim == 3:
-            ens = relentless.model.Ensemble(
-                T=2.0, V=relentless.model.Cube(L=10.0), N={"1": 2, "2": 3}
-            )
-        elif self.dim == 2:
-            ens = relentless.model.Ensemble(
-                T=2.0, V=relentless.model.Square(L=10.0), N={"1": 2, "2": 3}
-            )
-        else:
-            raise ValueError("LAMMPS supports 2d and 3d simulations")
-        ens.P = 2.5
-        pot = LinPot(ens.types, params=("m",))
+        pot = LinPot(("1", "2"), params=("m",))
         for pair in pot.coeff:
             pot.coeff[pair].update({"m": -2.0, "rmax": 1.0})
         pots = relentless.simulate.Potentials()
         pots.pair = relentless.simulate.PairPotentialTabulator(
             pot, start=1e-6, stop=2.0, num=10, neighbor_buffer=0.1
         )
+
         f = self.create_lammps_file()
         op = relentless.simulate.InitializeFromFile(filename=f)
         h = relentless.simulate.HOOMD(op)
@@ -541,7 +531,12 @@ class test_HOOMD(unittest.TestCase):
             masses=True,
         )
         gsdtrj = relentless.simulate.WriteTrajectory(
-            filename="test_writetrajectory.gsd", every=100, velocities=True
+            filename="test_writetrajectory.gsd",
+            every=100,
+            velocities=True,
+            images=True,
+            types=True,
+            masses=True,
         )
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=500,

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -118,7 +118,6 @@ class test_LAMMPS(unittest.TestCase):
         op = relentless.simulate.InitializeFromFile(filename=file_)
         lmp = relentless.simulate.LAMMPS(
             op,
-            dimension=self.dim,
             types={"1": 1, "2": 2},
             executable=self.executable,
         )
@@ -126,18 +125,14 @@ class test_LAMMPS(unittest.TestCase):
 
         # InitializeRandomly
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        lmp = relentless.simulate.LAMMPS(
-            op, dimension=self.dim, executable=self.executable
-        )
+        lmp = relentless.simulate.LAMMPS(op, executable=self.executable)
         lmp.run(potentials=pot, directory=self.directory)
 
     def test_random_initialize_options(self):
         # no T
         ens, pot = self.ens_pot()
         op = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V)
-        h = relentless.simulate.LAMMPS(
-            op, dimension=self.dim, executable=self.executable
-        )
+        h = relentless.simulate.LAMMPS(op, executable=self.executable)
         h.run(potentials=pot, directory=self.directory)
 
         # T + diameters
@@ -175,7 +170,6 @@ class test_LAMMPS(unittest.TestCase):
         lmp = relentless.simulate.LAMMPS(
             init,
             operations=[emin],
-            dimension=self.dim,
             types={"1": 1, "2": 2},
             executable=self.executable,
         )
@@ -196,9 +190,7 @@ class test_LAMMPS(unittest.TestCase):
         brn = relentless.simulate.RunBrownianDynamics(
             steps=1, timestep=1.0e-3, T=ens.T, friction=1.0, seed=2
         )
-        h = relentless.simulate.LAMMPS(
-            init, brn, dimension=self.dim, executable=self.executable
-        )
+        h = relentless.simulate.LAMMPS(init, brn, executable=self.executable)
         if "BROWNIAN" not in h.packages:
             self.skipTest("LAMMPS BROWNIAN package not installed")
         else:
@@ -216,9 +208,7 @@ class test_LAMMPS(unittest.TestCase):
     def test_langevin_dynamics(self):
         ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        lmp = relentless.simulate.LAMMPS(
-            init, dimension=self.dim, executable=self.executable
-        )
+        lmp = relentless.simulate.LAMMPS(init, executable=self.executable)
 
         # float friction
         lgv = relentless.simulate.RunLangevinDynamics(
@@ -256,9 +246,7 @@ class test_LAMMPS(unittest.TestCase):
     def test_molecular_dynamics(self):
         ens, pot = self.ens_pot()
         init = relentless.simulate.InitializeRandomly(seed=1, N=ens.N, V=ens.V, T=ens.T)
-        lmp = relentless.simulate.LAMMPS(
-            init, dimension=self.dim, executable=self.executable
-        )
+        lmp = relentless.simulate.LAMMPS(init, executable=self.executable)
 
         # VerletIntegrator - NVE
         vrl = relentless.simulate.RunMolecularDynamics(steps=1, timestep=1e-3)
@@ -320,9 +308,7 @@ class test_LAMMPS(unittest.TestCase):
             seed=2,
             analyzers=logger,
         )
-        lmp = relentless.simulate.LAMMPS(
-            init, brn, dimension=self.dim, executable=self.executable
-        )
+        lmp = relentless.simulate.LAMMPS(init, brn, executable=self.executable)
 
         pot = relentless.simulate.Potentials()
         pot.pair = relentless.simulate.PairPotentialTabulator(
@@ -356,9 +342,7 @@ class test_LAMMPS(unittest.TestCase):
             seed=1,
             analyzers=[analyzer, analyzer2],
         )
-        h = relentless.simulate.LAMMPS(
-            init, operations=lgv, dimension=self.dim, executable=self.executable
-        )
+        h = relentless.simulate.LAMMPS(init, operations=lgv, executable=self.executable)
         sim = h.run(potentials=pot, directory=self.directory)
 
         # extract ensemble
@@ -416,9 +400,7 @@ class test_LAMMPS(unittest.TestCase):
             barostat=relentless.simulate.MTKBarostat(0.0, 1.0),
             analyzers=analyzer,
         )
-        h = relentless.simulate.LAMMPS(
-            init, md, dimension=self.dim, executable=self.executable
-        )
+        h = relentless.simulate.LAMMPS(init, md, executable=self.executable)
 
         # NPT
         sim = h.run(pot, self.directory)
@@ -510,9 +492,7 @@ class test_LAMMPS(unittest.TestCase):
             seed=1,
             analyzers=[analyzer],
         )
-        h = relentless.simulate.LAMMPS(
-            init, operations=lgv, dimension=self.dim, executable=self.executable
-        )
+        h = relentless.simulate.LAMMPS(init, operations=lgv, executable=self.executable)
         sim = h.run(potentials=pot, directory=self.directory)
 
         # read trajectory file

--- a/tests/simulate/test_lammps.py
+++ b/tests/simulate/test_lammps.py
@@ -559,9 +559,7 @@ class test_LAMMPS(unittest.TestCase):
         lgv = relentless.simulate.RunLangevinDynamics(
             steps=10, timestep=0.001, T=ens.T, friction=1.0, seed=1, analyzers=analyzer
         )
-        h = relentless.simulate.LAMMPS(
-            init, lgv, dimension=self.dim, executable=self.executable
-        )
+        h = relentless.simulate.LAMMPS(init, lgv, executable=self.executable)
         sim = h.run(pot, self.directory)
 
         # check entries exist for data


### PR DESCRIPTION
This PR uses a feature I recently added to `lammpsio` to convert between GSD and LAMMPS snapshots. `InitializeFromFile` and `WriteTrajectory` should now be mostly agnostic to whether the box is HOOMD or LAMMPS.

In the process, I refactored a method for getting a temporary file name to the `Directory` to reduce code duplication.

Fixes #156 