### PR TITLE
Fix pair potential cutoff when `rmax` is not specified

### DIFF
--- a/src/relentless/simulate/simulate.py
+++ b/src/relentless/simulate/simulate.py
@@ -706,7 +706,7 @@ class PairPotentialTabulator(PotentialTabulator):
                 if len(all_rmax) == 0:
                     # there are no potentials, cutoff at minimum number of points
                     rcut = x[minimum_num - 1]
-                elif None not in all_rmax:
+                elif False not in all_rmax:
                     # use rmax if set for all potentials
                     rcut = min(max(all_rmax), x[-1])
                 else:

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -209,6 +209,10 @@ class test_PairPotentialTabulator(unittest.TestCase):
         r, u, f = t.pairwise_energy_and_force(("1",), x=t.linear_space[0])
         self.assertEqual(r, t.linear_space[0])
 
+        # tight without rmax
+        r, u, f = t.pairwise_energy_and_force(("1",), tight=True)
+        numpy.testing.assert_allclose(r, t.linear_space)
+
         # set rmax and use tight option
         p1.coeff["1", "1"]["rmax"] = 3.0
         r, u, f = t.pairwise_energy_and_force(("1",), tight=True)


### PR DESCRIPTION
This PR fixes an issue where the tabulated pair potential was trimmed incorrectly if the `tight` option was used but no `rmax` parameters were specified. The condition for "no cutoff" is `rmax is False` not `rmax is None`.

Fixes #204 