### PR TITLE
Drop support for HOOMD 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,13 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        hoomd-version: ["2.9.7", "3.11.0", "4.7.0"]
+        hoomd-version: ["3.11.0", "4.7.0"]
         include:
           - python-version: "3.12"
             hoomd-version: "4.7.0"
-        exclude:
-          - python-version: "3.11"
-            hoomd-version: "2.9.7"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,7 +83,7 @@ jobs:
           channel-priority: strict
           python-version: ${{ matrix.python-version }}
       - name: Force HOOMD 2 NumPy version
-        if: ${{ matrix.hoomd-version == '2.9.7' || matrix.hoomd-version == '3.11.0' }}
+        if: ${{ matrix.hoomd-version == '3.11.0' }}
         run: |
           conda install "numpy<2" "gsd<3.4"
       - name: Install test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         hoomd-version: ["3.11.0", "4.9.1"]
         include:
           - python-version: "3.12"
-            hoomd-version: "4.7.0"
+            hoomd-version: "4.9.1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/src/relentless/simulate/__init__.py
+++ b/src/relentless/simulate/__init__.py
@@ -38,6 +38,9 @@ It also helps document workflows that can be shared and reproduced by others.
     sim = lmp.run(potentials)
     sim[avg].ensemble.save('ensemble.json')
 
+Major versions of simulation engines are officially supported for two years after
+their last patch or stable release.
+
 Engines
 =======
 

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -28,12 +28,13 @@ if _hoomd_found:
         _hoomd_version = hoomd.__version__
     _hoomd_version = packaging.version.parse(_hoomd_version)
 
-    if _hoomd_version.major < 3:
-        raise ImportError("HOOMD 3.x or later is required.")
-
-    from hoomd.custom import Action
 else:
     _hoomd_version = None
+
+if _hoomd_found and _hoomd_version.major < 3:
+    raise ImportError("HOOMD version 3 or later is required")
+else:
+    from hoomd.custom import Action
 
 try:
     _gsd_version = gsd.version.version

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -31,10 +31,11 @@ if _hoomd_found:
 else:
     _hoomd_version = None
 
-if _hoomd_found and _hoomd_version.major >= 3:
-    from hoomd.custom import Action
-else:
+if _hoomd_version.major < 3:
     raise ImportError("HOOMD 3.x or later is required.")
+
+if _hoomd_found:
+    from hoomd.custom import Action
 
 try:
     _gsd_version = gsd.version.version
@@ -929,6 +930,8 @@ class EnsembleAverage(AnalysisOperation):
     _get_rdf_params = analyze.EnsembleAverage._get_rdf_params
 
     class EnsembleAverageAction(Action):
+        flags = [Action.Flags.PRESSURE_TENSOR]
+
         def __init__(
             self,
             types,
@@ -1274,6 +1277,8 @@ class Record(AnalysisOperation):
             mpi.world.barrier()
 
     class RecorderCallback(Action):
+        flags = [Action.Flags.PRESSURE_TENSOR]
+
         def __init__(self, thermo, quantities):
             self.thermo = thermo
             self.quantities = quantities

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -28,14 +28,12 @@ if _hoomd_found:
         _hoomd_version = hoomd.__version__
     _hoomd_version = packaging.version.parse(_hoomd_version)
 
+    if _hoomd_version.major < 3:
+        raise ImportError("HOOMD 3.x or later is required.")
+
+    from hoomd.custom import Action
 else:
     _hoomd_version = None
-
-if _hoomd_version.major < 3:
-    raise ImportError("HOOMD 3.x or later is required.")
-
-if _hoomd_found:
-    from hoomd.custom import Action
 
 try:
     _gsd_version = gsd.version.version

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1,3 +1,4 @@
+import abc
 import enum
 import os
 import shutil

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1,4 +1,3 @@
-import enum
 import os
 import shutil
 import warnings
@@ -35,11 +34,7 @@ else:
 if _hoomd_found and _hoomd_version.major >= 3:
     from hoomd.custom import Action
 else:
-    # we need to spoof this Action class to use later in v2 callbacks
-    class Action:
-        class Flags(enum.IntEnum):
-            PRESSURE_TENSOR = 0
-
+    raise ImportError("HOOMD 3.x or later is required.")
 
 try:
     _gsd_version = gsd.version.version
@@ -962,8 +957,6 @@ class EnsembleAverage(AnalysisOperation):
     _get_rdf_params = analyze.EnsembleAverage._get_rdf_params
 
     class EnsembleAverageAction(Action):
-        flags = [Action.Flags.PRESSURE_TENSOR]
-
         def __init__(
             self,
             types,
@@ -1320,8 +1313,6 @@ class Record(AnalysisOperation):
             mpi.world.barrier()
 
     class RecorderCallback(Action):
-        flags = [Action.Flags.PRESSURE_TENSOR]
-
         def __init__(self, thermo, quantities):
             self.thermo = thermo
             self.quantities = quantities

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1,3 +1,4 @@
+import enum
 import os
 import shutil
 import warnings
@@ -36,6 +37,12 @@ if _hoomd_found:
         raise ImportError("HOOMD version 3 or later is required")
     else:
         from hoomd.custom import Action
+else:
+
+    class Action:
+        class Flags(enum.IntEnum):
+            PRESSURE_TENSOR = 0
+
 
 try:
     _gsd_version = gsd.version.version

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -1341,7 +1341,7 @@ class HOOMD(simulate.Simulation):
     HOOMD-blue is a molecular dynamics program that can execute on both CPUs and
     GPUs, as a single process or with MPI parallelism. The launch configuration
     will be automatically selected for you when the simulation is run.
-    HOOMD 2.x, 3.x, and 4.x are supported.
+    HOOMD 3.x and 4.x are supported.
 
     .. warning::
 

--- a/src/relentless/simulate/hoomd.py
+++ b/src/relentless/simulate/hoomd.py
@@ -31,10 +31,11 @@ if _hoomd_found:
 else:
     _hoomd_version = None
 
-if _hoomd_found and _hoomd_version.major < 3:
-    raise ImportError("HOOMD version 3 or later is required")
-else:
-    from hoomd.custom import Action
+if _hoomd_found:
+    if _hoomd_version.major < 3:
+        raise ImportError("HOOMD version 3 or later is required")
+    else:
+        from hoomd.custom import Action
 
 try:
     _gsd_version = gsd.version.version


### PR DESCRIPTION
Addresses Issue #267. 

HOOMD 2's last patch release was Aug 3, 2021 well past the 2 year policy decided on in #267. 