### PR TITLE
Shorten tests and update workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,12 @@
 name: publish
 
 on:
-  push:
-    tags:
-      - "v*"
-
   release:
     types: [published]
 
 jobs:
-  test:
-    uses: ./.github/workflows/test.yml
-
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install pip --upgrade pip
@@ -31,13 +23,12 @@ jobs:
         run: |
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish to TestPyPI
-        if: github.event_name != 'release'
         uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+          skip-existing: true
       - name: Publish to PyPI
-        if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        hoomd-version: ["2.9.7", "3.9.0", "3.10.0", "3.11.0"]
+        hoomd-version: ["2.9.7", "3.11.0"]
         exclude:
           - python-version: "3.11"
             hoomd-version: "2.9.7"
@@ -101,11 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        lammps-version: ["2021.09.29", "2022.06.23"]
+        lammps-version: ["2022.06.23", "2023.08.02"]
         mpi: ["mpich", "openmpi"]
-        exclude:
-          - python-version: "3.11"
-            lammps-version: "2021.09.29"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -114,14 +111,6 @@ jobs:
         with:
           miniconda-version: latest
           python-version: ${{ matrix.python-version }}
-      - name: Install conda libjpeg workaround
-        if: ${{ matrix.lammps-version == '2021.09.29' }}
-        run: |
-          sudo apt-get install -y libjpeg9
-      - name: Install conda MPI workaround
-        if: ${{ matrix.lammps-version == '2021.09.29' && matrix.mpi == 'openmpi' }}
-        run: |
-          conda install -c conda-forge "openmpi=4.1.4=ha*"
       - name: Install test dependencies
         run: |
           conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: latest
+          channels: conda-forge
+          channel-priority: true
+          mamba-version: "*"
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
@@ -101,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        lammps-version: ["2022.06.23", "2023.08.02"]
+        lammps-version: ["2022.06.23"]
         mpi: ["mpich", "openmpi"]
     steps:
       - name: Checkout code
@@ -109,7 +111,9 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: latest
+          channels: conda-forge
+          channel-priority: true
+          mamba-version: "*"
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
@@ -144,7 +148,9 @@ jobs:
       - name: Setup Python 3.8
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: latest
+          channels: conda-forge
+          channel-priority: true
+          mamba-version: "*"
           python-version: 3.8
       - name: Install test dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge hoomd=${{ matrix.hoomd-version }}
+          mamba install hoomd=${{ matrix.hoomd-version }}
           pip install -r tests/requirements.txt
       - name: Install
         run: |
@@ -117,7 +117,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
+          mamba install "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
           pip install -r tests/requirements.txt
       - name: Install
         run: |
@@ -154,7 +154,7 @@ jobs:
           python-version: 3.8
       - name: Install test dependencies
         run: |
-          conda install -c conda-forge hoomd=3
+          mamba install hoomd=3
           pip install -r doc/requirements.txt
       - name: Install
         run: |


### PR DESCRIPTION
* Reduce test runtime by reducing number of combinations, eliminating problematic combinations of software, and using mamba
* Simplify the publish workflow to only run when releases are published