### PR TITLE
Make relentless compatible with NumPy 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
           channel-priority: true
           mamba-version: "*"
           python-version: ${{ matrix.python-version }}
+      - name: Force HOOMD 2 NumPy version
+        if: ${{ matrix.hoomd-version == '2.9.7' }}
+        run: |
+          mamba install "numpy<2"
       - name: Install test dependencies
         run: |
           mamba install hoomd=${{ matrix.hoomd-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 freud-analysis>=2
-gsd
-lammpsio>=0.4
+gsd<3.3.0; python_version < '3.9'
+gsd; python_version >= '3.9'
+lammpsio>=0.6.1
 networkx>=2.5
 numpy
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,9 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     freud-analysis>=2
-    gsd
-    lammpsio>=0.4
+    gsd<3.3.0; python_version < '3.9'
+    gsd; python_version >= '3.9'
+    lammpsio>=0.6.1
     networkx>=2.5
     numpy
     packaging

--- a/src/relentless/math.py
+++ b/src/relentless/math.py
@@ -15,6 +15,7 @@ Math functions (`relentless.math`)
 """
 
 import numpy
+import scipy.integrate
 import scipy.interpolate
 
 from .collections import FixedKeyDict
@@ -487,3 +488,30 @@ class KeyedArray(FixedKeyDict):
         """
         self._assert_same_keys(val)
         return numpy.sum([self[x] * val[x] for x in self])
+
+
+def _trapezoid(y, x):
+    """Wrapper around SciPy trapezoidal integration.
+
+    This function is a compatibility layer around different versions of SciPy,
+    which changed the name of the trapezoidal integration method.
+
+    Parameters
+    ----------
+    y : array_like
+        Integrand.
+    x : array_like
+        Independent variable.
+
+    Returns
+    -------
+    float
+        The integral.
+
+    """
+    try:
+        trapz = scipy.integrate.trapezoid
+    except AttributeError:
+        trapz = scipy.integrate.trapz
+
+    return trapz(y, x=x)

--- a/src/relentless/model/extent.py
+++ b/src/relentless/model/extent.py
@@ -555,7 +555,7 @@ class ObliqueArea(Area):
         box_vec = self.a + self.b
         self._low = -0.5 * box_vec
         self._high = 0.5 * box_vec
-        self._extent = numpy.linalg.norm(numpy.cross(self.a, self.b))
+        self._extent = numpy.linalg.det([self.a, self.b])
         self._convention = convention
 
     @classmethod

--- a/src/relentless/optimize/objective.py
+++ b/src/relentless/optimize/objective.py
@@ -60,7 +60,6 @@ import json
 import tempfile
 
 import numpy
-import scipy.integrate
 
 from relentless import data, math, mpi
 from relentless.model import extent, variable
@@ -479,7 +478,7 @@ class RelativeEntropy(ObjectiveFunction):
                     * (sim_factor * g_sim[i, j](r) - tgt_factor * g_tgt[i, j](r))
                     * dudvar(r)
                 )
-                update += scipy.integrate.trapz(y, x=r)
+                update += math._trapezoid(y, r)
 
             gradient[var] = update
 

--- a/src/relentless/simulate/dilute.py
+++ b/src/relentless/simulate/dilute.py
@@ -14,7 +14,7 @@ import abc
 
 import numpy
 
-from relentless import mpi
+from relentless import math, mpi
 from relentless.model import ensemble, extent
 
 from . import analyze, md, simulate
@@ -262,7 +262,7 @@ class Dilute(simulate.Simulation):
                 geo_prefactor = 2 * numpy.pi * r
             else:
                 raise ValueError("Geometric integration factor unknown for extent type")
-            B_ij = -0.5 * numpy.trapz(geo_prefactor * (numpy.exp(-u / kT) - 1), x=r)
+            B_ij = -0.5 * math._trapezoid(geo_prefactor * (numpy.exp(-u / kT) - 1), r)
 
             y_i = ens.N[i] / N
             y_j = ens.N[j] / N

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1608,6 +1608,16 @@ class HOOMD(simulate.Simulation):
         if not _hoomd_found:
             raise ImportError("HOOMD not found.")
 
+        if (
+            _hoomd_version.major == 2
+            and packaging.version.Version(numpy.__version__).major >= 2
+        ):
+            warnings.warn(
+                "NumPy 2 is likely incompatible with HOOMD 2, "
+                "suggest to downgrade to numpy<2.",
+                RuntimeWarning,
+            )
+
         super().__init__(initializer, operations)
 
     def _initialize_engine(self, sim):

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -4,7 +4,6 @@ import tempfile
 import unittest
 
 import numpy
-import scipy.integrate
 
 import relentless
 
@@ -161,7 +160,7 @@ class test_RelativeEntropy(unittest.TestCase):
             * (sim_factor * sim_rdf(r) - tgt_factor * tgt_rdf(r))
             * dudvar(r)
         )
-        return scipy.integrate.trapz(x=r, y=y)
+        return relentless.math._trapezoid(x=r, y=y)
 
     def test_init(self):
         relent = relentless.optimize.RelativeEntropy(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,1 @@
-gsd
 parameterized


### PR DESCRIPTION
* Update test requirements
* Create a wrapper in math module for trapezoidal integration
* Compute 2d cross product in a different way to avoid deprecation warning
* Warn about NumPy 2 with HOOMD 2 (produces errors)