### PR TITLE
Run GitHub Actions on a regular interval

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+  schedule:
+    - cron: "0 0 8 * 1/1 TUE#1"
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
We should run GitHub actions on a regular interval so that we catch if the code breaks because of our dependencies (such as what happened with Numpy 2.0). 

This will run our actions at 08:00 AM, on the first Tuesday of the month.