### PR TITLE
Replace mamba with conda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: conda-forge
-          channel-priority: flexible
+          channels: conda-forge,defaults
+          channel-priority: strict
           python-version: ${{ matrix.python-version }}
       - name: Force HOOMD 2 NumPy version
         if: ${{ matrix.hoomd-version == '2.9.7' || matrix.hoomd-version == '3.11.0' }}
@@ -122,8 +122,8 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: conda-forge
-          channel-priority: flexible
+          channels: conda-forge,defaults
+          channel-priority: strict
           python-version: ${{ matrix.python-version }}
       - name: Install LAMMPS
         run: |
@@ -164,8 +164,8 @@ jobs:
       - name: Setup Python 3.9
         uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: conda-forge
-          channel-priority: flexible
+          channels: conda-forge,defaults
+          channel-priority: strict
           python-version: 3.9
       - name: Install test dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,16 +83,15 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
+          channel-priority: flexible
           python-version: ${{ matrix.python-version }}
       - name: Force HOOMD 2 NumPy version
         if: ${{ matrix.hoomd-version == '2.9.7' || matrix.hoomd-version == '3.11.0' }}
         run: |
-          mamba install "numpy<2" "gsd<3.4"
+          conda install "numpy<2" "gsd<3.4"
       - name: Install test dependencies
         run: |
-          mamba install hoomd=${{ matrix.hoomd-version }} --no-update-deps
+          conda install hoomd=${{ matrix.hoomd-version }} --no-update-deps
           pip install -r tests/requirements.txt --upgrade-strategy only-if-needed
       - name: Install
         run: |
@@ -124,16 +123,15 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
+          channel-priority: flexible
           python-version: ${{ matrix.python-version }}
       - name: Install LAMMPS
         run: |
-          mamba install "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
+          conda install "lammps=${{ matrix.lammps-version }}=*${{ matrix.mpi }}*" mpi4py
       - name: Force libpnetcdf version
         if: ${{ matrix.lammps-version == '2023.08.02' }}
         run: |
-          mamba install "libpnetcdf<1.13.0"
+          conda install "libpnetcdf<1.13.0"
       - name: Install test dependencies
         run: |
           pip install -r tests/requirements.txt
@@ -163,16 +161,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: conda-incubator/setup-miniconda@v3
         with:
           channels: conda-forge
-          channel-priority: true
-          mamba-version: "*"
-          python-version: 3.8
+          channel-priority: flexible
+          python-version: 3.9
       - name: Install test dependencies
         run: |
-          mamba install hoomd=3
+          conda install hoomd=4
           pip install -r doc/requirements.txt
       - name: Install
         run: |


### PR DESCRIPTION
conda now uses mamba, so we might as well just use the regular one.