### PR TITLE
Improve default values of collections and errors

### DIFF
--- a/doc/source/guide/examples/binary_hard_spheres/binary_hard_spheres.ipynb
+++ b/doc/source/guide/examples/binary_hard_spheres/binary_hard_spheres.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i, j in target.pairs:\n",
+    "for i, j in target.rdf:\n",
     "    rdf = relentless.mpi.world.loadtxt(f\"rdf_{i}{j}.dat\")\n",
     "    target.rdf[i, j] = relentless.model.ensemble.RDF(rdf[:, 0], rdf[:, 1])"
    ]
@@ -338,7 +338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   },
   "vscode": {
    "interpreter": {

--- a/src/relentless/collections.py
+++ b/src/relentless/collections.py
@@ -14,6 +14,7 @@ Collections (`relentless.collections`)
 
 """
 import collections
+import copy
 
 
 class FixedKeyDict(collections.abc.MutableMapping):
@@ -102,7 +103,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
 
     def __delitem__(self, key):
         key = self._check_key(key)
-        self._data[key] = self.default
+        self._data[key] = copy.deepcopy(self.default)
 
     def __iter__(self):
         return iter(self._keys)
@@ -113,7 +114,7 @@ class FixedKeyDict(collections.abc.MutableMapping):
     def clear(self):
         """Clear entries in the dictionary, resetting to default."""
         for i in self._keys:
-            self._data[i] = self._default
+            self._data[i] = copy.deepcopy(self._default)
 
 
 class PairMatrix(collections.abc.MutableMapping):
@@ -181,19 +182,11 @@ class PairMatrix(collections.abc.MutableMapping):
 
     """
 
-    def __init__(self, types):
-        if len(types) == 0:
-            raise ValueError("Cannot initialize with empty types")
-        if not all(isinstance(t, str) for t in types):
-            raise TypeError("All types must be strings")
-        self.types = tuple(types)
-
-        # flood data with type pairs
+    def __init__(self, keys, default=None):
+        self._keys = tuple(keys)
+        self._default = default
         self._data = {}
-        for i in self.types:
-            for j in self.types:
-                if j >= i:
-                    self._data[i, j] = {}
+        self.clear()
 
     def _check_key(self, key):
         """Check that a pair key is valid.
@@ -212,10 +205,10 @@ class PairMatrix(collections.abc.MutableMapping):
         if len(key) != 2:
             raise KeyError("Coefficient matrix requires a pair of types.")
 
-        if key[0] not in self.types:
-            raise KeyError("Type {} is not in coefficient matrix.".format(key[0]))
-        elif key[1] not in self.types:
-            raise KeyError("Type {} is not in coefficient matrix.".format(key[1]))
+        if key[0] not in self._keys:
+            raise KeyError(f"Key {key[0]} is not in pair matrix.")
+        elif key[1] not in self._keys:
+            raise KeyError(f"Key {key[0]} is not in pair matrix.")
 
         if key[1] >= key[0]:
             return key
@@ -242,10 +235,12 @@ class PairMatrix(collections.abc.MutableMapping):
     def __len__(self):
         return len(self._data)
 
-    @property
-    def pairs(self):
-        """tuple: All unique pairs in the matrix."""
-        return tuple(self._data.keys())
+    def clear(self):
+        """Clear entries in the dictionary, resetting to default."""
+        for i in self._keys:
+            for j in self._keys:
+                if j >= i:
+                    self._data[i, j] = copy.deepcopy(self._default)
 
 
 class DefaultDict(collections.abc.MutableMapping):

--- a/src/relentless/model/ensemble.py
+++ b/src/relentless/model/ensemble.py
@@ -97,7 +97,7 @@ class Ensemble:
         self.V = V
 
         # rdf per-pair
-        self._rdf = PairMatrix(types=types)
+        self._rdf = PairMatrix(types)
 
     @property
     def T(self):
@@ -138,12 +138,7 @@ class Ensemble:
     @property
     def types(self):
         r"""tuple: The types in the ensemble."""
-        return self.N.keys()
-
-    @property
-    def pairs(self):
-        r"""tuple: The pairs in the ensemble."""
-        return self.rdf.pairs
+        return tuple(self.N.keys())
 
     @property
     def rdf(self):

--- a/src/relentless/model/potential/pair.py
+++ b/src/relentless/model/potential/pair.py
@@ -77,14 +77,9 @@ class PairParameters(potential.Parameters):
     def __init__(self, types, params):
         super().__init__(types, params)
         # override data container of parent to use pair matrix
-        self._data = collections.PairMatrix(types)
-        for pair in self:
-            self._data[pair] = collections.FixedKeyDict(keys=self.params)
-
-    @property
-    def pairs(self):
-        """tuple[tuple[str]]: Pairs in matrix."""
-        return self._data.pairs
+        self._data = collections.PairMatrix(
+            keys=types, default=collections.FixedKeyDict(keys=self.params)
+        )
 
 
 class PairPotential(potential.Potential):

--- a/src/relentless/optimize/objective.py
+++ b/src/relentless/optimize/objective.py
@@ -324,6 +324,11 @@ class RelativeEntropy(ObjectiveFunction):
             The result, which has unknown value ``None`` and known gradient.
 
         """
+        if self.thermo.rdf is None:
+            raise ValueError(
+                "EnsembleAverage needs to compute RDF, specify parameters."
+            )
+
         # a directory is needed for the simulation, so create one if we don't have one
         if directory is None:
             # create directory and synchronize
@@ -394,9 +399,14 @@ class RelativeEntropy(ObjectiveFunction):
         dvars = variable.graph.check_variables_and_types(variables, variable.Variable)
         gradient = math.KeyedArray(keys=dvars)
 
+        # make sure RDF has been computed
+        for pair in g_tgt:
+            if g_sim.get(pair, None) is None:
+                raise KeyError(f"RDF not computed for pair {pair}")
+
         for var in dvars:
             update = 0
-            for i, j in self.target.pairs:
+            for i, j in g_tgt:
                 rs = self.potentials.pair.linear_space
                 us = self.potentials.pair.energy((i, j))
                 dus = self.potentials.pair.derivative((i, j), var)

--- a/src/relentless/simulate/dilute.py
+++ b/src/relentless/simulate/dilute.py
@@ -189,7 +189,7 @@ class EnsembleAverage(simulate.AnalysisOperation):
         rdf_params = self._get_rdf_params(sim)
         if rdf_params is not None:
             kT = sim.potentials.kB * ens.T
-            for pair in ens.pairs:
+            for pair in sim.pairs:
                 bin_edges = numpy.linspace(
                     0, rdf_params["stop"], rdf_params["bins"] + 1
                 )

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1254,7 +1254,7 @@ class EnsembleAverage(AnalysisOperation):
             Radial distribution functions.
             """
             if self.num_rdf_samples > 0:
-                rdf = collections.PairMatrix(self._rdf.types)
+                rdf = collections.PairMatrix(self.types)
                 for pair in rdf:
                     if mpi.world.rank == 0:
                         gr = numpy.column_stack(

--- a/tests/model/potential/test_pair.py
+++ b/tests/model/potential/test_pair.py
@@ -13,7 +13,6 @@ class test_PairParameters(unittest.TestCase):
     def test_init(self):
         """Test creation from data"""
         types = ("A", "B")
-        pairs = (("A", "B"), ("B", "B"), ("A", "A"))
         params = ("energy", "mass")
 
         # test construction with tuple input
@@ -22,7 +21,6 @@ class test_PairParameters(unittest.TestCase):
         )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
-        self.assertCountEqual(m.pairs, pairs)
 
         # test construction with list input
         m = relentless.model.potential.PairParameters(
@@ -30,7 +28,6 @@ class test_PairParameters(unittest.TestCase):
         )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
-        self.assertCountEqual(m.pairs, pairs)
 
         # test construction with mixed tuple/list input
         m = relentless.model.potential.PairParameters(
@@ -38,7 +35,6 @@ class test_PairParameters(unittest.TestCase):
         )
         self.assertEqual(m.types, types)
         self.assertEqual(m.params, params)
-        self.assertCountEqual(m.pairs, pairs)
 
         # test construction with int type parameters
         with self.assertRaises(TypeError):
@@ -473,7 +469,7 @@ class test_LennardJones(unittest.TestCase):
         coeff = relentless.model.potential.PairParameters(
             types=("1",), params=("epsilon", "sigma", "rmin", "rmax", "shift")
         )
-        for pair in coeff.pairs:
+        for pair in coeff:
             coeff[pair]["rmin"] = False
             coeff[pair]["rmax"] = False
             coeff[pair]["shift"] = False
@@ -780,7 +776,7 @@ class test_Yukawa(unittest.TestCase):
         coeff = relentless.model.potential.PairParameters(
             types=("1",), params=("epsilon", "kappa", "rmin", "rmax", "shift")
         )
-        for pair in coeff.pairs:
+        for pair in coeff:
             coeff[pair]["rmin"] = False
             coeff[pair]["rmax"] = False
             coeff[pair]["shift"] = False

--- a/tests/model/test_ensemble.py
+++ b/tests/model/test_ensemble.py
@@ -40,7 +40,6 @@ class test_Ensemble(unittest.TestCase):
         # P and N set
         ens = relentless.model.Ensemble(T=10, P=2.0, N={"A": 1, "B": 2})
         self.assertCountEqual(ens.types, ("A", "B"))
-        self.assertCountEqual(ens.rdf.pairs, (("A", "B"), ("A", "A"), ("B", "B")))
         self.assertAlmostEqual(ens.T, 10)
         self.assertAlmostEqual(ens.P, 2.0)
         self.assertEqual(ens.V, None)
@@ -50,7 +49,6 @@ class test_Ensemble(unittest.TestCase):
         v_obj = relentless.model.Cube(L=3.0)
         ens = relentless.model.Ensemble(T=20, V=v_obj, N={"A": 1, "B": 2})
         self.assertCountEqual(ens.types, ("A", "B"))
-        self.assertCountEqual(ens.rdf.pairs, (("A", "B"), ("A", "A"), ("B", "B")))
         self.assertAlmostEqual(ens.T, 20)
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V, v_obj)
@@ -60,7 +58,6 @@ class test_Ensemble(unittest.TestCase):
         # one N is None
         ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": None, "B": 2})
         self.assertCountEqual(ens.types, ("A", "B"))
-        self.assertCountEqual(ens.rdf.pairs, (("A", "B"), ("A", "A"), ("B", "B")))
         self.assertAlmostEqual(ens.T, 100)
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V, v_obj)
@@ -70,7 +67,6 @@ class test_Ensemble(unittest.TestCase):
         # test creation with single type
         ens = relentless.model.Ensemble(T=100, V=v_obj, N={"A": 10})
         self.assertCountEqual(ens.types, ("A",))
-        self.assertCountEqual(ens.rdf.pairs, (("A", "A"),))
         self.assertAlmostEqual(ens.T, 100)
         self.assertEqual(ens.P, None)
         self.assertIs(ens.V, v_obj)
@@ -134,7 +130,6 @@ class test_Ensemble(unittest.TestCase):
         ens_ = ens.copy()
         self.assertIsNot(ens, ens_)
         self.assertCountEqual(ens.types, ens_.types)
-        self.assertCountEqual(ens.rdf.pairs, ens_.rdf.pairs)
         self.assertAlmostEqual(ens.T, ens_.T)
         self.assertAlmostEqual(ens.P, ens_.P)
         self.assertIsInstance(ens_.V, relentless.model.Cube)
@@ -164,7 +159,6 @@ class test_Ensemble(unittest.TestCase):
         ens_ = relentless.model.Ensemble.from_file(temp.name)
         self.assertIsNot(ens_, ens)
         self.assertCountEqual(ens.types, ens_.types)
-        self.assertCountEqual(ens.rdf.pairs, ens_.rdf.pairs)
         self.assertAlmostEqual(ens.T, ens_.T)
         self.assertAlmostEqual(ens.P, ens_.P)
         self.assertIsInstance(ens_.V, relentless.model.Cube)

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -216,6 +216,14 @@ class test_RelativeEntropy(unittest.TestCase):
         numpy.testing.assert_allclose(res_grad[self.epsilon], grad_eps, atol=1e-1)
         numpy.testing.assert_allclose(res_grad[self.sigma], grad_sig, atol=1e-1)
 
+    def test_compute_rdf_missing(self):
+        self.thermo.rdf = None
+        relent = relentless.optimize.RelativeEntropy(
+            self.target, self.simulation, self.potentials, self.thermo
+        )
+        with self.assertRaises((ValueError, KeyError)):
+            relent.compute((self.epsilon, self.sigma))
+
     def test_directory(self):
         relent = relentless.optimize.RelativeEntropy(
             self.target, self.simulation, self.potentials, self.thermo

--- a/tests/simulate/test_simulate.py
+++ b/tests/simulate/test_simulate.py
@@ -158,7 +158,7 @@ class test_PairPotentialTabulator(unittest.TestCase):
         p1 = QuadPairPot(types=("1",))
         p1.coeff["1", "1"]["m"] = relentless.model.IndependentVariable(2.0)
         p2 = QuadPairPot(types=("1", "2"))
-        for pair in p2.coeff.pairs:
+        for pair in p2.coeff:
             p2.coeff[pair]["m"] = 1.0
         t = relentless.simulate.PairPotentialTabulator(
             potentials=[p1, p2], start=0, stop=5, num=6, neighbor_buffer=0.4

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -146,38 +146,23 @@ class test_PairMatrix(unittest.TestCase):
 
     def test_init(self):
         """Test construction with different list types."""
-        types = ("A", "B")
-        pairs = (("A", "B"), ("B", "B"), ("A", "A"))
-
         # test construction with tuple input
-        m = relentless.collections.PairMatrix(types=("A", "B"))
-        self.assertEqual(m.types, types)
-        self.assertCountEqual(m.pairs, pairs)
+        pairs = (("A", "B"), ("B", "B"), ("A", "A"))
+        m = relentless.collections.PairMatrix(("A", "B"))
+        self.assertCountEqual(tuple(m.keys()), pairs)
 
         # test construction with list input
-        m = relentless.collections.PairMatrix(types=["A", "B"])
-        self.assertEqual(m.types, types)
-        self.assertCountEqual(m.pairs, pairs)
-
-        types = ("A",)
-        pairs = (("A", "A"),)
+        m = relentless.collections.PairMatrix(["A", "B"])
+        self.assertCountEqual(tuple(m.keys()), pairs)
 
         # test construction with single type tuple
-        m = relentless.collections.PairMatrix(types=("A",))
-        self.assertEqual(m.types, types)
-        self.assertCountEqual(m.pairs, pairs)
-
-        # test construction with int type input
-        with self.assertRaises(TypeError):
-            m = relentless.collections.PairMatrix(types=(1, 2))
-
-        # test construction with mixed type input
-        with self.assertRaises(TypeError):
-            m = relentless.collections.PairMatrix(types=("1", 2))
+        pairs = (("A", "A"),)
+        m = relentless.collections.PairMatrix(("A",))
+        self.assertCountEqual(tuple(m.keys()), pairs)
 
     def test_accessors(self):
         """Test get and set methods on pairs."""
-        m = relentless.collections.PairMatrix(types=("A", "B"))
+        m = relentless.collections.PairMatrix(("A", "B"), default={})
 
         # test set and get for each pair type
         m["A", "A"]["energy"] = 1.0
@@ -238,7 +223,7 @@ class test_PairMatrix(unittest.TestCase):
 
     def test_iteration(self):
         """Test iteration on the matrix."""
-        m = relentless.collections.PairMatrix(types=("A", "B"))
+        m = relentless.collections.PairMatrix(("A", "B"), default={})
 
         # test iteration for initialization
         for pair in m:


### PR DESCRIPTION
* Give PairMatrix a default
* Make all defaults copy safe
* Simplify access patterns using iterators
* Error check RDF parameters are set for relative entropy

Fixes #206 